### PR TITLE
Add structured repo link for irc bridge

### DIFF
--- a/gatsby/content/projects/2015-03-10-irc-bridge.mdx
+++ b/gatsby/content/projects/2015-03-10-irc-bridge.mdx
@@ -7,6 +7,7 @@ description:
 author: Matrix.org team
 language: JavaScript
 maturity: Early Beta
+repo: https://github.com/matrix-org/matrix-appservice-irc
 featured: true
 bridges: IRC
 thumbnail: /images/irc.png


### PR DESCRIPTION
... not sure if the link in the main text should be removed or not: other bridges also have the redundancy:
https://github.com/matrix-org/matrix.org/blame/943c21e68aa76d498dd8bd29886797c3a854035c/gatsby/content/projects/2015-09-18-matrix-appservice-slack.mdx#L32