### PR TITLE
migrate link per Gnome's GitLab notice

### DIFF
--- a/gatsby/content/projects/2017-08-31-fractal.mdx
+++ b/gatsby/content/projects/2017-08-31-fractal.mdx
@@ -1,7 +1,7 @@
 ---
 layout: projectimage
 title: Fractal
-categories: 
+categories:
  - client
 thumbnail: /docs/projects/images/fractal-small.png
 description: Fractal is a Matrix Client written in Rust.
@@ -9,7 +9,7 @@ author: danigm
 maturity: Beta
 language: Rust
 license: GPL3
-repo: https://gitlab.gnome.org/World/fractal
+repo: https://gitlab.gnome.org/GNOME/fractal
 home: https://wiki.gnome.org/Apps/Fractal
 screenshot: /docs/projects/images/fractal-large.png
 room: "#fractal-gtk:matrix.org"
@@ -47,6 +47,6 @@ features:
 
 Fractal is a Gtk+ Matrix Client written in Rust.
 
-Get the code from [Gnome gitlab](https://gitlab.gnome.org/World/fractal).
+Get the code from [Gnome gitlab](https://gitlab.gnome.org/GNOME/fractal).
 
 


### PR DESCRIPTION
<img width="1156" alt="Screen Shot 2019-08-27 at 14 21 10" src="https://user-images.githubusercontent.com/472721/63797375-f7a6be00-c8d5-11e9-90c5-a460bb5ec3ff.png">
