### PR TITLE
Update repo link for Pattle

### DIFF
--- a/jekyll/_posts/projects/2019-03-13-pattle.md
+++ b/jekyll/_posts/projects/2019-03-13-pattle.md
@@ -8,7 +8,7 @@ author: wilko
 maturity: Alpha
 language: Kotlin
 license: AGPL-3.0-or-later
-repo: https://git.pattle.im/pattle/android
+repo: https://git.pattle.im/pattle/app
 screenshot: /docs/projects/images/pattle.png
 room: "#pattle:matrix.org"
 platform: Android


### PR DESCRIPTION
Pattle's sources now live at https://git.pattle.im/pattle/app