### PR TITLE
Remove obsolete para about synapse webclient

### DIFF
--- a/gatsby/content/docs/2015-08-14-getting_involved.mdx
+++ b/gatsby/content/docs/2015-08-14-getting_involved.mdx
@@ -37,8 +37,6 @@ Riot.im web client.
 
 One of the core features of Matrix is that anyone can run a homeserver and join the federated network on equal terms (there is no hierarchy). If you want to set up your own homeserver, please see the relevant docs of the server you want to run. If you want to run Matrix.org's reference homeserver, please consult the [readme of the Synapse project](https://github.com/matrix-org/synapse/blob/master/README.rst).
 
-Note that Synapse comes with a bundled Matrix.org webclient - but you can tell it to use your [development checkout snapshot instead](https://github.com/matrix-org/matrix-angular-sdk#matrix-angular-sdk) (or to not run a webclient at all via the "web_client: false" config option).
-
 <a class="anchor" id="checkout"></a>
 
 ## Checkout our code - or write your own


### PR DESCRIPTION
Synapse's built-in webclient is deprecated. Even if code still exists and works (I'm not sure if it does), it's not appropriate to discuss such details on the "getting involved" page.