### PR TITLE
Fix Title in SimpleMatrix project file

### DIFF
--- a/jekyll/_posts/projects/2018-09-13-SimpleMatrix.md
+++ b/jekyll/_posts/projects/2018-09-13-SimpleMatrix.md
@@ -11,7 +11,9 @@ language: Kotlin
 license: AGPLv3
 repo: https://gitlab.com/Nordgedanken/SimpleMatrix
 ---
+
 ![screenshot](https://gitlab.com/Nordgedanken/SimpleMatrix/raw/master/images/stitched.jpg "{{ page.title }}")
+
 # {{ page.title }}
 SimpleMatrix is an Android client with the goal of having a simple UI and UX. Its goal is to have a more Whatsapp or Telegram like Interface design allowing people to switch more easily to Matrix.
 Repository: <{{page.repo}}>


### PR DESCRIPTION
It seems like it worked on Github but on the Matrix Page the Title did not get rendered as a Title. I think the reason is that I missed these 2 whitespaces. Sorry for that