### PR TITLE
Update on E2E implementation guide

### DIFF
--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -151,16 +151,17 @@ The signed JSON is then uploaded via
 Creating and registering one-time keys
 --------------------------------------
 
-At first start, and at regular intervals
-thereafter\ [#]_, the client should check how
-many one-time keys the homeserver has stored for it, and, if necessary,
-generate and upload some more.
-
-.. [#] Every 10 minutes is suggested.
+At first start, the client should check how many one-time keys the homeserver
+has stored for it, and, if necessary, generate and upload some more.
 
 The number of one-time keys currently stored is returned by
 ``POST /_matrix/client/unstable/keys/upload``. (Post an empty JSON object
 ``{}`` if you don’t want to upload the device keys.)
+
+However, a client should not rely on this in order to find out how many
+one-time keys are left on the homeserver during runtime. Instead, it should do
+so by inspecting the ``device_one_time_keys_count`` property of a ``/sync/``
+response, and upload more when it deems necessary.
 
 The maximum number of active keys supported by libolm is returned by
 ``olm_account_max_number_of_one_time_keys``. The client should try to

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -146,7 +146,7 @@ then signed with ``olm_account_sign``; the signature should be added to
 the JSON as ``signatures.<user_id>.ed25519:<device_id>``.
 
 The signed JSON is then uploaded via
-``POST /_matrix/client/unstable/keys/upload``.
+``POST /_matrix/client/r0/keys/upload``.
 
 Creating and registering one-time keys
 --------------------------------------
@@ -155,7 +155,7 @@ At first start, the client should check how many one-time keys the homeserver
 has stored for it, and, if necessary, generate and upload some more.
 
 The number of one-time keys currently stored is returned by
-``POST /_matrix/client/unstable/keys/upload``. (Post an empty JSON object
+``POST /_matrix/client/r0/keys/upload``. (Post an empty JSON object
 ``{}`` if you don’t want to upload the device keys.)
 
 However, a client should not rely on this in order to find out how many
@@ -235,7 +235,7 @@ To generate new one-time keys:
       }
     }
 
-* Upload the object via ``POST /_matrix/client/unstable/keys/upload``.
+* Upload the object via ``POST /_matrix/client/r0/keys/upload``.
 
 * Call ``olm_account_mark_keys_as_published`` to tell the olm library not to
   return the same keys from a future call to ``olm_account_one_time_keys``.
@@ -454,7 +454,7 @@ The client should build a JSON query object as follows:
   }
 
 Each member in the room should be included in the query. This is then
-sent via ``POST /_matrix/client/unstable/keys/query.``
+sent via ``POST /_matrix/client/r0/keys/query.``
 
 The result includes, for each listed user id, a map from device ID to an
 object containing information on the device, as follows:
@@ -579,7 +579,7 @@ __ `blocking`_
 
 Once all of the key-sharing event contents have been assembled, the
 events should be sent to the corresponding devices via
-``PUT /_matrix/client/unstable/sendToDevice/m.room.encrypted/<txnId>``.
+``PUT /_matrix/client/r0/sendToDevice/m.room.encrypted/<txnId>``.
 
 Rotating Megolm sessions
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -663,7 +663,7 @@ create a query object as follows:
     ...
   }
 
-and send this via ``POST /_matrix/client/unstable/keys/claim``. Claims
+and send this via ``POST /_matrix/client/r0/keys/claim``. Claims
 for multiple devices should be aggregated into a single request.
 
 This will return a result as follows:
@@ -746,7 +746,7 @@ follows:
 Once all of these have been constructed, they should be sent to all of the
 relevant user's devices (using the wildcard ``*`` in place of the
 ``device_id``) via ``PUT
-/_matrix/client/unstable/sendToDevice/m.new_device/<txnId>.``
+/_matrix/client/r0/sendToDevice/m.new_device/<txnId>.``
 
 Handling an ``m.new_device`` event
 ----------------------------------

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -226,8 +226,8 @@ There are currently two defined algorithms:
 In the spec, this algorithm is detailed `here`__ and an example payload can be
 seen `here`__ .
 
