### PR TITLE
Point users towards official docker image

### DIFF
--- a/jekyll/_posts/projects/2014-08-12-synapse.md
+++ b/jekyll/_posts/projects/2014-08-12-synapse.md
@@ -18,7 +18,7 @@ Matrix.org’s reference server – Synapse: [https://github.com/matrix-org/syna
 
 Apt repo: [https://matrix.org/packages/debian/](https://matrix.org/packages/debian/)
 
-Dockerfile from Silvio Fricke and AVENTER: [https://hub.docker.com/r/avhost/docker-matrix/](https://hub.docker.com/r/avhost/docker-matrix/)
+Docker image [matrixdotorg/synapse](https://hub.docker.com/r/matrixdotorg/synapse/) is built using [docker/Dockerfile](https://github.com/matrix-org/synapse/tree/master/docker)
 
 ArchLinux package from Ivan Shapovalov: [https://www.archlinux.org/packages/community/any/matrix-synapse/](https://www.archlinux.org/packages/community/any/matrix-synapse/)
 


### PR DESCRIPTION
Since this caused confusion in https://github.com/matrix-org/synapse/issues/3992 . Maybe the previously recommended image can be listed in projects instead?