### PR TITLE
Route matrix client traffic to matrix-client.matrix.org

### DIFF
--- a/content/.well-known/matrix/client
+++ b/content/.well-known/matrix/client
@@ -1,6 +1,6 @@
 {
     "m.homeserver": {
-        "base_url": "https://matrix.org"
+        "base_url": "https://matrix-client.matrix.org"
     },
     "m.identity_server": {
         "base_url": "https://vector.im"


### PR DESCRIPTION
This is just so that we can route matrix client traffic separately from website traffic if we wish (by pointing matrix-client.matrix.org to a different HAProxy)