### PR TITLE
Update download link after app rename

### DIFF
--- a/jekyll/_posts/projects/2015-06-02-riot-android.md
+++ b/jekyll/_posts/projects/2015-06-02-riot-android.md
@@ -13,6 +13,6 @@ maturity: Released
 # {{ page.title }}
 The Android version of the [Riot](https://matrix.org/docs/projects/client/riot.html) web client. Riot is a glossy client with focus on performance and usability.
 
-The code is available from [github](https://github.com/vector-im/vector-android), and the app is available from the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha) and [F-Droid](https://f-droid.org/repository/browse/?fdfilter=vector&fdid=im.vector.alpha).
+The code is available from [github](https://github.com/vector-im/vector-android), and the app is available from the [Google Play store](https://play.google.com/store/apps/details?id=im.vector.alpha) and [F-Droid](https://f-droid.org/packages/im.vector.alpha/).
 
 If you want to help test the app, you can download development versions from [Jenkins](https://matrix.org/jenkins/job/VectorAndroidDevelop/).


### PR DESCRIPTION
Seems like the link still points to the app with an old name.