### PR TITLE
FreeBSD package location has moved.

### DIFF
--- a/jekyll/_posts/projects/2014-08-12-synapse.md
+++ b/jekyll/_posts/projects/2014-08-12-synapse.md
@@ -22,7 +22,7 @@ Docker image [matrixdotorg/synapse](https://hub.docker.com/r/matrixdotorg/synaps
 
 ArchLinux package from Ivan Shapovalov: [https://www.archlinux.org/packages/community/any/matrix-synapse/](https://www.archlinux.org/packages/community/any/matrix-synapse/)
 
-There is a FreeBSD package on [freshports.org](http://www.freshports.org/net/py-matrix-synapse/).
+There is a FreeBSD package on [freshports.org](http://www.freshports.org/net-im/py-matrix-synapse/).
 
 Martin Giess has created an auto-deployment process with vagrant/ansible, tested with VirtualBox/AWS/DigitalOcean – see [https://github.com/EMnify/matrix-synapse-auto-deploy](https://github.com/EMnify/matrix-synapse-auto-deploy) for details.
 


### PR DESCRIPTION
Reason for package moving, from net to net-im because it is a more appropriate category.