### PR TITLE
Update license identifier in all projects to use SPDX

### DIFF
--- a/gatsby/content/projects/2014-06-09-riot.mdx
+++ b/gatsby/content/projects/2014-06-09-riot.mdx
@@ -9,7 +9,7 @@ description: Riot is a glossy web client with an emphasis on performance and usa
 author: Riot.im
 maturity: Stable
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/vector-im/riot-web/
 home: https://riot.im/
 screenshot: /docs/projects/images/riot-web-large.png

--- a/gatsby/content/projects/2014-09-10-neb.mdx
+++ b/gatsby/content/projects/2014-09-10-neb.mdx
@@ -7,7 +7,7 @@ description: Our dear Matrix Bot (v1)
 author: Kegsay
 maturity: Late Beta
 language: Python
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/Matrix-NEB
 ---
 

--- a/gatsby/content/projects/2014-11-04-matrix.org-angularjs-sdk.mdx
+++ b/gatsby/content/projects/2014-11-04-matrix.org-angularjs-sdk.mdx
@@ -7,7 +7,7 @@ description: AngularJS SDK is deprecated.
 author: Matrix.org team
 maturity: Not actively maintained
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-angular-sdk
 ---
 

--- a/gatsby/content/projects/2015-02-27-matrix.org-as-sdk.mdx
+++ b/gatsby/content/projects/2015-02-27-matrix.org-as-sdk.mdx
@@ -6,6 +6,7 @@ categories:
 author: Matrix.org team
 language: JavaScript
 maturity: Early Beta
