### PR TITLE
Use a more intuitive title

### DIFF
--- a/gatsby/content/docs/python-nio.mdx
+++ b/gatsby/content/docs/python-nio.mdx
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Usage of matrix-nio (Python Sans IO)
+title: Usage of matrix-nio (Python Matrix client library)
 section: guides
 slug: usage-of-matrix-nio
 ---


### PR DESCRIPTION
I just stumbled on this page and considered the "Python Sans IO" bit confusing without context, even though I'm familiar with matrix-nio. Since matrix-nio is now no longer exclusively no-IO, it would probably be better not to mention it here at all and instead use a more descriptive title.