### PR TITLE
Raku is the new name for perl6

### DIFF
--- a/gatsby/content/projects/2018-02-23-perl6-matrix-client.mdx
+++ b/gatsby/content/projects/2018-02-23-perl6-matrix-client.mdx
@@ -3,10 +3,10 @@ layout: projectimage
 title: Matrix::Client
 categories: 
  - sdk
-description: Perl6 Matrix client SDK
+description: Raku Matrix client SDK
 author: matiaslina
 maturity: Alpha
-language: Perl
+language: Raku
 license: Artistic2
 repo: https://github.com/matiaslina/perl6-matrix-client
 featured: true
@@ -14,4 +14,4 @@ thumbnail: /docs/projects/images/perl.png
 screenshot: /docs/projects/images/perl.png
 ---
 
-Perl6 Matrix client. [github](https://github.com/matiaslina/perl6-matrix-client)
+Raku Matrix client. [github](https://github.com/matiaslina/perl6-matrix-client)


### PR DESCRIPTION
Raku is also not perl (5)

Renaming of perl6 -> raku: https://docs.raku.org/language/faq#What's_the_difference_between_Raku,_Rakudo_and_Perl_6?

Some renaming inside the project: https://github.com/matiaslina/perl6-matrix-client/commit/e50b8fa9e02b19ece80ebeb576051e451d3a7812