-__ https://matrix.org/docs/spec/client_server/unstable.html#m-olm-v1-curve25519-aes-sha2
-__ https://matrix.org/docs/spec/client_server/unstable.html#m-room-encrypted
+__ https://matrix.org/docs/spec/client_server/r0.4.0.html#m-olm-v1-curve25519-aes-sha2
+__ `m.room.encrypted`_
 
 The ``sender_key`` property of the event content gives the Curve25519
 identity key of the sender. Clients should maintain a list of known Olm
@@ -311,8 +311,8 @@ as follows [#]_.
 In the spec, this algorithm is detailed `here`__ and an example payload can be
 seen `here`__.
 
-__ https://matrix.org/docs/spec/client_server/unstable.html#m-megolm-v1-aes-sha2
-__ https://matrix.org/docs/spec/client_server/unstable.html#m-room-encrypted
+__ https://matrix.org/docs/spec/client_server/r0.4.0.html#m-megolm-v1-aes-sha2
+__ `m.room.encrypted`_
 
 Encrypted events using this algorithm should have ``sender_key``,
 ``session_id`` and ``ciphertext`` content properties. If the
@@ -495,7 +495,7 @@ When encrypting an event using Olm, the client should:
 
 -  Build an encryption payload as illustrated in the `spec`__.
 
-   __ `https://matrix.org/docs/spec/client_server/unstable.html#m-olm-v1-curve25519-aes-sha2`
+   __ `https://matrix.org/docs/spec/client_server/r0.4.0.html#m-olm-v1-curve25519-aes-sha2`
 
 -  Check if it has an existing Olm session; if it does not, `start a new
    one`__. If it has several (as may happen due to
@@ -561,7 +561,7 @@ with a new member.
 
 The device tracking process which should be implemented is documented `in the
 spec
-<https://matrix.org/docs/spec/client_server/unstable.html#tracking-the-device-list-for-a-user>`__.
+<https://matrix.org/docs/spec/client_server/r0.4.0.html#tracking-the-device-list-for-a-user>`__.
 
 .. _`blocking`:
 
@@ -572,7 +572,7 @@ It should be possible for a user to mark each device belonging to
 another user as 'Blocked' or 'Verified', through a process detailed
 `in the spec`__.
 
-__ https://matrix.org/docs/spec/client_server/unstable.html#device-verification
+__ https://matrix.org/docs/spec/client_server/r0.4.0.html#device-verification
 
 When a user chooses to block a device, this means that no further
 encrypted messages should be shared with that device. In short, it
@@ -600,7 +600,7 @@ Encrypted attachments
 Homeservers must not be able to read files shared in encrypted rooms.
 Clients should implement a strategy described `in the spec`__.
 
-__ https://matrix.org/docs/spec/client_server/unstable.html#sending-encrypted-attachments
+__ https://matrix.org/docs/spec/client_server/r0.4.0.html#sending-encrypted-attachments
 
 Currently, the files are encrypted using AES-CTR, which is not included in
 libolm. Clients have to rely on a third party library.
@@ -652,21 +652,21 @@ to ``"cancel_request"`` and ``request_id`` to the ID of the initial request.
 
 
 .. |m.room.encryption| replace:: ``m.room.encryption``
-.. _`m.room.encryption`: https://matrix.org/docs/spec/client_server/unstable.html#m-room-encryption
+.. _`m.room.encryption`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-encryption
 
 .. |m.room.encrypted| replace:: ``m.room.encrypted``
-.. _`m.room.encrypted`: https://matrix.org/docs/spec/client_server/unstable.html#m-room-encrypted
+.. _`m.room.encrypted`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-encrypted
 
 .. |room_key| replace:: ``m.room_key``
-.. _`room_key`: https://matrix.org/docs/spec/client_server/unstable.html#m-room-key
+.. _`room_key`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-key
 
 .. |m.room_key_request| replace:: ``m.room_key_request``
-.. _`room_key_request`: https://matrix.org/docs/spec/client_server/unstable.html#m-room-key-request
+.. _`room_key_request`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-key-request
 
 .. |m.forwarded_room_key| replace:: ``m.forwarded_room_key``
-.. _`forwarded_room_key`: https://matrix.org/docs/spec/client_server/unstable.html#m-forwarded-room-key
+.. _`forwarded_room_key`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-forwarded-room-key
 
 .. _`Signing JSON`: https://matrix.org/docs/spec/appendices.html#signing-json
-.. _/keys/query: https://matrix.org/docs/spec/client_server/unstable.html#post-matrix-client-r0-keys-query
-.. _`/keys/upload`: https://matrix.org/docs/spec/client_server/unstable.html#post-matrix-client-r0-keys-upload
-.. _/keys/claim: https://matrix.org/docs/spec/client_server/unstable.html#post-matrix-client-r0-keys-claim
+.. _/keys/query: https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-keys-query
+.. _`/keys/upload`: https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-keys-upload
+.. _/keys/claim: https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-keys-claim

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -141,10 +141,11 @@ The number of one-time keys currently stored is returned by
 ``POST /_matrix/client/r0/keys/upload``. (Post an empty JSON object
 ``{}`` if you don’t want to upload the device keys.)
 
-However, a client should not rely on this in order to find out how many
-one-time keys are left on the homeserver during runtime. Instead, it should do
-so by inspecting the ``device_one_time_keys_count`` property of a ``/sync/``
-response, and upload more when it deems necessary.
+However, a client should not rely on this in order to keep track of how many
+one-time keys are left on the homeserver during runtime, for performance
+reasons. Instead, it should do so by inspecting the
+``device_one_time_keys_count`` property of a ``/sync/`` response, and upload
+more when it deems necessary.
 
 The maximum number of active keys supported by libolm is returned by
 ``olm_account_max_number_of_one_time_keys``. The client should try to

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -134,18 +134,11 @@ clients should call ``olm_account_sign``.
 Creating and registering one-time keys
 --------------------------------------
 
-At first start, the client should check how many one-time keys the homeserver
+The client should keep track of how many one-time keys the homeserver
 has stored for it, and, if necessary, generate and upload some more.
 
-The number of one-time keys currently stored is returned by
-``POST /_matrix/client/r0/keys/upload``. (Post an empty JSON object
-``{}`` if you don’t want to upload the device keys.)
-
-However, a client should not rely on this in order to keep track of how many
-one-time keys are left on the homeserver during runtime, for performance
-reasons. Instead, it should do so by inspecting the
-``device_one_time_keys_count`` property of a ``/sync/`` response, and upload
-more when it deems necessary.
+This can be achieved by inspecting the ``device_one_time_keys_count``
+property of a ``/sync/`` response.
 
 The maximum number of active keys supported by libolm is returned by
 ``olm_account_max_number_of_one_time_keys``. The client should try to

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -367,7 +367,7 @@ list of devices for each user in the room. This can be done proactively,
 or deferred until the first message is sent. The information is also
 required to allow users to `verify or block devices`__.
 
-__ `blocking`
+__ `blocking`_
 
 The client should use the `/keys/query`_ endpoint, passing the IDs of the
 members of the room in the ``device_keys`` property of the request.

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -594,6 +594,17 @@ m.room.encrypted event`_ for notes on how to do this
 for each algorithm. Events sent from a verified device can be decorated
 in the UI to show that they have been sent from a verified device.
 
+Encrypted attachments
+=====================
+
+Homeservers must not be able to read files shared in encrypted rooms.
+Clients should implement a strategy described `in the spec`__.
+
+__ https://matrix.org/docs/spec/client_server/unstable.html#sending-encrypted-attachments
+
+Currently, the files are encrypted using AES-CTR, which is not included in
+libolm. Clients have to rely on a third party library.
+
 
 
 .. |m.room.encryption| replace:: ``m.room.encryption``

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -611,10 +611,10 @@ request them from other clients which may have them. Similarly, a client may
 want to reply to a key request with the associated key if it can assert that
 the requesting device is allowed to see the messages encrypted with this key.
 
-Those capabilities are achieved using |m.room_key_request| and
-|m.forwarded_room_key| events.
+Those capabilities are achieved using |m.room_key_request|_ and
+|m.forwarded_room_key|_ events.
 
-The ``session_key`` property of a |m.forwarded_room_key| event differs from the
+The ``session_key`` property of a |m.forwarded_room_key|_ event differs from the
 one of a |room_key| event, as it does not include the Ed25519 signature of the
 original sender. It should be obtained from
 ``olm_export_inbound_group_session`` at the desired ``message index``, and the
@@ -644,7 +644,7 @@ shared with, and at which ``message index``.
 
 Key requests can be sent to all of the current user's devices, as well as the
 original sender of the session, and other devices present in the room. When the
-client receives the requested key, it should send a |m.room_key_request| event
+client receives the requested key, it should send a |m.room_key_request|_ event
 to all the devices it requested the key from, setting the ``action`` property
 to ``"cancel_request"`` and ``request_id`` to the ID of the initial request.
 
@@ -659,10 +659,10 @@ to ``"cancel_request"`` and ``request_id`` to the ID of the initial request.
 .. _`room_key`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-key
 
 .. |m.room_key_request| replace:: ``m.room_key_request``
-.. _`room_key_request`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-key-request
+.. _`m.room_key_request`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-room-key-request
 
 .. |m.forwarded_room_key| replace:: ``m.forwarded_room_key``
-.. _`forwarded_room_key`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-forwarded-room-key
+.. _`m.forwarded_room_key`: https://matrix.org/docs/spec/client_server/r0.4.0.html#m-forwarded-room-key
 
 .. _`Signing JSON`: https://matrix.org/docs/spec/appendices.html#signing-json
 .. _/keys/query: https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-keys-query

--- a/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
+++ b/jekyll/_posts/guides/2016-10-18-e2e_implementation.rst
@@ -224,8 +224,7 @@ There are currently two defined algorithms:
 ``m.olm.v1.curve25519-aes-sha2``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the spec, this algorithm is detailed `here`__ and an example payload can be
-seen `here`__ .
+The spec gives `details on this algorithm`__ and an `example payload`__ .
 
 __ https://matrix.org/docs/spec/client_server/r0.4.0.html#m-olm-v1-curve25519-aes-sha2
 __ `m.room.encrypted`_
@@ -309,8 +308,7 @@ as follows [#]_.
 ``m.megolm.v1.aes-sha2``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the spec, this algorithm is detailed `here`__ and an example payload can be
-seen `here`__.
+The spec gives `details on this algorithm`__ and an `example payload`__ .
 
 __ https://matrix.org/docs/spec/client_server/r0.4.0.html#m-megolm-v1-aes-sha2
 __ `m.room.encrypted`_
@@ -460,13 +458,12 @@ __ `m.room_key`_
 
 The client must then share the keys for this session with each device in the
 room. It must therefore `download the device list`_ if it hasn't already done
-so. and for each device in the room which has not been `blocked`__, the client
-Then it should build a unique |room_key|_ event, and send it encrypted to each
-device in the room which has not been `blocked`__, `using Olm`__.
+so.
+Then it should build a unique |room_key|_ event, and send it encrypted `using
+Olm`__ to each device in the room which has not been `blocked`__, .
 
-__ `blocking`_
-__ `blocking`_
 __ `olm_encrypt`_
+__ `blocking`_
 
 Once all of the key-sharing event contents have been assembled, the
 events should be sent to the corresponding devices via


### PR DESCRIPTION
Attempt to bring the implementation guide up-to-date with the current state of E2E in Matrix.

It can't be merged before https://github.com/matrix-org/matrix-doc/pull/1465, https://github.com/matrix-org/matrix-doc/pull/1420, and https://github.com/matrix-org/matrix-doc/pull/1284 are, since it contains links to those parts.

Signed-off-by: Valentin Deniaud \<valentin.deniaud@inpt.fr\>