### PR TITLE
Deprioritize unmaintained python sdk

### DIFF
--- a/gatsby/content/projects/2015-01-06-matrix.org-python-sdk.mdx
+++ b/gatsby/content/projects/2015-01-06-matrix.org-python-sdk.mdx
@@ -10,7 +10,7 @@ language: Python
 license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-python-sdk
 room: "#matrix-python-sdk:matrix.org"
-featured: true
+featured: false
 ---
 
 This is a Matrix client-server SDK for Python 2.7 and 3.4+


### PR DESCRIPTION
Hopefully closes #590 although I don't entirely understand how Gatsby works.