### PR TITLE
Use packages.matrix.org for packages

### DIFF
--- a/jekyll/_posts/projects/2014-08-12-synapse.md
+++ b/jekyll/_posts/projects/2014-08-12-synapse.md
@@ -20,7 +20,7 @@ To install, first take a look at **[Installing Synapse](https://matrix.org/docs/
 
 You can use the [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy) to easily install Synapse and related dependencies using pre-build Ansible playbooks and docker images.
 
-Apt repo: [https://matrix.org/packages/debian/](https://matrix.org/packages/debian/)
+Apt repo: [https://packages.matrix.org/debian/](https://packages.matrix.org/debian/)
 
 Docker image [matrixdotorg/synapse](https://hub.docker.com/r/matrixdotorg/synapse/) is built using [docker/Dockerfile](https://github.com/matrix-org/synapse/tree/master/docker)
 


### PR DESCRIPTION
See https://github.com/vector-im/riot-web/issues/9497 (applies to more than just Olm)
See also https://github.com/matrix-org/synapse/pull/5067