+license: Apache-2.0
 ---
 
 A framework from Matrix.org for building Application Services in Node.js/Express: [https://github.com/matrix-org/matrix-appservice-node](https://github.com/matrix-org/matrix-appservice-node)

--- a/gatsby/content/projects/2015-03-10-irc-bridge.mdx
+++ b/gatsby/content/projects/2015-03-10-irc-bridge.mdx
@@ -7,6 +7,7 @@ description:
 author: Matrix.org team
 language: JavaScript
 maturity: Early Beta
+license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-appservice-irc
 room: "#irc:matrix.org"
 featured: true

--- a/gatsby/content/projects/2015-03-17-jsynapse.mdx
+++ b/gatsby/content/projects/2015-03-17-jsynapse.mdx
@@ -7,6 +7,7 @@ thumbnail: https://matrix.org/blog/wp-content/uploads/2015/04/jsynapse2.png
 author: Swarmcom
 language: Java
 maturity: Alpha
+license: Apache-2.0
 screenshot: https://matrix.org/blog/wp-content/uploads/2015/04/jsynapse2.png
 slug: jsynapse
 ---

--- a/gatsby/content/projects/2015-04-02-riot-ios.mdx
+++ b/gatsby/content/projects/2015-04-02-riot-ios.mdx
@@ -8,7 +8,7 @@ description: Riot is a glossy client with an emphasis on performance and usabili
 author: Riot.im
 maturity: Released
 language: Objective-C
-license: Apache
+license: Apache-2.0
 repo: https://github.com/vector-im/riot-ios
 home: https://riot.im/
 screenshot: /docs/projects/images/riot-ios.png

--- a/gatsby/content/projects/2015-05-06-newlisp-matrix-client.mdx
+++ b/gatsby/content/projects/2015-05-06-newlisp-matrix-client.mdx
@@ -6,6 +6,7 @@ categories:
 author: Ingo Hohmann
 language: Lisp
 maturity: Early Beta
+license: MIT
 ---
 
 Client SDK for newlisp available at [https://github.com/IngoHohmann/newlisp-matrix-client](https://github.com/IngoHohmann/newlisp-matrix-client)

--- a/gatsby/content/projects/2015-06-02-matrix-erlang-sdk.mdx
+++ b/gatsby/content/projects/2015-06-02-matrix-erlang-sdk.mdx
@@ -6,6 +6,7 @@ categories:
 author: Andreas Hallberg
 language: Erlang
 maturity: Alpha
+license: Apache-2.0
 ---
 
 Andreas Hallberg's client SDK for Erlang [https://github.com/anhallbe/matrix-erlang-sdk](https://github.com/anhallbe/matrix-erlang-sdk)

--- a/gatsby/content/projects/2015-06-02-riot-android.mdx
+++ b/gatsby/content/projects/2015-06-02-riot-android.mdx
@@ -8,7 +8,7 @@ description: Riot is a glossy client with an emphasis on performance and usabili
 author: Riot.im
 maturity: Released
 language: Java
-license: Apache
+license: Apache-2.0
 repo: https://github.com/vector-im/riot-android
 home: https://riot.im/
 screenshot: /docs/projects/images/vector-android-large.png

--- a/gatsby/content/projects/2015-06-09-matrix.org-react-sdk.mdx
+++ b/gatsby/content/projects/2015-06-09-matrix.org-react-sdk.mdx
@@ -6,6 +6,7 @@ categories:
 author: Matrix.org team
 language: JavaScript
 maturity: Early Beta
+license: Apache-2.0
 slug: matrix.org-react-sdk
 ---
 

--- a/gatsby/content/projects/2015-07-01-xmpptrix.mdx
+++ b/gatsby/content/projects/2015-07-01-xmpptrix.mdx
@@ -5,6 +5,7 @@ categories:
  - as
 author: SkaveRat
 language: JavaScript
+license: GPL-2.0-only
 maturity: Alpha
 ---
 

--- a/gatsby/content/projects/2015-08-19-matrix-appservice-bridge.mdx
+++ b/gatsby/content/projects/2015-08-19-matrix-appservice-bridge.mdx
@@ -5,6 +5,7 @@ categories:
  - as
 author: Kegsay
 language: JavaScript
+license: Apache-2.0
 maturity: Early Beta
 ---
 

--- a/gatsby/content/projects/2015-09-10-matrix-appservice-respoke.mdx
+++ b/gatsby/content/projects/2015-09-10-matrix-appservice-respoke.mdx
@@ -5,6 +5,7 @@ categories:
  - as
 author: Matrix.org team
 language: JavaScript
+license: Apache-2.0
 maturity: Alpha
 ---
 

--- a/gatsby/content/projects/2015-09-10-vertobridge.mdx
+++ b/gatsby/content/projects/2015-09-10-vertobridge.mdx
@@ -5,6 +5,7 @@ categories:
  - as
 author: Matthew / Kegan
 language: JavaScript
+license: Apache-2.0
 maturity: Alpha
 ---
 

--- a/gatsby/content/projects/2015-09-17-bullettime.mdx
+++ b/gatsby/content/projects/2015-09-17-bullettime.mdx
@@ -7,7 +7,7 @@ description: An experimental golang Matrix homeserver
 author: Patrik Oldsberg
 maturity: Not actively maintained
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/bullettime
 ---
 

--- a/gatsby/content/projects/2015-09-18-matrix-appservice-slack.mdx
+++ b/gatsby/content/projects/2015-09-18-matrix-appservice-slack.mdx
@@ -9,7 +9,7 @@ maturity: Beta
 repo: https://github.com/matrix-org/matrix-appservice-slack
 room: "#matrix_appservice_slack:cadair.com"
 screenshot: /docs/projects/images/slack-bridge.png
-license: Apache
+license: Apache-2.0
 description: This project bridges Slack to Matrix
 bridges: Slack
 featured: true

--- a/gatsby/content/projects/2015-10-09-slackbridge.mdx
+++ b/gatsby/content/projects/2015-10-09-slackbridge.mdx
@@ -5,6 +5,7 @@ categories:
  - as
 author: illicitonion
 language: Go
+license: Apache-2.0
 maturity: Alpha
 ---
 

--- a/gatsby/content/projects/2015-10-13-purple-matrix.mdx
+++ b/gatsby/content/projects/2015-10-13-purple-matrix.mdx
@@ -7,7 +7,7 @@ description: A plugin for libpurple
 author: Matrix.org team
 language: C
 maturity: Alpha
-license: Unknown
+license: GPL-2.0-or-later
 ---
 
 This project is a plugin for [libpurple](https://developer.pidgin.im/wiki/WhatIsLibpurple) which adds the ability to communicate with matrix.org homeservers to any libpurple-based clients (such as [Pidgin](https://www.pidgin.im/)).

--- a/gatsby/content/projects/2015-10-23-bender.mdx
+++ b/gatsby/content/projects/2015-10-23-bender.mdx
@@ -7,6 +7,7 @@ description: A simple/flexible bot framework
 author: Dylan Griffith
 language: Elixir
 maturity: Alpha
+license: MIT
 ---
 
 Bender is a Matrix bot framework written in Elixir: [https://github.com/DylanGriffith/bender](https://github.com/DylanGriffith/bender)

--- a/gatsby/content/projects/2015-11-10-mero.mdx
+++ b/gatsby/content/projects/2015-11-10-mero.mdx
@@ -7,6 +7,7 @@ description: NodeJS based XMPP facade bridge for matrix.org
 author: SkaveRat
 language: JavaScript
 maturity: Alpha
+license: Apache-2.0
 ---
 
 NodeJS based XMPP facade bridge for matrix.org

--- a/gatsby/content/projects/2015-12-10-glib-sdk.mdx
+++ b/gatsby/content/projects/2015-12-10-glib-sdk.mdx
@@ -7,7 +7,7 @@ description: Matrix Client SDK for GLib
 author: Gergely Polonkai
 maturity: Alpha
 language: C
-license: LGPL
+license: LGPL-3.0-or-later
 repo: https://github.com/gergelypolonkai/matrix-glib-sdk
 featured: true
 thumbnail: /docs/projects/images/gtk.png

--- a/gatsby/content/projects/2015-12-10-pto.mdx
+++ b/gatsby/content/projects/2015-12-10-pto.mdx
@@ -7,7 +7,7 @@ description: PTO is an IRC frontend to the federated Matrix network.
 author: tdfischer
 maturity: Not actively maintained
 language: Rust
-license: Apache
+license: Apache-2.0
 repo: https://github.com/tdfischer/pto
 ---
 

--- a/gatsby/content/projects/2016-01-02-matrix-console-ios.mdx
+++ b/gatsby/content/projects/2016-01-02-matrix-console-ios.mdx
@@ -7,6 +7,7 @@ thumbnail: /docs/projects/images/matrix-console-ios-2016-02-16-cropped.png
 description: A neutral iOS client showcasing Matrix capabilities and implementation.
 author: Matrix.org team
 language: Objective-C
+license: Apache-2.0
 maturity: Not actively maintained
 screenshot: /docs/projects/images/matrix-console-ios-2016-02-16-large.png
 ---

--- a/gatsby/content/projects/2016-01-03-matrix-console-android.mdx
+++ b/gatsby/content/projects/2016-01-03-matrix-console-android.mdx
@@ -7,6 +7,7 @@ thumbnail: /docs/projects/images/matrix-console-android-2016-02-16-cropped.png
 description: A neutral Android client showcasing Matrix capabilities and implementation.
 author: Matrix.org team
 language: Java
+license: Apache-2.0
 maturity: Not actively maintained
 screenshot: /docs/projects/images/matrix-console-android-2016-02-16-large.png
 ---

--- a/gatsby/content/projects/2016-01-04-matrix-console.mdx
+++ b/gatsby/content/projects/2016-01-04-matrix-console.mdx
@@ -7,6 +7,7 @@ thumbnail: https://matrix.org/blog/wp-content/uploads/2015/04/syweb2-400x284.png
 description: Matrix.org’s legacy AngularJS web client.
 author: Matrix.org team
 language: JavaScript
+license: Apache-2.0
 maturity: Not actively maintained
 screenshot: https://matrix.org/blog/wp-content/uploads/2015/04/syweb2-1080x806.png
 ---

--- a/gatsby/content/projects/2016-01-30-rocket-chat-federation.mdx
+++ b/gatsby/content/projects/2016-01-30-rocket-chat-federation.mdx
@@ -6,6 +6,7 @@ categories:
 thumbnail: https://raw.githubusercontent.com/Sing-Li/bbug/master/images/rcsnynapse.png
 author: Rocket.Chat
 language: JavaScript
+license: MIT
 maturity: Alpha
 screenshot: https://raw.githubusercontent.com/Sing-Li/bbug/master/images/rcsnynapse.png
 ---

--- a/gatsby/content/projects/2016-02-01-unplug.mdx
+++ b/gatsby/content/projects/2016-02-01-unplug.mdx
@@ -7,6 +7,7 @@ thumbnail: https://matrix.org/blog/wp-content/uploads/2015/04/unplug-0.1.5-400x2
 description: Experimental Kotlin client
 author: hrjet
 language: Kotlin
+license: GPL-3.0-only
 maturity: Alpha
 screenshot: https://matrix.org/blog/wp-content/uploads/2015/04/unplug-0.1.5.png
 ---

--- a/gatsby/content/projects/2016-02-05-headjack.mdx
+++ b/gatsby/content/projects/2016-02-05-headjack.mdx
@@ -8,7 +8,7 @@ description: Experimental Chrome App client
 author: SkaveRat
 maturity: Not actively maintained
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: 
 screenshot: https://matrix.org/blog/wp-content/uploads/2015/05/headjack.png
 ---

--- a/gatsby/content/projects/2016-02-10-matrix-appservice-gitter.mdx
+++ b/gatsby/content/projects/2016-02-10-matrix-appservice-gitter.mdx
@@ -7,7 +7,7 @@ description: This project bridges to Matrix, via the AS API on the Matrix side, 
 author: LeoNerd
 maturity: Early Beta
 language: JavaScript
-license: 
+license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-appservice-gitter
 thumbnail: /docs/projects/images/gitter-logo.svg
 bridges: Gitter

--- a/gatsby/content/projects/2016-04-30-concourse-matrix-notification-resource.mdx
+++ b/gatsby/content/projects/2016-04-30-concourse-matrix-notification-resource.mdx
@@ -8,7 +8,7 @@ description: Post notifications from Concourse CI jobs
 author: freelock
 maturity: Beta
 language: Shell
-license: Apache
+license: Apache-2.0
 repo: https://github.com/freelock/matrix-notification-resource
 home: https://hub.docker.com/r/freelock/matrix-notification-resource/
 ---

--- a/gatsby/content/projects/2016-05-11-goMatrix.mdx
+++ b/gatsby/content/projects/2016-05-11-goMatrix.mdx
@@ -7,7 +7,7 @@ description: A Matrix library for go currently in development.
 author: geir54
 maturity: Not actively maintained
 language: Go
-license: MPL2
+license: MPL-2.0
 repo: https://github.com/geir54/goMatrix
 home: https://godoc.org/github.com/geir54/goMatrix
 ---

--- a/gatsby/content/projects/2016-05-23-twitter-bridge.mdx
+++ b/gatsby/content/projects/2016-05-23-twitter-bridge.mdx
@@ -7,7 +7,7 @@ description:
 author: Half-Shot
 maturity: Not actively maintained
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/Half-Shot/matrix-appservice-twitter
 ---
 

--- a/gatsby/content/projects/2016-06-19-matrix-appservice-discord.mdx
+++ b/gatsby/content/projects/2016-06-19-matrix-appservice-discord.mdx
@@ -7,7 +7,7 @@ description: This project bridges Discord to Matrix via the Application Service 
 author: Half-Shot
 maturity: Beta
 language: TypeScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/Half-Shot/matrix-appservice-discord
 screenshot: /docs/projects/images/discord.png
 room: "#discord:half-shot.uk"

--- a/gatsby/content/projects/2016-07-03-nachat.mdx
+++ b/gatsby/content/projects/2016-07-03-nachat.mdx
@@ -8,7 +8,7 @@ description: Desktop Qt client
 author: Ralith
 maturity: Alpha
 language: C++/Qt
-license: Apache
+license: Apache-2.0
 repo: https://github.com/Ralith/nachat
 screenshot: /docs/projects/images/nachat005.jpg
 ---

--- a/gatsby/content/projects/2016-07-29-go-neb.mdx
+++ b/gatsby/content/projects/2016-07-29-go-neb.mdx
@@ -7,7 +7,7 @@ description: Our dear Matrix Bot (v2)
 author: Kegsay
 maturity: Late Beta
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/go-neb
 ---
 

--- a/gatsby/content/projects/2016-07-29-matrix-appservice-rocketchat.mdx
+++ b/gatsby/content/projects/2016-07-29-matrix-appservice-rocketchat.mdx
@@ -7,7 +7,7 @@ description: This project bridges Rocket Chat to Matrix.
 author: oddvar
 maturity: Early Beta
 language: JavaScript
-license: 
+license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-appservice-rocketchat
 ---
 

--- a/gatsby/content/projects/2016-08-10-matrix-appservice-gitter-twisted.mdx
+++ b/gatsby/content/projects/2016-08-10-matrix-appservice-gitter-twisted.mdx
@@ -7,7 +7,7 @@ description: Python 2 application using Twisted that bridges the Matrix chat net
 author: Remi Rampin
 maturity: Not actively maintained
 language: Python
-license: BSD
+license: BSD-3-Clause
 repo: https://github.com/remram44/matrix-appservice-gitter-twisted/
 ---
 

--- a/gatsby/content/projects/2016-09-04-hello-matrix-bot.mdx
+++ b/gatsby/content/projects/2016-09-04-hello-matrix-bot.mdx
@@ -7,7 +7,7 @@ description: Bot with an array of plugins
 author: Alexander Rudyk
 maturity: Alpha
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://gitlab.com/argit/hello-matrix-bot
 ---
 

--- a/gatsby/content/projects/2016-10-04-matrix-ircd.mdx
+++ b/gatsby/content/projects/2016-10-04-matrix-ircd.mdx
@@ -7,7 +7,7 @@ description: An IRCd implementation backed by Matrix.
 author: Erik
 maturity: Alpha
 language: Rust
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-ircd
 ---
 

--- a/gatsby/content/projects/2016-10-22-journal.mdx
+++ b/gatsby/content/projects/2016-10-22-journal.mdx
@@ -5,9 +5,9 @@ categories:
  - client
 description: A web client for writing news stories, personal blogs and more, built on matrix.
 author: Luke Barnard
-maturity: Early Beta
+maturity: Not actively maintained
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/lukebarnard1/journal
 ---
 

--- a/gatsby/content/projects/2016-10-30-mxpp.mdx
+++ b/gatsby/content/projects/2016-10-30-mxpp.mdx
@@ -7,7 +7,7 @@ description: Bot for bridging Matrix and one-to-one XMPP chats
 author: anewusername
 maturity: Not actively maintained
 language: Python
-license: 
+license: AGPL-3.0-only
 repo: https://github.com/anewusername/mxpp
 ---
 

--- a/gatsby/content/projects/2016-11-27-synapse-password-reset.mdx
+++ b/gatsby/content/projects/2016-11-27-synapse-password-reset.mdx
@@ -7,7 +7,7 @@ description: A tool to manage Synapse password resets
 author: Euan Kemp
 maturity: Alpha
 language: Rust
-license: AGPL3
+license: AGPL-3.0-or-later
 repo: https://github.com/euank/synapse-password-reset
 ---
 

--- a/gatsby/content/projects/2016-11-29-matrix-live.mdx
+++ b/gatsby/content/projects/2016-11-29-matrix-live.mdx
@@ -7,7 +7,7 @@ description: Liveblogging based on Matrix
 author: Alexander Rudyk
 maturity: Beta
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://gitlab.com/argit/matrix-live/
 ---
 

--- a/gatsby/content/projects/2016-12-21-tiny-matrix-bot.mdx
+++ b/gatsby/content/projects/2016-12-21-tiny-matrix-bot.mdx
@@ -7,7 +7,7 @@ description: Bot with plugins
 author: Ander Punnar
 maturity: Alpha
 language: Shell/Python
-license: Unknown
+license: WTFPL
 repo: https://github.com/4nd3r/tiny-matrix-bot
 featured: true
 ---

--- a/gatsby/content/projects/2017-01-23-mxisd.mdx
+++ b/gatsby/content/projects/2017-01-23-mxisd.mdx
@@ -5,9 +5,9 @@ categories:
  - other
 description: Federated Identity server
 author: Kamax.io
-maturity: Stable
+maturity: Not actively maintained
 language: Java
-license: AGPL3
+license: AGPL-3.0-or-later
 repo: https://github.com/kamax-io/mxisd
 ---
 

--- a/gatsby/content/projects/2017-02-05-navi.mdx
+++ b/gatsby/content/projects/2017-02-05-navi.mdx
@@ -7,7 +7,7 @@ description: A minimal Matrix notification bot
 author: Maximilian Fricke
 maturity: Alpha
 language: Python
-license: Apache
+license: Apache-2.0
 repo: https://github.com/madmax28/navi
 ---
 

--- a/gatsby/content/projects/2017-02-06-matrixclient.mdx
+++ b/gatsby/content/projects/2017-02-06-matrixclient.mdx
@@ -7,7 +7,7 @@ description: Matrix Client for macOS
 author: Avery Pierce
 maturity: Not actively maintained
 language: Swift
-license: Apache
+license: Apache-2.0
 repo: https://github.com/aapierce0/MatrixClient
 screenshot: /docs/projects/images/matrixclient.png
 ---

--- a/gatsby/content/projects/2017-04-27-matrix-sync-java-sdk.mdx
+++ b/gatsby/content/projects/2017-04-27-matrix-sync-java-sdk.mdx
@@ -7,7 +7,7 @@ description:
 author: Kamax.io
 maturity: Not actively maintained
 language: Java
-license: AGPL3
+license: AGPL-3.0-or-later
 repo: https://github.com/kamax-io/matrix-java-sdk
 room: "#matrix-java-sdk:kamax.io"
 featured: true

--- a/gatsby/content/projects/2017-05-02-dendrite.mdx
+++ b/gatsby/content/projects/2017-05-02-dendrite.mdx
@@ -7,7 +7,7 @@ description: Dendrite (aka 'Dendron done Right') is a next-generation homeserver
 author: Matrix.org team
 maturity: Alpha
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/dendrite
 ---
 

--- a/gatsby/content/projects/2017-05-02-neo.mdx
+++ b/gatsby/content/projects/2017-05-02-neo.mdx
@@ -8,15 +8,15 @@ description: A Lightweight Webclient
 author: f0x
 maturity: Alpha
 language: JavaScript
-license: AGPL3
-repo: https://github.com/f0x52/neo
-home: https://neo.lain.haus/
+license: AGPL-3.0-only
+repo: https://git.pixie.town/neo/neo
+home: https://neo.pixie.town
 screenshot: /docs/projects/images/neo.png
 ---
 
 Neo is a Webclient made with react.js. It's designed after Telegram, with the
 (planned) functionality of everything riot does.
 
-Instance: [try it now!](https://f.0x52.eu/neo)
+Instance: [try it now!](https://neo.pixie.town/app)
 
 

--- a/gatsby/content/projects/2017-05-02-nheko.mdx
+++ b/gatsby/content/projects/2017-05-02-nheko.mdx
@@ -8,7 +8,7 @@ description: A Qt/C++14 desktop client for Matrix
 author: mujx and red_sky
 maturity: Beta
 language: C++/Qt
-license:  GPL-3.0-only
+license: GPL-3.0-or-later
 repo: https://github.com/Nheko-Reborn/nheko
 home: https://github.com/Nheko-Reborn/nheko
 screenshot: /docs/projects/images/nheko.png

--- a/gatsby/content/projects/2017-05-02-sydent.mdx
+++ b/gatsby/content/projects/2017-05-02-sydent.mdx
@@ -7,7 +7,7 @@ description: The official Matrix Identity Server implementation
 author: Matrix.org team
 maturity: Stable
 language: Python
-license: Apache
+license: Apache-2.0
 repo: https://github.com/matrix-org/sydent
 ---
 

--- a/gatsby/content/projects/2017-05-02-synapse-diaspora-auth.mdx
+++ b/gatsby/content/projects/2017-05-02-synapse-diaspora-auth.mdx
@@ -7,7 +7,7 @@ description: A diaspora authenticator for synapse
 author: Shamil K Muhammed
 maturity: Stable
 language: Python
-license:  GPL-3.0-only
+license: GPL-3.0-or-later
 repo: https://git.fosscommunity.in/necessary129/synapse-diaspora-auth
 ---
 

--- a/gatsby/content/projects/2017-05-24-matrix-appservice-email.mdx
+++ b/gatsby/content/projects/2017-05-24-matrix-appservice-email.mdx
@@ -5,9 +5,9 @@ categories:
  - bridge
 description: Two ways Email<->Matrix bridge
 author: Kamax.io and Open-Xchange
-maturity: Alpha
+maturity: Not actively maintained
 language: Java
-license: AGPL3
+license: AGPL-3.0-or-later
 repo: https://github.com/kamax-io/matrix-appservice-email
 featured: true
 bridges: Email

--- a/gatsby/content/projects/2017-06-27-mautrix-appservice-go.mdx
+++ b/gatsby/content/projects/2017-06-27-mautrix-appservice-go.mdx
@@ -7,7 +7,7 @@ description: An application service framework written in Go
 author: Tulir
 maturity: Early beta
 language: Go
-license: MPL2
+license: MPL-2.0
 repo: https://github.com/tulir/mautrix-appservice-go
 ---
 

--- a/gatsby/content/projects/2017-07-03-matrix-wishlist.mdx
+++ b/gatsby/content/projects/2017-07-03-matrix-wishlist.mdx
@@ -7,7 +7,7 @@ description: A github repository tracking community requests for bridges, bots, 
 author: Travis Ralston
 maturity: Stable
 language: None
-license: 
+license: N/A
 repo: https://github.com/turt2live/matrix-wishlist
 ---
 

--- a/gatsby/content/projects/2017-08-09-matrix-static.mdx
+++ b/gatsby/content/projects/2017-08-09-matrix-static.mdx
@@ -7,7 +7,7 @@ description: A static golang generated preview of public world readable Matrix r
 author: Michael Telatynski
 maturity: Stable
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/t3chguy/matrix-static
 ---
 

--- a/gatsby/content/projects/2017-08-21-matterbridge.mdx
+++ b/gatsby/content/projects/2017-08-21-matterbridge.mdx
@@ -7,7 +7,7 @@ description: Bot for bridging Matrix and Mattermost, IRC, XMPP, Gitter, Slack, D
 author: 42wim
 maturity: Stable
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/42wim/matterbridge
 ---
 

--- a/gatsby/content/projects/2017-09-13-godot-matrix.mdx
+++ b/gatsby/content/projects/2017-09-13-godot-matrix.mdx
@@ -7,7 +7,7 @@ description: Godot Engine module for Matrix client
 author: vurpo
 maturity: Alpha
 language: C++
-license: 
+license: MIT
 repo: https://gitlab.com/vurpo/godot-matrix
 featured: true
 thumbnail: /docs/projects/images/godot-480.png

--- a/gatsby/content/projects/2017-10-12-SmsMatrix.mdx
+++ b/gatsby/content/projects/2017-10-12-SmsMatrix.mdx
@@ -7,7 +7,7 @@ description: A simple Android SMS (text message) <--> Matrix bridge, implemented
 author: Gerben Droogers
 maturity: Alpha
 language: Java
-license: 
+license: GPL-3.0-only
 repo: https://github.com/tijder/SmsMatrix
 slug: SmsMatrix
 featured: true

--- a/gatsby/content/projects/2017-11-23-Trinity.mdx
+++ b/gatsby/content/projects/2017-11-23-Trinity.mdx
@@ -7,7 +7,7 @@ description: A management GUI for Matrix-Synapse server
 author: Amin Husni
 maturity: Beta
 language: C#
-license: AGPL3
+license: AGPL-3.0-only
 repo: https://github.com/aminhusni/Trinity_Matrix_Management_GUI
 screenshot: /docs/projects/images/trinity.png
 ---

--- a/gatsby/content/projects/2018-02-02-matrix-haxe.mdx
+++ b/gatsby/content/projects/2018-02-02-matrix-haxe.mdx
@@ -7,7 +7,7 @@ description:
 author: endes
 maturity: Alpha
 language: Haxe
-license: AGPL3
+license: AGPL-3.0-only
 repo: https://notabug.org/Tamaimo/haxe-matrix-im
 home: https://lib.haxe.org/p/matrix-im/
 featured: false

--- a/gatsby/content/projects/2018-04-10-matrix-monitor-bot.mdx
+++ b/gatsby/content/projects/2018-04-10-matrix-monitor-bot.mdx
@@ -7,7 +7,7 @@ description: Measures latency between homeservers as perceived by users
 author: Travis Ralston
 maturity: Stable
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/turt2live/matrix-monitor-bot
 home: https://lag.t2bot.io/
 room: "#monitorbot:t2bot.io"

--- a/gatsby/content/projects/2018-04-24-Operator.mdx
+++ b/gatsby/content/projects/2018-04-24-Operator.mdx
@@ -7,7 +7,7 @@ description: Operator is a C++ library for plugging into the Matrix
 author: uhoreg
 maturity: Alpha
 language: C++
-license: Apache
+license: Apache-2.0
 repo: https://vcs.uhoreg.ca/git/cgit/operator/
 ---
 

--- a/gatsby/content/projects/2018-04-24-matrix-appservice-prosody.mdx
+++ b/gatsby/content/projects/2018-04-24-matrix-appservice-prosody.mdx
@@ -7,7 +7,7 @@ description: Prosody module to act as a Matrix Application Service
 author: uhoreg
 maturity: Alpha
 language: Lua
-license: 
+license: MIT
 repo: https://gitlab.com/uhoreg/matrix-appservice-prosody
 ---
 

--- a/gatsby/content/projects/2018-04-24-matrix-docker-ansible-deploy.mdx
+++ b/gatsby/content/projects/2018-04-24-matrix-docker-ansible-deploy.mdx
@@ -7,7 +7,7 @@ description: Matrix server setup using Ansible and Docker
 author: spantaleev
 maturity: Beta
 language: Shell
-license: 
+license: AGPL-3.0-only
 repo: https://github.com/spantaleev/matrix-docker-ansible-deploy
 ---
 

--- a/gatsby/content/projects/2018-04-24-matrix-redux-wrap.mdx
+++ b/gatsby/content/projects/2018-04-24-matrix-redux-wrap.mdx
@@ -7,7 +7,7 @@ description: A library that exposes matrix-js-sdk state via Redux
 author: Luke Barnard
 maturity: Stable
 language: JavaScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/lukebarnard1/matrix-redux-wrap
 ---
 

--- a/gatsby/content/projects/2018-04-24-matrix-synapse-rest-auth.mdx
+++ b/gatsby/content/projects/2018-04-24-matrix-synapse-rest-auth.mdx
@@ -5,9 +5,9 @@ categories:
  - other
 description: REST endpoint Authentication module for synapse
 author: Max Dor
-maturity: Beta
+maturity: Not actively maintained
 language: Python
-license: AGPL3
+license: AGPL-3.0-or-later
 repo: https://github.com/kamax-io/matrix-synapse-rest-auth
 ---
 

--- a/gatsby/content/projects/2018-04-24-matrixmon.mdx
+++ b/gatsby/content/projects/2018-04-24-matrixmon.mdx
@@ -7,7 +7,7 @@ description: A small end-to-end prober and Prometheus stats exporter for a Matri
 author: leonerd
 maturity: Beta
 language: Perl
-license: 
+license: Apache-2.0
 repo: https://github.com/matrix-org/matrixmon
 ---
 

--- a/gatsby/content/projects/2018-04-24-matrixstats.org.mdx
+++ b/gatsby/content/projects/2018-04-24-matrixstats.org.mdx
@@ -5,7 +5,7 @@ categories:
  - other
 description: The first public catalog for matrix rooms, grouped by ratings or categories
 author: a13xmt
-maturity: Beta
+maturity: Not actively maintained
 language: Python
 license: 
 repo: https://github.com/a13xmt/matrixstats.org

--- a/gatsby/content/projects/2018-04-24-mini-vector-android.mdx
+++ b/gatsby/content/projects/2018-04-24-mini-vector-android.mdx
@@ -7,7 +7,7 @@ description: A simpler Matrix client for Android, with fewer permissions and dep
 author: LiMium
 maturity: Beta
 language: Java
-license: Apache
+license: Apache-2.0
 repo: https://github.com/LiMium/mini-vector-android
 room: "#miniVectorAndroid:matrix.org"
 slug: minivector

--- a/gatsby/content/projects/2018-04-24-mxhsd.mdx
+++ b/gatsby/content/projects/2018-04-24-mxhsd.mdx
@@ -5,9 +5,9 @@ categories:
   - server
 description: mxhsd is Matrix Homeserver aimed towards entities who want to have in-depth control of their servers
 author: Max Dor
-maturity: Early Beta
+maturity: Not actively maintained
 language: Java
-license: 
+license: AGPL-3.0-or-later
 repo: https://github.com/kamax-io/mxhsd
 ---
 

--- a/gatsby/content/projects/2018-04-24-olm.mdx
+++ b/gatsby/content/projects/2018-04-24-olm.mdx
@@ -7,7 +7,7 @@ description: An implementation of the Double Ratchet cryptographic ratchet in C+
 author: matrix.org
 maturity: Stable
 language: C++
-license: Apache
+license: Apache-2.0
 repo: https://git.matrix.org/git/olm
 home: https://git.matrix.org/git/olm/about/docs/olm.rst
 ---

--- a/gatsby/content/projects/2018-04-24-picard.mdx
+++ b/gatsby/content/projects/2018-04-24-picard.mdx
@@ -7,7 +7,7 @@ description: Tools for handling slack channels and converting them to matrix
 author: Cadair and SolarDrew
 maturity: Alpha
 language: Python
-license: 
+license: Apache-2.0
 repo: https://github.com/SolarDrew/skill-picard
 ---
 

--- a/gatsby/content/projects/2018-04-24-silvy-matrix.mdx
+++ b/gatsby/content/projects/2018-04-24-silvy-matrix.mdx
@@ -7,7 +7,7 @@ description: A personal chatbot
 author: jaller94
 maturity: Beta
 language: JavaScript
-license: AGPL3
+license: AGPL-3.0-only
 repo: https://gitlab.com/jaller94/silvy-matrix
 ---
 

--- a/gatsby/content/projects/2018-04-26-matrix-synapse-pam.mdx
+++ b/gatsby/content/projects/2018-04-26-matrix-synapse-pam.mdx
@@ -7,7 +7,7 @@ description: Allows Synapse to use UNIX accounts through PAM
 author: 14mRh4X0r
 maturity: Alpha
 language: Python
-license: EUPL
+license: EUPL-1.1
 repo: https://github.com/14mRh4X0r/matrix-synapse-pam
 ---
 

--- a/gatsby/content/projects/2018-04-26-matrix-synapse-smf.mdx
+++ b/gatsby/content/projects/2018-04-26-matrix-synapse-smf.mdx
@@ -7,7 +7,7 @@ description: Allows synapse to use SMF 2.1 forum accounts from its database as a
 author: juju2143
 maturity: Alpha
 language: Python
-license: Apache
+license: Apache-2.0
 repo: https://github.com/juju2143/matrix-synapse-smf
 ---
 

--- a/gatsby/content/projects/2018-06-17-terraform-provider-matrix.mdx
+++ b/gatsby/content/projects/2018-06-17-terraform-provider-matrix.mdx
@@ -7,7 +7,7 @@ description: Terraform your matrix homeserver
 author: Travis Ralston
 maturity: Beta
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/turt2live/terraform-provider-matrix
 ---
 

--- a/gatsby/content/projects/2018-06-27-transform.mdx
+++ b/gatsby/content/projects/2018-06-27-transform.mdx
@@ -7,7 +7,7 @@ description: Transform is a matrix homeserver built using Typescript and Redis.
 author: bettiah
 maturity: Not actively maintained
 language: TypeScript
-license: Apache
+license: Apache-2.0
 repo: https://github.com/bettiah/transform
 ---
 

--- a/gatsby/content/projects/2018-06-28-VoipMS-SMS-Matrix.mdx
+++ b/gatsby/content/projects/2018-06-28-VoipMS-SMS-Matrix.mdx
@@ -7,7 +7,7 @@ description: send and recieve SMS messages with voip.ms
 author: untidylamp
 maturity: Alpha
 language: Python
-license: 
+license: Unlicense
 repo: https://gitlab.com/untidylamp/VoipMS-SMS-Matrix/
 ---
 

--- a/gatsby/content/projects/2018-06-28-python-olm.mdx
+++ b/gatsby/content/projects/2018-06-28-python-olm.mdx
@@ -7,7 +7,7 @@ description: Python bindings for the Olm C library.
 author: poljar
 maturity: Beta
 language: Python
-license: Apache
+license: Apache-2.0
 repo: https://github.com/poljar/python-olm
 ---
 

--- a/gatsby/content/projects/2018-07-02-matrix-appservice-voip.mdx
+++ b/gatsby/content/projects/2018-07-02-matrix-appservice-voip.mdx
@@ -10,7 +10,7 @@ repo: https://github.com/kamax-matrix/matrix-appservice-voip
 room: "#mxasd-voip:kamax.io"
 description: 
 author: Kamax.io
-maturity: Beta
+maturity: Not actively maintained
 ---
 
 

--- a/gatsby/content/projects/2018-07-18-fed-tester.mdx
+++ b/gatsby/content/projects/2018-07-18-fed-tester.mdx
@@ -7,7 +7,7 @@ description: React.js frontend for the federation-tester api
 author: f0x
 maturity: Beta
 language: JavaScript
-license: AGPL3
+license: AGPL-3.0-only
 repo: https://github.com/f0x52/fed-tester
 home: https://neo.lain.haus/fed-tester/
 ---

--- a/gatsby/content/projects/2018-07-18-libolm-go.mdx
+++ b/gatsby/content/projects/2018-07-18-libolm-go.mdx
@@ -7,7 +7,7 @@ description: Go Bindings for libolm
 author: NotAFile
 maturity: Stable
 language: Go
-license: Apache
+license: Apache-2.0
 repo: https://github.com/NotAFile/libolm-go
 ---
 

--- a/gatsby/content/projects/2018-07-18-synapse_scripts.mdx
+++ b/gatsby/content/projects/2018-07-18-synapse_scripts.mdx
@@ -5,7 +5,7 @@ categories:
  - other
 description: Various tools for maintaining a matrix synapse chat server
 author: xwiki-labs
-maturity: Beta
+maturity: Not actively maintained
 language: Shell
 license: 
 repo: https://github.com/xwiki-labs/synapse_scripts

--- a/gatsby/content/projects/2018-09-03-racket-matrix-sdk.mdx
+++ b/gatsby/content/projects/2018-09-03-racket-matrix-sdk.mdx
@@ -7,7 +7,7 @@ description: A Matrix client library written in Racket
 author: Aidan Gauland
 maturity: Alpha
 language: Racket
-license: LGPL
+license: LGPL-3.0-or-later
 repo: https://gitlab.com/aidalgol/racket-matrix-sdk/
 featured: true
 thumbnail: /docs/projects/images/racket.png

--- a/gatsby/content/projects/2018-12-10-MatrixAPI.mdx
+++ b/gatsby/content/projects/2018-12-10-MatrixAPI.mdx
@@ -7,7 +7,7 @@ description: A Matrix library for C# UWP
 author: VRocker
 maturity: Alpha
 language: C#
-license: 
+license: Apache-2.0
 repo: https://github.com/VRocker/MatrixAPI
 featured: true
 thumbnail: /docs/projects/images/c-sharp.png

--- a/gatsby/content/projects/2018-12-13-mxtoot.mdx
+++ b/gatsby/content/projects/2018-12-13-mxtoot.mdx
@@ -7,7 +7,7 @@ description: A Matrix<->Mastodon bot written in Java.
 author: ma1uta
 maturity: Alpha
 language: Java
-license: Apache
+license: Apache-2.0
 repo: https://github.com/ma1uta/mxtoot
 room: "#mxtoot:matrix.org"
 featured: true

--- a/gatsby/content/projects/2019-02-12-dice.mdx
+++ b/gatsby/content/projects/2019-02-12-dice.mdx
@@ -7,7 +7,7 @@ description: A maubot that rolls dice. Has built-in calculator.
 author: tulir
 maturity: Beta
 language: Python
-license: AGPL-3.0-only
+license: AGPL-3.0-or-later
 repo: https://github.com/maubot/dice
 featured: true
 ---

--- a/gatsby/content/projects/2019-02-12-karma.mdx
+++ b/gatsby/content/projects/2019-02-12-karma.mdx
@@ -7,7 +7,7 @@ description: A maubot that tracks the karma of users.
 author: tulir
 maturity: Beta
 language: Python
-license: AGPL-3.0-only
+license: AGPL-3.0-or-later
 repo: https://github.com/maubot/karma
 featured: true
 ---

--- a/gatsby/content/projects/2019-03-06-matrixtexting.mdx
+++ b/gatsby/content/projects/2019-03-06-matrixtexting.mdx
@@ -7,7 +7,7 @@ description: Android App that will bridge SMS/MMS messages
 author: untidylamp
 maturity: Alpha
 language: Java
-license: 
+license: Unlicense
 repo: https://gitlab.com/untidylamp/MatrixTexting
 ---
 

--- a/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-discord.mdx
@@ -6,7 +6,7 @@ categories:
 description: mx-puppet-discord is a (double)puppeting bridge for discord.
 author: Sorunome
 language: TypeScript
-license: Apache 2.0
+license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/matrix-discord/mx-puppet-discord # your source code repository

--- a/gatsby/content/projects/2020-01-18-mx-puppet-instagram.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-instagram.mdx
@@ -6,7 +6,7 @@ categories:
 description: mx-puppet-instagram is a (double)puppeting bridge for instagram.
 author: Sorunome
 language: TypeScript
-license: Apache 2.0
+license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/Sorunome/mx-puppet-instagram # your source code repository

--- a/gatsby/content/projects/2020-01-18-mx-puppet-slack.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-slack.mdx
@@ -6,7 +6,7 @@ categories:
 description: mx-puppet-slack is a (double)puppeting bridge for slack.
 author: Sorunome
 language: TypeScript
-license: Apache 2.0
+license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/Sorunome/mx-puppet-slack # your source code repository

--- a/gatsby/content/projects/2020-01-18-mx-puppet-tox.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-tox.mdx
@@ -6,7 +6,7 @@ categories:
 description: mx-puppet-tox is a (double)puppeting bridge for tox.
 author: Sorunome
 language: TypeScript
-license: Apache 2.0
+license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/Sorunome/mx-puppet-tox # your source code repository

--- a/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
+++ b/gatsby/content/projects/2020-01-18-mx-puppet-twitter.mdx
@@ -6,7 +6,7 @@ categories:
 description: mx-puppet-twitter is a (double)pupepting bridge for twitter DMs.
 author: Sorunome
 language: TypeScript
-license: Apache 2.0
+license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
 repo: https://github.com/Sorunome/mx-puppet-twitter # your source code repository

--- a/gatsby/content/projects/2020-04-14-maelstrom.mdx
+++ b/gatsby/content/projects/2020-04-14-maelstrom.mdx
@@ -7,7 +7,7 @@ description: A high-performance Matrix Home-Server written in Rust designed to b
 author: Chris Bruce
 maturity: Alpha
 language: Rust
-license: Apache2.0/MIT
+license: (Apache-2.0 OR MIT)
 repo: https://github.com/maelstrom-rs/maelstrom
 home: https://github.com/maelstrom-rs/maelstrom
 room: "#maelstrom-server:matrix.org"

--- a/gatsby/content/projects/bots/poll-bot.mdx
+++ b/gatsby/content/projects/bots/poll-bot.mdx
@@ -6,7 +6,7 @@ description: Matrix bot to do polls. What more do you need?
 author: Brendan Abolivier
 maturity: Alpha
 language: Go
-license: Unknown
+license: AGPL-3.0-only
 repo: https://github.com/babolivier/matrix-poll-bot
 screenshot: https://user-images.githubusercontent.com/5547783/60209177-029b8e80-9852-11e9-8aee-c91d7ccaaec1.png
 thumbnail: https://user-images.githubusercontent.com/5547783/60209177-029b8e80-9852-11e9-8aee-c91d7ccaaec1.png

--- a/gatsby/content/projects/bridges/takitam-email-bridge.mdx
+++ b/gatsby/content/projects/bridges/takitam-email-bridge.mdx
@@ -8,7 +8,7 @@ description: An (almost) transparent matrix gateway. Sending and receiving email
 author: https://gitlab.com/takitam_matrix
 maturity: Alpha
 language: Python
-license: Unknown
+license: GPL-3.0-only
 repo: https://gitlab.com/takitam_matrix/matrix-email-bridge
 featured: true
 bridges: Email


### PR DESCRIPTION
Intended to fix this mess:

![image](https://user-images.githubusercontent.com/4224639/81286522-da7fdd00-9069-11ea-8f23-59ac6735d3a7.png)

Also a few other fixes, like marking all of kamax's projects, [synapse_scripts](https://github.com/xwiki-labs/synapse_scripts) and matrixstats.org as not maintained and updating neo's links

Maelstrom has Apache/MIT dual license, so I made it use the `(Apache-2.0 OR MIT)` like SPDX says dual licenses should be. The license filtering probably doesn't support it, but could be updated to follow the SPDX spec fully.