### PR TITLE
Deploy a .well-known/matrix/server file.

### DIFF
--- a/content/.well-known/matrix/server
+++ b/content/.well-known/matrix/server
@@ -1,0 +1,1 @@
+{ "m.server": "matrix-federation.matrix.org:443" } 


### PR DESCRIPTION
Move federation traffic for the matrix.org synapse server away from `https://matrix.org:8443/` to `https://matrix-federation.matrix.org:443/`

 moving federation traffic over to using .well-known because we can't route it because the SRV mechanism sends the Host: and SNI server_name as `matrix.org`, not  `matrix-federation.matrix.org`