### PR TITLE
Replace link to nginx-rtmp-module with a maintained fork

### DIFF
--- a/gatsby/content/docs/online-events.mdx
+++ b/gatsby/content/docs/online-events.mdx
@@ -50,7 +50,7 @@ alternative is to capture the jitsi meet screen and broadcast it as a video stre
 [OBS](https://obsproject.com/) to capture the screen.
 
 For the streaming server, one option is to use the
-[nginx RTMP plugin](https://github.com/arut/nginx-rtmp-module) set up to receive a stream
+[nginx RTMP plugin](https://github.com/sergey-dryabzhinsky/nginx-rtmp-module) set up to receive a stream
 via RTMP and then convert this into an HLS stream for viewing on the web. This can also relay
 the stream to another RTMP server so you can make the stream available on another platform
 like YouTube. 


### PR DESCRIPTION
So I had to set up livestreaming this weekend for an event and decide to use our blog post!

It worked out in the end, but the suggested repo for nginx-rtmp-module just wouldn't compile with the latest nginx. Plus seeing the last commit being in 2017 made me think hard about turning around. I did try it, but it wouldn't even compile with the latest stable release of nginx.

I looked up some guides for the process and found everyone recommending a fork of this module at https://github.com/sergey-dryabzhinsky/nginx-rtmp-module. This one seems to be actively maintained, and sure enough compiled fine.

I think we should recommend people use this up-to-date version instead of the current one.