### PR TITLE
Fix the RSS feed so it shows the full post (#408)

### DIFF
--- a/gatsby/blog/2019-04-11/security.mdx
+++ b/gatsby/blog/2019-04-11/security.mdx
@@ -122,4 +122,4 @@ was passphrased and based on our initial analysis of the release, we believe it 
 
 <h2 id="toc_9">What are we doing to prevent this in future?</h2>
 
-<p>Once things are back up and running we will retrospect on this incident in detail to identify the changes we need to make. We will provide a proper postmortem, including follow-up steps; meanwhile we are obviously going to take measures to improve the security of our production infrastructure, including patching services more aggressively and more regular vulnerability scans.</p>
+<p>Once things are back up and running we will retrospect on this incident in detail to identify the changes we need to make. We will provide a proper postmortem, including follow-up steps; meanwhile we are obviously going to take measures to improve the security of our production infrastructure, including patching services more aggressively and more regular vulnerability scans.</p>

--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -27,18 +27,26 @@ module.exports = {
         `,
         feeds: [
           {
-            serialize: ({ query: { site, allMdx } }) => {              return allMdx.edges.map(edge => {                return Object.assign({}, edge.node.frontmatter, {
+            serialize: ({ query: { site, allMdx } }) => {
+              return allMdx.edges.map(edge => {
+                return {
+                  ...edge.node.frontmatter,
                   description: edge.node.excerpt,
                   date: edge.node.frontmatter.date,
                   url: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
                   custom_elements: [{ "content:encoded": edge.node.html }],
-                })
+                }
               })
             },
             query: `
               {
-                allMdx(   limit: 10,               sort: { order: DESC, fields: [frontmatter___date] },
+                allMdx(
+                  limit: 10,
+                  sort: {
+                    order: DESC,
+                    fields: [frontmatter___date]
+                  },
                 ) {
                   edges {
                     node {

--- a/gatsby/package-lock.json
+++ b/gatsby/package-lock.json
@@ -1308,16 +1308,20 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-0.20.3.tgz",
-      "integrity": "sha512-IIlssEIPPAqo04krm270ifGjSVPqtTmjlryYGi8/4VXHCdi42l8v2piTJPo2NVc7J+HizY1uxxZb6AeoFsO/Iw==",
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.0.18.tgz",
+      "integrity": "sha512-KO2odMrZC77Yf9bhL0Qu0GtvVivVV6dL5DWJeuMeSkc9wkL9fBT06re67TfgeJ37R+lyslkG+uPUahIj4/SOoQ==",
+      "dev": true,
       "requires": {
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+        "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
         "change-case": "^3.0.2",
         "detab": "^2.0.0",
         "hast-util-raw": "^5.0.0",
+        "lodash.uniq": "^4.5.0",
         "mdast-util-to-hast": "^4.0.0",
+        "remark-mdx": "^1.0.18",
         "remark-parse": "^6.0.0",
         "remark-squeeze-paragraphs": "^3.0.1",
         "to-style": "^1.3.3",
@@ -1325,6 +1329,12 @@
         "unist-builder": "^1.0.1",
         "unist-util-visit": "^1.3.0"
       }
+    },
+    "@mdx-js/react": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.0.16.tgz",
+      "integrity": "sha512-HJJO8LYogt9UT4TP3+TVeokMj0lgwCONKlcOfr7VMb38Z6DDE3Ydvi+M3iScUea2DfifS4kGztgJ7zH6HXynTw==",
+      "dev": true
     },
     "@mdx-js/tag": {
       "version": "0.20.3",
@@ -1880,9 +1890,9 @@
       }
     },
     "array-iterate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.2.tgz",
-      "integrity": "sha512-1hWSHTIlG/8wtYD+PPX5AOBtKWngpDFjrsrHgZpe+JdgNGz0udYu6ZIkAa/xuenIUEqFv7DvE2Yr60jxweJSrQ=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.3.tgz",
+      "integrity": "sha512-7MIv7HE9MuzfK6B2UnWv07oSHBLOaY1UUXAxZ07bIeRM+4IkPTlveMDs9MY//qvxPZPSvCn2XV4bmtQgSkVodg=="
     },
     "array-map": {
       "version": "0.0.0",
@@ -2101,9 +2111,9 @@
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
     },
     "babel-eslint": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
-      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3127,6 +3137,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.1"
@@ -3226,6 +3237,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
       "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "dev": true,
       "requires": {
         "camel-case": "^3.0.0",
         "constant-case": "^2.0.0",
@@ -3543,12 +3555,10 @@
       }
     },
     "comma-separated-tokens": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.5.tgz",
-      "integrity": "sha512-Cg90/fcK93n0ecgYTAz1jaA3zvnQ0ExlmKY1rdbyHqAx6BHxwoJc+J7HDu0iuQ7ixEs1qaa+WyQ6oeuBpYP1iA==",
-      "requires": {
-        "trim": "0.0.1"
-      }
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.6.tgz",
+      "integrity": "sha512-f20oA7jsrrmERTS70r3tmRSxR8IJV2MTN7qe6hzgX+3ARfXrdMJFvGWvWQK0xpcBurg9j9eO2MiqzZ8Y+/UPCA==",
+      "dev": true
     },
     "command-exists": {
       "version": "1.2.8",
@@ -3724,6 +3734,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
       "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "dev": true,
       "requires": {
         "snake-case": "^2.1.0",
         "upper-case": "^1.1.1"
@@ -4008,6 +4019,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "source-map": "^0.6.1",
@@ -4307,6 +4319,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -4617,9 +4634,10 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detab": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
-      "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.2.tgz",
+      "integrity": "sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==",
+      "dev": true,
       "requires": {
         "repeat-string": "^1.5.4"
       }
@@ -4840,6 +4858,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
       "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0"
       }
@@ -6309,7 +6328,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6327,11 +6347,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6344,15 +6366,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6455,7 +6480,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6465,6 +6491,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6477,17 +6504,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6504,6 +6534,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6576,7 +6607,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6586,6 +6618,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6661,7 +6694,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6691,6 +6725,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6708,6 +6743,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6746,11 +6782,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7355,11 +7393,16 @@
       }
     },
     "gatsby-mdx": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/gatsby-mdx/-/gatsby-mdx-0.4.5.tgz",
