### PR TITLE
Grammar fix: its -> it's

### DIFF
--- a/gatsby/content/projects/2014-12-10-ivar2-matrix-irc-bot.mdx
+++ b/gatsby/content/projects/2014-12-10-ivar2-matrix-irc-bot.mdx
@@ -12,4 +12,4 @@ repo: https://github.com/torhve/ivar2
 featured: true
 ---
 
-ivar2 is an IRC/Matrix bot on speed, with a mentally unstable mind. Partially because its written in Lua, which could make the most sane mind go unstable. If that's not obscure enough for you, ivar2 also supports running MoonScript modules.
+ivar2 is an IRC/Matrix bot on speed, with a mentally unstable mind. Partially because it's written in Lua, which could make the most sane mind go unstable. If that's not obscure enough for you, ivar2 also supports running MoonScript modules.


### PR DESCRIPTION
Because the long form is "it is written in Lua".

Used on: https://matrix.org/docs/projects/bots/