### PR TITLE
fix typos in bridges page

### DIFF
--- a/gatsby/content/projects/2015-03-10-irc-bridge.mdx
+++ b/gatsby/content/projects/2015-03-10-irc-bridge.mdx
@@ -15,4 +15,4 @@ thumbnail: /images/irc.png
 
 An application service gateway from Matrix.org for bridging between IRC networks and Matrix, written using [matrix-appservice-node](https://matrix.org/blog/project/matrix-appservice-node/). You can get the [code on github](https://github.com/matrix-org/matrix-appservice-irc).
 
-Supports dynamically bridging IRC channels on demand; synchronised user-lists, and other goodness.
+Supports dynamically bridging IRC channels on demand, synchronised user-lists, and other goodness.

--- a/gatsby/content/projects/2019-06-18-matrix-puppet-groupme.mdx
+++ b/gatsby/content/projects/2019-06-18-matrix-puppet-groupme.mdx
@@ -14,7 +14,7 @@ bridges: GroupMe
 thumbnail: /docs/projects/images/groupme-icon.png
 ---
 
-This is a Matrix bridge for GroupMe
+This is a Matrix bridge for GroupMe.
 
 You will need to acquire your Access Token from GroupMe.
 

--- a/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
@@ -17,7 +17,7 @@ featured: true
 bridges: Discord
 ---
 
-[mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) discord slack and matrix together via (double)puppeting. Additionally a relay mode can be enabled.
+[mx-puppet-discord](https://github.com/matrix-discord/mx-puppet-discord) bridges discord slack and matrix together via (double)puppeting. Additionally, a relay mode can be enabled.
 
 &#10003; Direct (1:1) Chats
 &#10003; DM Group Chats

--- a/gatsby/content/projects/bridges/jojiis-mail-bridge.mdx
+++ b/gatsby/content/projects/bridges/jojiis-mail-bridge.mdx
@@ -3,7 +3,7 @@ layout: project
 title: EmailBridge for matrix
 categories:
  - bridge
-description: A bridge written in GOlang to let you read and write your emails in matrix.
+description: A bridge written in Golang to let you read and write your emails in matrix.
 author: Jojii
 home: https://github.com/JojiiOfficial/Matrix-EmailBridge
 language: Go
@@ -16,7 +16,7 @@ featured: true
 bridges: Email
 ---
 
-A matrix-bridge written in GOlang to let you read and write your emails in matrix. You can have multiple emailaccounts in different private rooms.
+A matrix-bridge written in Golang to let you read and write your emails in matrix. You can have multiple email accounts in different private rooms.
 
 ## Features
 

--- a/gatsby/src/pages/bridges.js
+++ b/gatsby/src/pages/bridges.js
@@ -24,7 +24,7 @@ const Bridges = ({data}) => {
               <h1 id="bridges">Bridges</h1>
               <p>An important idea in Matrix is <em>Interoperability</em>. This means that Matrix is open to exchanging data and messages with other platforms using an <a href="https://matrix.org/docs/spec">Open Standard</a>. We refer to the connection to other platforms as <em>bridging</em>.</p>
               <p>For a thorough examination of the different methods of bridging, and a discussion of the terminology involved, check out <em><a href="https://matrix.org/blog/2017/03/11/how-do-i-bridge-thee-let-me-count-the-ways">How do I bridge thee? Let me count the ways...</a></em></p>
-              <p>Currently recommened bridges are shown in the grid below.</p>
+              <p>Currently recommended bridges are shown in the grid below.</p>
             </div>
             <div className="mxgrid__item50">
               <h3>Quick bridging concepts</h3>


### PR DESCRIPTION
Fixed incorrect spelling, punctuation, and supplied missing words in the https://matrix.org/bridges/ page.

Signed-off-by: teikjun <teikjunhci@gmail.com>