### PR TITLE
Rename GTK

### DIFF
--- a/gatsby/content/projects/2017-08-31-fractal.mdx
+++ b/gatsby/content/projects/2017-08-31-fractal.mdx
@@ -46,7 +46,7 @@ features:
     voip: no
 ---
 
-Fractal is a Gtk+ Matrix Client written in Rust.
+Fractal is a GTK Matrix Client written in Rust.
 
 Get the code from [Gnome gitlab](https://gitlab.gnome.org/GNOME/fractal).
 


### PR DESCRIPTION
A year ago, GTK officially dropped the + from its name https://lwn.net/Articles/779305/