### PR TITLE
Changed Dockerfile location after handover

### DIFF
--- a/jekyll/_posts/projects/2014-08-12-synapse.md
+++ b/jekyll/_posts/projects/2014-08-12-synapse.md
@@ -14,7 +14,7 @@ Matrix.org’s reference server – Synapse: [https://github.com/matrix-org/syna
 
 Apt repo: [https://matrix.org/packages/debian/](https://matrix.org/packages/debian/)
 
-Dockerfile from Silvio Fricke: [https://registry.hub.docker.com/u/silviof/docker-matrix/](https://registry.hub.docker.com/u/silviof/docker-matrix/)
+Dockerfile from Silvio Fricke and AVENTER: [https://hub.docker.com/r/avhost/docker-matrix/](https://hub.docker.com/r/avhost/docker-matrix/)
 
 ArchLinux package from Ivan Shapovalov: [https://www.archlinux.org/packages/community/any/matrix-synapse/](https://www.archlinux.org/packages/community/any/matrix-synapse/)
 


### PR DESCRIPTION
The dockerfile is now maintained by aventer and the images are at a different location on docker hub.