### PR TITLE
Add outdated spec warning to r0.1.0 of s2s

### DIFF
--- a/unstyled_docs/spec/server_server/r0.1.0.html
+++ b/unstyled_docs/spec/server_server/r0.1.0.html
@@ -913,6 +913,7 @@ div.admonition-example {
 <div class="document" id="federation-api">
 
 <h1 class="title">Federation API</h1>
+%outdatedspecwarning%
 
 
 


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix.org/pull/228 until https://github.com/matrix-org/matrix.org/issues/230 exists.