-      "integrity": "sha512-zyh5CheYXrdV8USjY4m6THuLAFmcNTGWCfoFC51dPeO8ODZUFJ2adHI0RVQW76u2IciK3hc73FNXUx8OslTvhQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/gatsby-mdx/-/gatsby-mdx-0.6.2.tgz",
+      "integrity": "sha512-knTLJCONK4I4ItDfnCBuxEy6imXzyUJ9rbjzoqgy8Z8sDjmwlXcJ4j2RRJnjttZP8NxPt/YR/Dljj0HVotC+YA==",
       "requires": {
-        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/core": "^7.4.3",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "@babel/preset-react": "^7.0.0",
+        "core-js": "2",
+        "dataloader": "^1.4.0",
         "debug": "^4.0.1",
         "escape-string-regexp": "^1.0.5",
         "fs-extra": "^7.0.0",
@@ -7367,14 +7410,14 @@
         "loader-utils": "^1.2.3",
         "lodash": "^4.17.10",
         "mdast-util-to-string": "^1.0.4",
-        "mdast-util-toc": "^2.0.1",
+        "mdast-util-toc": "^3.0.0",
         "mime": "^2.3.1",
         "pretty-bytes": "^5.1.0",
-        "remark": "^9.0.0",
-        "retext": "^5.0.0",
+        "remark": "^10.0.0",
+        "remark-retext": "^3.1.2",
+        "retext-english": "^3.0.2",
         "slash": "^2.0.0",
         "static-site-generator-webpack-plugin": "^3.4.2",
-        "strip-markdown": "^3.0.1",
         "underscore.string": "^3.3.4",
         "unist-util-map": "^1.0.4",
         "unist-util-remove": "^1.0.1",
@@ -8373,9 +8416,10 @@
       }
     },
     "hast-to-hyperscript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-6.0.0.tgz",
