### PR TITLE
Fix code block languages

### DIFF
--- a/gatsby/content/blog/2019/07/python-nio.mdx
+++ b/gatsby/content/blog/2019/07/python-nio.mdx
@@ -15,7 +15,7 @@ This article concerns [matrix-nio](https://github.com/poljar/matrix-nio), and [a
 
 First create a new venv, and install matrix-nio via `pip`. On the command line, run:
 
-```unix
+```shell
 python3 -m venv env
 source env/bin/activate
 pip install matrix-nio
@@ -71,7 +71,7 @@ The remainder of this tutorial assumes you are running everything from an `async
 
 The response string should look like:
 
-```unix
+```shell
 Logged in as @pyconweb-bot:matrix.org, device id: ZBLAJHLKVP.
 ```
 

--- a/gatsby/content/blog/2020/03/2020-03-23-synapse-1.12.0-release.mdx
+++ b/gatsby/content/blog/2020/03/2020-03-23-synapse-1.12.0-release.mdx
@@ -59,7 +59,7 @@ installation remains secure.
 * Administrators who have [installed Synapse from
   source](https://github.com/matrix-org/synapse/blob/master/INSTALL.md#installing-from-source)
   should upgrade Twisted within their virtualenv by running:
-  ```sh
+  ```shell
   <path_to_virtualenv>/bin/pip install 'Twisted>=20.3.0'
   ```
 * Administrators who have installed Synapse from distribution packages should

--- a/gatsby/content/docs/2018-09-21-usage-of-the-matrix-js-sdk.mdx
+++ b/gatsby/content/docs/2018-09-21-usage-of-the-matrix-js-sdk.mdx
@@ -24,7 +24,7 @@ We'll use Node.js as our environment, though the [matrix-js-sdk] can also be use
 
 Before we start, make sure you have Node.js and NPM installed: follow instructions at [nodejs.org](https://nodejs.org/) for your platform. Then create a new directory to work in:
 
-```unix
+```shell
 mkdir my-first-matrix-client
 cd my-first-matrix-client
 ```
@@ -33,7 +33,7 @@ cd my-first-matrix-client
 
 Once you're ready, the first thing to do is install the [matrix-js-sdk] from NPM:
 
-```unix
+```shell
 npm install matrix-js-sdk
 ```
 

--- a/gatsby/content/docs/free-small-matrix-server.mdx
+++ b/gatsby/content/docs/free-small-matrix-server.mdx
@@ -97,7 +97,7 @@ The Oracle Cloud Ubuntu images come with somewhat restrictive iptables rules by
 default. Docker manages the instance firewall and we have the Oracle Cloud
 firewall in front, so let's remove the current firewall to avoid trouble:
 
-```sh
+```shell
 apt purge netfilter-persistent iptables-persistent
 ```
 
@@ -107,7 +107,7 @@ Oracle cloud includes a somewhat heavy monitoring daemon. We have better use for
 that memory since current versions of Synapse, the Matrix homeserver, can be
 memory hungry.
 
-```sh
+```shell
 snap remove oracle-cloud-agent
 apt remove snapd open-iscsi lxd lxcfs
 ```
@@ -116,7 +116,7 @@ apt remove snapd open-iscsi lxd lxcfs
 
 I suggest enabling swap, since there's only 1 GB of RAM.
 
-```sh
+```shell
 dd if=/dev/zero of=/swap bs=1M count=1k
 chmod 0600 /swap
 mkswap /swap
@@ -142,7 +142,7 @@ Follow the [guide], with some tweaks:
 
 ### Guide in a nutshell, TL;DR
 
-```sh
+```shell
 git clone https://github.com/spantaleev/matrix-docker-ansible-deploy/
 cd matrix-docker-ansible-deploy
 mkdir inventory/host_vars/matrix.$domain
@@ -195,7 +195,7 @@ client](https://matrix.org/clients).
 
 Remember to keep your VM up to date!
 
-```sh
+```shell
 apt update
 apt upgrade
 reboot # e.g. kernel,dbus,systemd updates

--- a/gatsby/content/docs/matrix-js-bot-sdk-intro.mdx
+++ b/gatsby/content/docs/matrix-js-bot-sdk-intro.mdx
@@ -12,7 +12,7 @@ Note that although the SDK is written in TypeScript, we'll use JavaScript in our
 
 Let's make a new folder, and import our only npm dependency. The following examples are all meant to be run in a bash terminal.
 
-```unix
+```shell
 mkdir matrix-js-echo-bot
 cd matrix-js-echo-bot
 npm install matrix-bot-sdk
@@ -85,7 +85,7 @@ client.start().then(() => console.log("Client started!"));
 
 Let's run it:
 
-```unix
+```shell
 node index.js
 ```
 
@@ -167,13 +167,13 @@ This SDK uses TypeScript, which provides a lot of benefits. In this example, we 
 
 First let's install `tsc`, which compiles from TypeScript to JavaScript:
 
-```unix
+```shell
 npm install tsc
 ```
 
 Now, start tsc in watch-mode (`-w`), and leave it to compile our code:
 
-```unix
+```shell
 npx tsc --watch *.ts
 ```
 

--- a/gatsby/content/docs/python-nio.mdx
+++ b/gatsby/content/docs/python-nio.mdx
@@ -11,7 +11,7 @@ This article concerns [matrix-nio](https://github.com/poljar/matrix-nio), and [a
 
 First create a new venv, and install matrix-nio via `pip`. On the command line, run:
 
-```unix
+```shell
 python3 -m venv env
 source env/bin/activate
 pip install matrix-nio
@@ -67,7 +67,7 @@ The remainder of this tutorial assumes you are running everything from an `async
 
 The response string should look like:
 
-```unix
+```shell
 Logged in as @pyconweb-bot:matrix.org, device id: ZBLAJHLKVP.
 ```
 

--- a/gatsby/content/docs/whatsapp-bridging-mautrix-whatsapp.mdx
+++ b/gatsby/content/docs/whatsapp-bridging-mautrix-whatsapp.mdx
@@ -31,7 +31,7 @@ matrix_mautrix_whatsapp_enabled: true
 
 ... and re-running the setup:
 
-```unix
+```shell
 ansible-playbook -i inventory/hosts setup.yml --tags=setup-all
 ```
 


### PR DESCRIPTION
This fixes two warnings about `sh` and `unix` not being recognized languages in PrismJS.

A warning `warn code block or inline code language not specified in markdown. applying generic code block` remains; putting languages in for all of the code blocks that do not have languages specified did not fix that.  Maybe a language would have to be specified for all of the inline code blocks too.