### PR TITLE
Update 2018-12-27-fluffychat.md

### DIFF
--- a/jekyll/_posts/projects/2018-12-27-fluffychat.md
+++ b/jekyll/_posts/projects/2018-12-27-fluffychat.md
@@ -2,14 +2,14 @@
 layout: projectimage
 title: FluffyChat
 categories: projects client
-thumbnail: https://christianpauly.github.io/fluffychat/images/screenshot.png
+thumbnail: https://christianpauly.github.io/fluffychat/assets/images/screenshot.png
 description: Open, nonprofit and cute client for Ubuntu Touch
 author: Christian Pauly
 maturity: Released
 language: Qml
 license: GPL-3.0-only
 repo: https://github.com/ChristianPauly/fluffychat
-screenshot: https://christianpauly.github.io/fluffychat/images/screenshot.png
+screenshot: https://christianpauly.github.io/fluffychat/assets/images/screenshot.png
 room: "#fluffychat:matrix.org"
 ---
 


### PR DESCRIPTION
The FluffyChat website has moved to jekyll with localization so I have moved everything in an assets directory.