-      "integrity": "sha512-QnJbXddVGNJ5v3KegK1MY6luTkNDBcJnCQZcekt7AkES2z4tYy85pbFUXx7Mb0iXZBKfwoVdgfxU12GbmlwbbQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-7.0.0.tgz",
+      "integrity": "sha512-0BqSZCyxxIzPNPy0sx18Ii+xLKIkv4pu8b4M9bOvAqCwRmEDcYdLT1jyl2CqPlM2Egb7RWrqOPRfNgFAeriPSg==",
+      "dev": true,
       "requires": {
         "comma-separated-tokens": "^1.0.0",
         "property-information": "^5.0.0",
@@ -8389,6 +8433,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-5.0.0.tgz",
       "integrity": "sha512-A7ev5OseS/J15214cvDdcI62uwovJO2PB60Xhnq7kaxvvQRFDEccuqbkrFXU03GPBGopdPqlpQBRqIcDS/Fjbg==",
+      "dev": true,
       "requires": {
         "ccount": "^1.0.3",
         "hastscript": "^5.0.0",
@@ -8400,12 +8445,14 @@
     "hast-util-parse-selector": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.1.tgz",
-      "integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw=="
+      "integrity": "sha512-Xyh0v+nHmQvrOqop2Jqd8gOdyQtE8sIP9IQf7mlVDqp924W4w/8Liuguk2L2qei9hARnQSG2m+wAOCxM7npJVw==",
+      "dev": true
     },
     "hast-util-raw": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-5.0.0.tgz",
       "integrity": "sha512-X8sogDDaCkqj+Ghia0+TRD2AQDXeNRpYDTm9Z2mJ1Pzy/Nb4p20YJVfbPwIRU0U7XXU0GrhPhEMZvnfV69/igA==",
+      "dev": true,
       "requires": {
         "hast-util-from-parse5": "^5.0.0",
         "hast-util-to-parse5": "^5.0.0",
@@ -8418,11 +8465,12 @@
       }
     },
     "hast-util-to-parse5": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-5.0.0.tgz",
-      "integrity": "sha512-1BG07SLp9RHnAy/A2Fugza5YCo45Ter8csOGbxL7a7f9Rvq9aE64/4hlqc083M8yLLp7J5tYxmiFWYbD0zQJnA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-5.1.0.tgz",
+      "integrity": "sha512-o08Q+7KNu2mO9060o0TojXOxiZmbU0G+IMDaAahE0vuwr9zSejFRonfnSQLn6pDqSDJyaEkdqtVcwITBIT2jqw==",
+      "dev": true,
       "requires": {
-        "hast-to-hyperscript": "^6.0.0",
+        "hast-to-hyperscript": "^7.0.0",
         "property-information": "^5.0.0",
         "web-namespaces": "^1.0.0",
         "xtend": "^4.0.1",
@@ -8433,6 +8481,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.0.0.tgz",
       "integrity": "sha512-xJtuJ8D42Xtq5yJrnDg/KAIxl2cXBXKoiIJwmWX9XMf8113qHTGl/Bf7jEsxmENJ4w6q4Tfl8s/Y6mEZo8x8qw==",
+      "dev": true,
       "requires": {
         "comma-separated-tokens": "^1.0.0",
         "hast-util-parse-selector": "^2.2.0",
@@ -8444,6 +8493,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
       "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.1.3"
@@ -8522,9 +8572,10 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-void-elements": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.3.tgz",
-      "integrity": "sha512-SaGhCDPXJVNrQyKMtKy24q6IMdXg5FCPN3z+xizxw9l+oXQw5fOoaj/ERU5KqWhSYhXtW5bWthlDbTDLBhJQrA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
+      "integrity": "sha512-yMk3naGPLrfvUV9TdDbuYXngh/TpHbA6TrOw3HL9kS8yhwx7i309BReNg7CbAJXGE+UMJ6je5OqJ7lC63o6YuQ==",
+      "dev": true
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -9271,6 +9322,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "dev": true,
       "requires": {
         "lower-case": "^1.1.0"
       }
@@ -9449,6 +9501,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "dev": true,
       "requires": {
         "upper-case": "^1.1.0"
       }
@@ -10095,12 +10148,14 @@
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
     },
     "lower-case-first": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "dev": true,
       "requires": {
         "lower-case": "^1.1.2"
       }
@@ -10191,9 +10246,9 @@
       "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
     },
     "markdown-table": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
