### PR TITLE
Tweaks

### DIFF
--- a/gatsby/src/components/Navigation.js
+++ b/gatsby/src/components/Navigation.js
@@ -80,12 +80,12 @@ const Navigation = (navmode) => (
 <img src="/images/matrix-logo.svg" alt="" className="mxnavbar__logo" />
 </a>
         <nav role="navigation" className="mxnavbar__navmenu w-nav-menu">
-          <a href="https://shop.matrix.org" className={"mxnavbar__navlink w-nav-link "}>Shop</a>
           <a href="/docs/guides" className={"mxnavbar__navlink w-nav-link " + (navmode.navmode === "discover" ? "w--current":"")}>Discover</a>
           <a href="/docs/develop" className={"mxnavbar__navlink w-nav-link " + (navmode.navmode === "develop" ? "w--current":"")}>Develop</a>
+          <a href="/foundation" className="mxnavbar__navlink w-nav-link ">Foundation</a>
           <a href="/blog/posts" className={"mxnavbar__navlink w-nav-link " + (navmode.navmode === "blog" ? "w--current":"")}>Blog</a>
           <a href="/faq" className="mxnavbar__navlink w-nav-link">FAQs</a>
-          <a href="/foundation" className="mxnavbar__navlink w-nav-link ">Foundation</a>
+          <a href="https://shop.matrix.org" className={"mxnavbar__navlink w-nav-link "}>Shop</a>
           <a href="/try-now" className="mxnavbar__navlink mxnavbar__navlink--try w-nav-link">Try Now</a>
           <a href="/try-now" className="mxnavbar__navlink mxnavbar__navlink--primary w-nav-link">Try Now</a>
         </nav>

--- a/gatsby/src/pages/clients.js
+++ b/gatsby/src/pages/clients.js
@@ -20,28 +20,30 @@ const ClientsMatrix = ({data}) => {
           </Helmet>
           <h1>Clients Matrix</h1>
           <p>To connect to the Matrix federation, you will use a client. These are some of the most popular Matrix clients available today, and more are available at  <a href="/docs/projects/try-matrix-now/">try-matrix-now</a>. To get started using Matrix, pick a client and join <a href="https://matrix.to/#/#matrix:matrix.org">#matrix:matrix.org</a></p>
-          <div className="mxgrid mxgrid--discover" style={{"border": "solid 1px black","padding": "10px"}}>
+          <div className="mxgrid mxgrid--clients">
             <div className="mxgrid_item33">
-              Select your platform:
+              <h3 style={{"line-height": "0px", "padding-bottom": "10px"}}>
+                Select your platform:
+              </h3>
             </div>
-            <div className="mxgrid_item33"></div>
-            <div className="mxgrid_item33"></div>
-            <div className="mxgrid_item33">
+            <div className="mxgrid_item33 mxgrid_item33--clients"></div>
+            <div className="mxgrid_item33 mxgrid_item33--clients"></div>
+            <div className="mxgrid_item33 mxgrid_item33--clients">
               <input type="radio" name="platform" id="linux" /><label htmlFor="linux"> Linux</label>
             </div>
-            <div className="mxgrid_item33">
+            <div className="mxgrid_item33 mxgrid_item33--clients">
               <input type="radio" name="platform" id="mac" /><label htmlFor="mac"> MacOS</label>
             </div>
-            <div className="mxgrid_item33">
+            <div className="mxgrid_item33 mxgrid_item33--clients">
               <input type="radio" name="platform" id="windows" /><label htmlFor="windows"> Windows</label>
             </div>
-            <div className="mxgrid_item33">
+            <div className="mxgrid_item33 mxgrid_item33--clients">
               <input type="radio" name="platform" id="android" /><label htmlFor="android"> Android</label>
             </div>
-            <div className="mxgrid_item33">
+            <div className="mxgrid_item33 mxgrid_item33--clients">
               <input type="radio" name="platform" id="ios" /><label htmlFor="ios"> iOS</label>
             </div>
-            <div className="mxgrid_item33">
+            <div className="mxgrid_item33 mxgrid_item33--clients">
               <input type="radio" name="platform" id="ubuntutouch" /><label htmlFor="ubuntutouch"> Ubuntu Touch</label>
             </div>
           </div>
@@ -70,7 +72,7 @@ const ClientsMatrix = ({data}) => {
                       platformClass = "green";
                       platformSupport = "✓";
                     }
-                    
+
                     return (
                       <td className={platformClass} data-platforms={client.platformString}>{platformSupport}</td>
                     )
@@ -96,7 +98,7 @@ const ClientsMatrix = ({data}) => {
             <tbody>
               <tr>
                 <td>Repo</td>
-                {clients.map(function(client, i) {                    
+                {clients.map(function(client, i) {
                     return (
                       <td data-platforms={client.platformString}>
                         <a href={client.repo}>{client.repo.split('/')[2]}</a>
@@ -106,7 +108,7 @@ const ClientsMatrix = ({data}) => {
               </tr>
               <tr>
                 <td>Matrix Room</td>
-                {clients.map(function(client, i) {                    
+                {clients.map(function(client, i) {
                     return (
                       <td data-platforms={client.platformString}>
                         <small><a href={"https://matrix.to/#/" + client.room}>{client.room}</a></small>
@@ -118,7 +120,7 @@ const ClientsMatrix = ({data}) => {
               ["language","SDK"].map(function(detail) {
                 return (<tr>
                   <td>{detail.charAt(0).toUpperCase() + detail.slice(1)}</td>
-                  {clients.map(function(client, i) {                    
+                  {clients.map(function(client, i) {
                     return (
                       <td data-platforms={client.platformString}>{client[detail]}</td>
                     )
@@ -171,7 +173,7 @@ const ClientsMatrix = ({data}) => {
 }
 
 
-export const query = graphql`{ 
+export const query = graphql`{
  allMdx(filter: {
    frontmatter: {
      categories: {in: ["client"]},

--- a/gatsby/static/css/webflow-overrides.css
+++ b/gatsby/static/css/webflow-overrides.css
@@ -113,8 +113,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .legacy-table td, tr, th {
-  padding-right: 20px;
-  padding-bottom: 4px;
+  padding: 10px 20px;
   text-align: center;
 }
 
@@ -123,7 +122,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .legacy-table > tbody > tr:nth-child(odd) {
-  background-color: #ddd;
+  background-color: #f4f4f4;
 }
 
 .legacy-table td:nth-child(1) {
@@ -199,7 +198,7 @@ div.title {
 #questions-wrapper h2, #questions-wrapper h3, #questions-wrapper h4 {
   padding-top: 75px;
   margin-top: -75px;
-} 
+}
 
 .green {
   color: #78A830;
@@ -211,4 +210,23 @@ div.title {
 }
 .red {
   color: #D84830;
+}
+
+.mxgrid.mxgrid--clients {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  background-color: #f4f4f4;
+  padding: 10px 20px;
+  margin: 20px 0px 40px 0px;
+}
+
+.mxgrid_item33.mxgrid_item33--clients {
+  padding: 10px;
+}
+
+label {
+  font-weight: normal;
+  margin: 10px 0px;
 }

--- a/gatsby/static/css/webflow-overrides.css
+++ b/gatsby/static/css/webflow-overrides.css
@@ -230,3 +230,7 @@ label {
   font-weight: normal;
   margin: 10px 0px;
 }
+
+.mxcontent {
+  width: 100%;
+}


### PR DESCRIPTION
General styling improvements to tables & content, now looks like:

<img width="1792" alt="Screenshot 2019-08-20 at 15 38 05" src="https://user-images.githubusercontent.com/4626865/63389525-d4719100-c360-11e9-8736-925d10e1a9a6.png">

<img width="1792" alt="Screenshot 2019-08-20 at 15 38 11" src="https://user-images.githubusercontent.com/4626865/63389524-d4719100-c360-11e9-9bf7-acef97a12ff2.png">

Also improved the navigation hierarchy to better reflect the importance of the links, and made it so that content would always be 100% width even if there isn't enough to fill it.