### PR TITLE
Mark mxhsd as no longer maintained

### DIFF
--- a/jekyll/_posts/projects/2018-04-24-mxhsd.md
+++ b/jekyll/_posts/projects/2018-04-24-mxhsd.md
@@ -4,7 +4,7 @@ title: mxhsd
 categories: projects server
 description: mxhsd is Matrix Homeserver aimed towards entities who want to have in-depth control of their servers
 author: Max Dor
-maturity: Early Beta
+maturity: No longer maintained
 language: Java
 license: 
 repo: https://github.com/kamax-io/mxhsd


### PR DESCRIPTION
The following commit makes that clear:
https://github.com/kamax-matrix/mxhsd/commit/43558deb59c6ed64b02ab61788bc33f54ceea6ce

It might still be interesting to preserve the "Early Beta" state somewhere, although I expect this to become less and less true with time.