-      "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+      "integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q=="
     },
     "md5": {
       "version": "2.2.1",
@@ -10234,6 +10289,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-3.0.4.tgz",
       "integrity": "sha512-sUu55X5JWisBqfiq2pwQv4SnLb11EBua0NWjvcl6WORfV18MdWoyODE2tS4pyqjwXbFTaq3y3Ca/4OMNvx8B0Q==",
+      "dev": true,
       "requires": {
         "unist-util-remove": "^1.0.0"
       }
@@ -10258,6 +10314,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-4.0.0.tgz",
       "integrity": "sha512-yOTZSxR1aPvWRUxVeLaLZ1sCYrK87x2Wusp1bDM/Ao2jETBhYUKITI3nHvgy+HkZW54HuCAhHnS0mTcbECD5Ig==",
+      "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.0",
         "detab": "^2.0.0",
@@ -10272,18 +10329,30 @@
         "xtend": "^4.0.1"
       }
     },
+    "mdast-util-to-nlcst": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-nlcst/-/mdast-util-to-nlcst-3.2.2.tgz",
+      "integrity": "sha512-TmJlri8dHt7duRU6jfWBMqf5gW+VZ6o/8GHaWzwdxslseB2lL8bSOiox6c8VwYX5v2E4CzUWm/1GkAYqgbNw9A==",
+      "requires": {
+        "nlcst-to-string": "^2.0.0",
+        "repeat-string": "^1.5.2",
+        "unist-util-position": "^3.0.0",
+        "vfile-location": "^2.0.0"
+      }
+    },
     "mdast-util-to-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz",
       "integrity": "sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A=="
     },
     "mdast-util-toc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-2.1.0.tgz",
-      "integrity": "sha512-ove/QQWSrYOrf9G3xn2MTAjy7PKCtCmm261wpQwecoPAsUtkihkMVczxFqil7VihxgSz4ID9c8bBTsyXR30gQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-3.1.0.tgz",
+      "integrity": "sha512-Za0hqL1PqWrvxGtA/3NH9D5nhGAUS9grMM4obEAz5+zsk1RIw/vWUchkaoDLNdrwk05A0CSC5eEXng36/1qE5w==",
       "requires": {
-        "github-slugger": "^1.1.1",
-        "mdast-util-to-string": "^1.0.2",
+        "github-slugger": "^1.2.1",
+        "mdast-util-to-string": "^1.0.5",
+        "unist-util-is": "^2.1.2",
         "unist-util-visit": "^1.1.0"
       }
     },
@@ -10295,7 +10364,8 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
     },
     "mdx-utils": {
       "version": "0.0.2",
@@ -10756,6 +10826,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
       }
@@ -11333,6 +11404,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0"
       }
@@ -11384,6 +11456,17 @@
         "xml2js": "^0.4.5"
       }
     },
+    "parse-english": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/parse-english/-/parse-english-4.1.2.tgz",
+      "integrity": "sha512-+PBf+1ifxqJlOpisODiKX4A8wBEgWm4goMvDB5O9zx/cQI58vzHTZeWFbAgCF9fUXRl8/YdINv1cfmfIRR1acg==",
+      "requires": {
+        "nlcst-to-string": "^2.0.0",
+        "parse-latin": "^4.0.0",
+        "unist-util-modify-children": "^1.0.0",
+        "unist-util-visit-children": "^1.0.0"
+      }
+    },
     "parse-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
@@ -11425,9 +11508,9 @@
       }
     },
     "parse-latin": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.1.1.tgz",
