### PR TITLE
Replace broken link to Jira with link to GitHub

### DIFF
--- a/jekyll/_posts/guides/2015-08-19-faq.md
+++ b/jekyll/_posts/guides/2015-08-19-faq.md
@@ -420,10 +420,11 @@ to write a client.
 ##### How can I help out with this?
 
 Come say hi on [\#matrix:matrix.org](https://matrix.to/#/#matrix:matrix.org)!  Install synapse and tell us how you get on. Critique the spec.  Write
-clients.  Write bridges!  Run bridges!  Nose around in [Jira](https://matrix.org/jira) and
-send us some pull requests on github to fix some bugs or add some features!  You could even
-try to write a homeserver (but be warned, Matrix's architecture makes homeservers orders of
-magnitude harder than clients or bridges.)
+clients.  Write bridges!  Run bridges!  Nose around in the repositories in our
+[GitHub organization](https://github.com/matrix-org) and send us some pull requests
+to fix some bugs or add some features!  You could even try to write a homeserver
+(but be warned, Matrix's architecture makes homeservers orders of magnitude harder
+than clients or bridges.)
 
 See [CONTRIBUTING.rst](http://github.com/matrix-org/synapse/tree/master/CONTRIBUTING.rst) for
 full details on how to contribute to the project.  All are welcome!


### PR DESCRIPTION
As far as I'm aware, Jira is no longer being used and the link to it in the FAQ returns 404. So, this removes the link and instead adds a link to the GitHub organization.