### PR TITLE
Fluffychat website has moved

### DIFF
--- a/gatsby/content/projects/2018-12-27-fluffychat.mdx
+++ b/gatsby/content/projects/2018-12-27-fluffychat.mdx
@@ -50,4 +50,4 @@ features:
     voip: no
 ---
 
-FluffyChat is a Flutter-based client with a simple and clean UI. The focus is on replacing common messenger apps like WhatsApp or Telegram on all major platforms. Find more info on the website: <http://fluffy.chat>
+FluffyChat is a Flutter-based client with a simple and clean UI. The focus is on replacing common messenger apps like WhatsApp or Telegram on all major platforms. Find more info on the website: <https://fluffychat.im/>


### PR DESCRIPTION
Fluffychat now has their website at https://fluffychat.im/en/, not http://fluffy.chat (old website gives an ugly HTTP 401).

Their official repo links to the new site already: https://gitlab.com/ChristianPauly/fluffychat-flutter