### PR TITLE
Add new metadata to my projects

### DIFF
--- a/jekyll/_posts/projects/2017-06-27-mautrix-appservice-go.md
+++ b/jekyll/_posts/projects/2017-06-27-mautrix-appservice-go.md
@@ -5,12 +5,12 @@ categories: projects as
 description: An application service framework written in Go
 author: Tulir
 maturity: Alpha
-language: 
-license: 
-repo: 
+language: Go
+license: GPL3
+repo: https://github.com/tulir/mautrix-appservice-go
 ---
 
 # {{ page.title }}
 mautrix-appservice-go is an application service framework written in Go.
 
-Check it out on [GitHub](https://github.com/tulir/mautrix-appservice-go)
+Repository: <{{page.repo}}>

--- a/jekyll/_posts/projects/2017-09-29-maulabbot.md
+++ b/jekyll/_posts/projects/2017-09-29-maulabbot.md
@@ -5,9 +5,9 @@ categories: projects bot
 description: A GitLab bot for Matrix
 author: Tulir
 maturity: Alpha
-language: 
-license: 
-repo: 
+language: Go
+license: GPL3
+repo: https://github.com/tulir/maulabbot
 ---
 
 # {{ page.title }}
@@ -16,4 +16,6 @@ It allows you to interact with GitLab from Matrix and receive notifications
 from GitLab webhooks (issues, merge requests, pushes, etc..).
 
 You can use the publicly hosted instance on [t2bot.io](https://t2bot.io/gitlab),
-or check out the project on [GitHub](https://github.com/tulir/maulabbot)
+or check out the project on [GitHub]({{ page.repo }})
+
+Repository: <{{page.repo}}>

--- a/jekyll/_posts/projects/2017-11-28-mautrix-telegram.md
+++ b/jekyll/_posts/projects/2017-11-28-mautrix-telegram.md
@@ -5,9 +5,9 @@ categories: projects as
 description: A Matrix-Telegram hybrid puppeting/relaybot bridge
 author: Tulir
 maturity: Early Beta
-language: 
-license: 
-repo: 
+language: Python
+license: AGPL3
+repo: https://github.com/tulir/mautrix-telegram
 ---
 
 ![screenshot](/docs/projects/images/mautrix-telegram.png "{{ page.title }}")
@@ -15,4 +15,4 @@ repo:
 # {{ page.title }}
 A Matrix-Telegram hybrid puppeting/relaybot bridge. Written in Python using [Telethon](https://github.com/LonamiWebs/Telethon).
 
-Check it out on [GitHub](https://github.com/tulir/mautrix-telegram)
+Repository: <{{page.repo}}>

--- a/jekyll/_posts/projects/2018-03-15-gomuks.md
+++ b/jekyll/_posts/projects/2018-03-15-gomuks.md
@@ -16,6 +16,4 @@ repo: https://github.com/tulir/gomuks
 # {{ page.title }}
 gomuks is a terminal-based Matrix client written in Go with [gomatrix](https://github.com/matrix-org/gomatrix) and [tview](https://github.com/rivo/tview).
 
-Check it out on [GitHub](https://github.com/tulir/gomuks)
-
 Repository: <{{page.repo}}>


### PR DESCRIPTION
Added language, license and repo metadata to mautrix-appservice-go, maulabbot and mautrix-telegram and made links in the description of those projects and gomuks more consistent.