### PR TITLE
Correct term: Mozilla Thing -> Mozilla WebThings

### DIFF
--- a/gatsby/content/blog/2020/06/2020-06-19-twim.mdx
+++ b/gatsby/content/blog/2020/06/2020-06-19-twim.mdx
@@ -400,11 +400,11 @@ pub enum AnyStateEvent {
 
 ## Dept of Internet of Things 💡
 
-### Mozilla Thing Matrix Adapter
+### Mozilla WebThings Matrix Adapter
 
-[Christian](https://matrix.to/#/@christianp:vector.modular.im) offered:
+[](https://matrix.to/#/@christianp:vector.modular.im) offered:
 
-> I heard that you people like IoT?! With the Mozilla Thing Matrix Adapter your Raspberry Pi sends you messages about your home. Want a log of when the front door has been opened? Need a low battery alert for your IoT devices? With the Mozilla IoT gateway and this adapter, you can send these events to a Matrix room of your choice!
+> I heard that you people like IoT?! With the Mozilla WebThings Matrix Adapter your Raspberry Pi sends you messages about your home. Want a log of when the front door has been opened? Need a low battery alert for your IoT devices? With the Mozilla IoT gateway and this adapter, you can send these events to a Matrix room of your choice!
 >
 > <https://gitlab.com/webthings/matrix-adapter>
 

--- a/gatsby/content/blog/2020/06/2020-06-19-twim.mdx
+++ b/gatsby/content/blog/2020/06/2020-06-19-twim.mdx
@@ -402,7 +402,7 @@ pub enum AnyStateEvent {
 
 ### Mozilla WebThings Matrix Adapter
 
-[](https://matrix.to/#/@christianp:vector.modular.im) offered:
+[Christian](https://matrix.to/#/@christianp:vector.modular.im) offered:
 
 > I heard that you people like IoT?! With the Mozilla WebThings Matrix Adapter your Raspberry Pi sends you messages about your home. Want a log of when the front door has been opened? Need a low battery alert for your IoT devices? With the Mozilla IoT gateway and this adapter, you can send these events to a Matrix room of your choice!
 >


### PR DESCRIPTION
Mozilla WebThings is the common term for the project.

https://iot.mozilla.org