### PR TITLE
Fix mx-puppet-bridge information

### DIFF
--- a/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
@@ -13,6 +13,7 @@ repo: https://github.com/matrix-discord/mx-puppet-discord # your source code rep
 room: "#mx-puppet-bridge:sorunome.de"
 thumbnail: /docs/projects/images/discord-logo.svg
 maturity: Late Alpha # Options are: Released, Stable, Late Beta, Beta, Early Beta, Late Alpha, Alpha, Early Alpha, or Not actively maintained
+featured: true
 bridges: Discord
 ---
 

--- a/gatsby/content/projects/2020-01-18-mx-puppet-slack.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-slack.mdx
@@ -13,6 +13,7 @@ repo: https://github.com/Sorunome/mx-puppet-slack # your source code repository
 room: "#mx-puppet-bridge:sorunome.de"
 thumbnail: /docs/projects/bridges/images/slack-icon.svg
 maturity: Late Alpha # Options are: Released, Stable, Late Beta, Beta, Early Beta, Late Alpha, Alpha, Early Alpha, or Not actively maintained
+featured: true
 bridges: Slack
 ---
 

--- a/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
@@ -12,6 +12,7 @@ license: Apache 2.0
 repo: https://github.com/Sorunome/mx-puppet-twitter # your source code repository
 room: "#mx-puppet-bridge:sorunome.de"
 thumbnail: /docs/projects/bridges/images/twitter-logo.svg
+featured: true
 maturity: Alpha # Options are: Released, Stable, Late Beta, Beta, Early Beta, Late Alpha, Alpha, Early Alpha, or Not actively maintained
 bridges: Twitter
 ---

--- a/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
@@ -11,7 +11,7 @@ license: Apache 2.0
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/Sorunome/mx-puppet-twitter # your source code repository
 room: "#mx-puppet-bridge:sorunome.de"
-thumbnail: /docs/projects/bridges/images/tox-logo.svg
+thumbnail: /docs/projects/bridges/images/twitter-logo.svg
 maturity: Alpha # Options are: Released, Stable, Late Beta, Beta, Early Beta, Late Alpha, Alpha, Early Alpha, or Not actively maintained
 bridges: Twitter
 ---


### PR DESCRIPTION
Twitter accidentally had the tox icon and set `featured:true`

Reason why it isn't set in tox: It currently only works with an old version of node due to a node-ffi bug

Reason why it isn't set in instagram: There is currently a bug when logging in with 2fa