### PR TITLE
Metadata tidying for projects

### DIFF
--- a/gatsby/content/projects/2018-09-05-mxbridge.mdx
+++ b/gatsby/content/projects/2018-09-05-mxbridge.mdx
@@ -3,7 +3,7 @@ layout: projectimage
 title: MxBridge
 categories: 
  - bot
-language: elixir
+language: Elixir
 license: MIT
 repo: https://github.com/djmaze/mxbridge
 description: A non-puppeting (i.e. bot) bridge between Matrix and XMPP group chats.

--- a/gatsby/content/projects/2020-01-18-miitrix.mdx
+++ b/gatsby/content/projects/2020-01-18-miitrix.mdx
@@ -6,7 +6,7 @@ categories:
 description: A Matrix client for the Nintendo 3DS
 author: Sorunome
 language: C/C++
-license: Apache 2.0
+license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/Sorunome/miitrix # your source code repository

--- a/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
@@ -5,7 +5,7 @@ categories:
  - bridge
 description: mx-puppet-discord is a (double)puppeting bridge for discord.
 author: Sorunome
-language: Typescript
+language: TypeScript
 license: Apache 2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other

--- a/gatsby/content/projects/2020-01-18-mx-puppet-instagram.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-instagram.mdx
@@ -5,7 +5,7 @@ categories:
  - bridge
 description: mx-puppet-instagram is a (double)puppeting bridge for instagram.
 author: Sorunome
-language: Typescript
+language: TypeScript
 license: Apache 2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other

--- a/gatsby/content/projects/2020-01-18-mx-puppet-slack.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-slack.mdx
@@ -5,7 +5,7 @@ categories:
  - bridge
 description: mx-puppet-slack is a (double)puppeting bridge for slack.
 author: Sorunome
-language: Typescript
+language: TypeScript
 license: Apache 2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other

--- a/gatsby/content/projects/2020-01-18-mx-puppet-tox.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-tox.mdx
@@ -5,7 +5,7 @@ categories:
  - bridge
 description: mx-puppet-tox is a (double)puppeting bridge for tox.
 author: Sorunome
-language: Typescript
+language: TypeScript
 license: Apache 2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other

--- a/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
@@ -5,7 +5,7 @@ categories:
  - bridge
 description: mx-puppet-twitter is a (double)pupepting bridge for twitter DMs.
 author: Sorunome
-language: Typescript
+language: TypeScript
 license: Apache 2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other

--- a/gatsby/content/projects/bots/matrix-notification-bot.mdx
+++ b/gatsby/content/projects/bots/matrix-notification-bot.mdx
@@ -6,7 +6,7 @@ categories:
 description: A remind me bot for Matrix.org's synapse.
 author: joakimvonanka
 maturity: Beta
-language: Javascript
+language: JavaScript
 license: MIT
 repo: https://github.com/joakimvonanka/Matrix-Remind-me-bot
 ---


### PR DESCRIPTION
#671 

Fix capitalization for a few projects that had TypeScript, Javascript, and Elixir capitalized incorrectly.  Also fixed formatting of license name for one.

This prevents some duplicate entries from showing on https://matrix.org/docs/projects/try-matrix-now