-      "integrity": "sha512-9fPVvDdw6G8LxL3o/PL6IzSGNGpF+3HEjCzFe0dN83sZPstftyr+McP9dNi3+EnR7ICYOHbHKCZ0l7JD90K5xQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.2.0.tgz",
+      "integrity": "sha512-b8PvsA1Ohh7hIQwDDy6kSjx3EbcuR3oKYm5lC1/l/zIB6mVVV5ESEoS1+Qr5+QgEGmp+aEZzc+D145FIPJUszw==",
       "requires": {
         "nlcst-to-string": "^2.0.0",
         "unist-util-modify-children": "^1.0.0",
@@ -11442,7 +11525,8 @@
     "parse5": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+      "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
@@ -11469,6 +11553,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
       "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "dev": true,
       "requires": {
         "camel-case": "^3.0.0",
         "upper-case-first": "^1.1.0"
@@ -11488,6 +11573,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
       "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0"
       }
@@ -12378,9 +12464,9 @@
       }
     },
     "pretty-bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
-      "integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.2.0.tgz",
+      "integrity": "sha512-ujANBhiUsl9AhREUDUEY1GPOharMGm8x8juS7qOHybcLi7XsKfrYQ88hSly1l2i0klXHTDYrlL8ihMCG55Dc3w=="
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -12473,6 +12559,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.0.1.tgz",
       "integrity": "sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==",
+      "dev": true,
       "requires": {
         "xtend": "^4.0.1"
       }
@@ -13103,66 +13190,28 @@
       }
     },
     "remark": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-9.0.0.tgz",
-      "integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+      "integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
       "requires": {
-        "remark-parse": "^5.0.0",
-        "remark-stringify": "^5.0.0",
-        "unified": "^6.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "remark-parse": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-          "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-          "requires": {
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.1.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "unified": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-          "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "trough": "^1.0.0",
-            "vfile": "^2.0.0",
-            "x-is-string": "^0.1.0"
-          }
-        },
-        "vfile": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-          "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-          "requires": {
-            "is-buffer": "^1.1.4",
-            "replace-ext": "1.0.0",
-            "unist-util-stringify-position": "^1.0.0",
-            "vfile-message": "^1.0.0"
-          }
-        }
+        "remark-parse": "^6.0.0",
+        "remark-stringify": "^6.0.0",
+        "unified": "^7.0.0"
+      }
+    },
+    "remark-mdx": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.0.18.tgz",
+      "integrity": "sha512-PLsY2LNXuJ8YHaxjuOpRk+hDviB7jBFwLmLN4m4P5/Ev+NlmG8uXisAkP4P4Al47CPmJyKHQRJMjA8mWu4exVw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.2.2",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "is-alphabetical": "^1.0.2",
+        "remark-parse": "^6.0.0",
+        "unified": "^7.0.0"
       }
     },
     "remark-parse": {
@@ -13187,18 +13236,27 @@
         "xtend": "^4.0.1"
       }
     },
+    "remark-retext": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.2.tgz",
+      "integrity": "sha512-+48KzJdSXvsPupY5pj5AY7oBUSiDOqFPZBKebX5WemrMyIG+RImIt9hgeqelluVDd1kooHen33K/aybTPyoI9g==",
+      "requires": {
+        "mdast-util-to-nlcst": "^3.2.0"
+      }
+    },
     "remark-squeeze-paragraphs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/remark-squeeze-paragraphs/-/remark-squeeze-paragraphs-3.0.3.tgz",
       "integrity": "sha512-eDvjtwFa9eClqb7XgdF/1H9Pfs2LPnf/P3eRs9ucYAWUuv4WO8ZOVAUeT/1h66rQvghnfctz9au+HEmoKcdoqA==",
+      "dev": true,
       "requires": {
         "mdast-squeeze-paragraphs": "^3.0.0"
       }
     },
     "remark-stringify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
