### PR TITLE
Remove "RSS Feed" from site title of feed

### DIFF
--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -70,7 +70,7 @@ module.exports = {
               }
             `,
             output: "/blog/feed",
-            title: "matrix.org RSS Feed",
+            title: "matrix.org",
           },
         ],
       },


### PR DESCRIPTION
The "title" of the feed should describe the original site, not the feed itself.