### PR TITLE
Update 2017-05-02-thunderbird.md

### DIFF
--- a/jekyll/_posts/projects/2017-05-02-thunderbird.md
+++ b/jekyll/_posts/projects/2017-05-02-thunderbird.md
@@ -13,4 +13,4 @@ repo:
 # {{ page.title }}
 Initial support for Matrix in [Mozilla Thunderbird](https://www.mozilla.org/en-US/thunderbird/), available in Nightly since March 2017, and due to land in Instantbird/Thunderbird 54.
 
-To enable, turn `chat.prpls.prpl-matrix.disable` to `false` in the advanced config editor.
+To enable, turn `chat.prpls.prpl-matrix.disable` to `false` in the advanced config editor (>Tools >Options >Advanced >Config Editor).


### PR DESCRIPTION
took me 20 minutes to find the "advanced config Editor" in Thunderbird. Thought I'd add the path to the thunderbird.md and likewise make it easier to find.

concrete: 

L16 added the path to the "advanced Config Editor" in Thunderbird 
(>Tools >Options >Advanced >Config Editor)