-      "integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
       "requires": {
         "ccount": "^1.0.0",
         "is-alphanumeric": "^1.0.0",
@@ -13370,62 +13428,13 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
-    "retext": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retext/-/retext-5.0.0.tgz",
-      "integrity": "sha1-XZAYxKZ31hA8FCNi129Q6x05i/Y=",
+    "retext-english": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/retext-english/-/retext-english-3.0.2.tgz",
+      "integrity": "sha512-iWffdWUvJngqaRlE570SaYRgQbn4/QVBfGa/XseEBuBazymnyW24o37oLPY0vm+PJdLmDghnjZX0UbkZSZF0Cg==",
       "requires": {
-        "retext-latin": "^2.0.0",
-        "retext-stringify": "^2.0.0",
-        "unified": "^6.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "unified": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-          "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "trough": "^1.0.0",
-            "vfile": "^2.0.0",
-            "x-is-string": "^0.1.0"
-          }
-        },
-        "vfile": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-          "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
-          "requires": {
-            "is-buffer": "^1.1.4",
-            "replace-ext": "1.0.0",
-            "unist-util-stringify-position": "^1.0.0",
-            "vfile-message": "^1.0.0"
-          }
-        }
-      }
-    },
-    "retext-latin": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-2.0.2.tgz",
-      "integrity": "sha512-7eIuQ23AepCmIbWPoJY/1YBPKYkfR81Pcr0daU6GWWenxF/UM6WUvKGHLtko4g9wrrQiu8XyDSfQ9jAV6rbKyg==",
-      "requires": {
-        "parse-latin": "^4.0.0",
+        "parse-english": "^4.0.0",
         "unherit": "^1.0.4"
-      }
-    },
-    "retext-stringify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-2.0.2.tgz",
-      "integrity": "sha512-SphWgEipyuEVXRsKqxhUN6+h7H6GNFFjPDxNJs4ZX7HEhizmaXUdHSSuOyRjbY764SH2mMVf+kj8NNpMksfgUA==",
-      "requires": {
-        "nlcst-to-string": "^2.0.0"
       }
     },
     "rgb-regex": {
@@ -13692,6 +13701,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
       "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0",
         "upper-case-first": "^1.1.2"
@@ -13924,6 +13934,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
       "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0"
       }
@@ -14247,12 +14258,10 @@
       "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
     },
     "space-separated-tokens": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.2.tgz",
-      "integrity": "sha512-G3jprCEw+xFEs0ORweLmblJ3XLymGGr6hxZYTYZjIlvDti9vOBUjRQa1Rzjt012aRrocKstHwdNi+F7HguPsEA==",
-      "requires": {
-        "trim": "0.0.1"
-      }
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.3.tgz",
+      "integrity": "sha512-/M5RAdBuQlSDPNfA5ube+fkHbHyY08pMuADLmsAQURzo56w90r681oiOoz3o3ZQyWdSeNucpTFjL+Ggd5qui3w==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -14704,11 +14713,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
-    "strip-markdown": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/strip-markdown/-/strip-markdown-3.0.3.tgz",
-      "integrity": "sha512-G2DSM9wy3PWxY3miAibWpsTqZgXLXgRoq0yVyaVs9O7FDGEwPO6pmSE8CyzHhU88Z2w1dkFqFmWUklFNsQKwqg=="
-    },
     "strip-outer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
@@ -14730,6 +14734,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.2.2.tgz",
       "integrity": "sha512-GcbtvfsqyKmIPpHeOHZ5Rmwsx2MDJct4W9apmTGcbPTbpA2FcgTFl2Z43Hm4Qb61MWGPNK8Chki7ITiY7lLOow==",
+      "dev": true,
       "requires": {
         "css": "2.2.4"
       }
@@ -14849,6 +14854,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "dev": true,
       "requires": {
         "lower-case": "^1.1.1",
         "upper-case": "^1.1.1"
@@ -15078,6 +15084,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "dev": true,
       "requires": {
         "no-case": "^2.2.0",
         "upper-case": "^1.0.3"
@@ -15157,7 +15164,8 @@
     "to-style": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/to-style/-/to-style-1.3.3.tgz",
-      "integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw="
+      "integrity": "sha1-Y6K3Cm9KfU/cLtV6C+TnI1y2aZw=",
+      "dev": true
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -15194,9 +15202,10 @@
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-lines": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.1.tgz",
-      "integrity": "sha512-X+eloHbgJGxczUk1WSjIvn7aC9oN3jVE3rQfRVKcgpavi3jxtCn0VVKtjOBj64Yop96UYn/ujJRpTbCdAF1vyg=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
+      "integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ==",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -15318,6 +15327,12 @@
       "version": "0.0.54",
       "resolved": "https://registry.npmjs.org/typeface-open-sans/-/typeface-open-sans-0.0.54.tgz",
       "integrity": "sha512-w6wOd6EicZdZKf0jSU/K3EzEi3zFgvWQSN7NOpRIQI5KeMWmC5Pg/lqtBVJHB0pRChYRmLdhf4h8ROur0A3JZQ=="
+    },
+    "typescript": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.19",
@@ -15486,6 +15501,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.3.tgz",
       "integrity": "sha512-/KB8GEaoeHRyIqClL+Kam+Y5NWJ6yEiPsAfv1M+O1p+aKGgjR89WwoEHKTyOj17L6kAlqtKpAgv2nWvdbQDEig==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.0"
       }
