### PR TITLE
Clarify matrix-js-sdk usage on tensor's page

### DIFF
--- a/jekyll/_posts/projects/2015-06-26-tensor.md
+++ b/jekyll/_posts/projects/2015-06-26-tensor.md
@@ -14,6 +14,6 @@ repo: https://github.com/davidar/tensor
 ![screenshot](https://matrix.org/blog/wp-content/uploads/2015/11/tensor1.png "{{ page.title }}")
 
 # {{ page.title }}
-Tensor is a cross-platform native Matrix client, based on QtQuick/QML and libqmatrixclient (formerly matrix-js-sdk). It has been tested on Desktop GNU/Linux, OS X, Windows, Android, SailfishOS and Ubuntu Touch. Get it from [github](https://github.com/davidar/tensor).
+Tensor is a cross-platform native Matrix client, based on QtQuick/QML and libqmatrixclient (previous versions used matrix-js-sdk). It has been tested on Desktop GNU/Linux, OS X, Windows, Android, SailfishOS and Ubuntu Touch. Get it from [github](https://github.com/davidar/tensor).
 
 Repository: <{{page.repo}}>


### PR DESCRIPTION
The text made it seem like libqmatrixclient was previously matrix-js-sdk. Rather, it is Tensor that was previously using matrix-js-sdk.

I assume this is what you meant, because libqmatrixclient appears to be a C++ library, not a javascript one.

cc @davidar