@@ -15574,7 +15590,8 @@
     "unist-util-generated": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.3.tgz",
-      "integrity": "sha512-qlPeDqnQnd84KIqwphzOR+l02cxjDzvEYEBl84EjmKRrX4eUmjyAo8xJv1SCDhJqNjyHRnBMZWNKAiBtXE6hBg=="
+      "integrity": "sha512-qlPeDqnQnd84KIqwphzOR+l02cxjDzvEYEBl84EjmKRrX4eUmjyAo8xJv1SCDhJqNjyHRnBMZWNKAiBtXE6hBg==",
+      "dev": true
     },
     "unist-util-is": {
       "version": "2.1.2",
@@ -15750,12 +15767,14 @@
     "upper-case": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
     },
     "upper-case-first": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "dev": true,
       "requires": {
         "upper-case": "^1.1.1"
       }
@@ -15993,9 +16012,10 @@
       }
     },
     "web-namespaces": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.2.tgz",
-      "integrity": "sha512-II+n2ms4mPxK+RnIxRPOw3zwF2jRscdJIUE9BfkKHm4FYEg9+biIoTMnaZF5MpemE3T+VhMLrhbyD4ilkPCSbg=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
+      "integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA==",
+      "dev": true
     },
     "webpack": {
       "version": "4.28.4",
@@ -16953,9 +16973,10 @@
       }
     },
     "zwitch": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.3.tgz",
-      "integrity": "sha512-aynRpmJDw7JIq6X4NDWJoiK1yVSiG57ArWSg4HLC1SFupX5/bo0Cf4jpX0ifwuzBfxpYBuNSyvMlWNNRuy3cVA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.4.tgz",
+      "integrity": "sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg==",
+      "dev": true
     }
   }
 }

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -4,12 +4,11 @@
   "version": "3.0.0",
   "author": "LekoArts <hello@lekoarts.de> (https://www.lekoarts.de)",
   "dependencies": {
-    "@mdx-js/mdx": "^0.20.3",
     "@mdx-js/tag": "^0.20.3",
     "babel-plugin-styled-components": "^1.10.0",
     "gatsby": "^2.4.2",
     "gatsby-cli": "^2.5.12",
-    "gatsby-mdx": "^0.4.5",
+    "gatsby-mdx": "0.6.2",
     "gatsby-plugin-catch-links": "^2.0.13",
     "gatsby-plugin-feed": "^2.2.0",
     "gatsby-plugin-google-analytics": "^2.0.18",
@@ -56,7 +55,9 @@
     "format": "prettier \"**/*.{md,mdx} \" --write"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
+    "@mdx-js/mdx": "^1.0.18",
+    "@mdx-js/react": "^1.0.16",
+    "babel-eslint": "^9.0.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.1.0",
@@ -64,6 +65,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
-    "prettier": "^1.17.0"
+    "prettier": "^1.17.0",
+    "typescript": "^3.4.5"
   }
 }


### PR DESCRIPTION
Apparently the html output was just broken on that version of gatsby-mdx. When I update it to version 0.6.2 the RSS feed works but if I update it to the latest version (0.6.3) I get some awful react error when building the site. No idea up with that but at least the RSS feed works.

Also had to remove a random character from one of the blog posts to get the XML to be valid. We may need some way of validating blog posts so those characters don't get added and silently break the feed.

Fixes #408