### PR TITLE
Add language to bots overview

### DIFF
--- a/gatsby/src/components/MXProjectCard.js
+++ b/gatsby/src/components/MXProjectCard.js
@@ -3,6 +3,10 @@ const MXProjectCard = ({ project, imageSize }) => {
     imageSize = imageSize ? imageSize : 300;
     return <div className="mxclientcard">
         <h3><a href={project.slug}>{project.title}</a></h3>
+        {project.categories && project.categories[0] === "bot" && <>
+        <small>{project.language}</small>
+        <br />
+        </>}
         {project.thumbnail && <a href={project.slug}>
             <img alt={project.title} src={project.thumbnail}
             style={{ "maxWidth": `${imageSize}px`, "maxHeight": `${imageSize}px` }} />
@@ -14,7 +18,6 @@ const MXProjectCard = ({ project, imageSize }) => {
                 Example mxid: <a href={"https://matrix.to/#/"+project.example_mxid}>{project.example_mxid}</a>
             </div>
         }
-        
     </div>
 }
 export default MXProjectCard


### PR DESCRIPTION
As a beginner looking for inspiration to write a bot in language X, this
allows me to filter bots of interests without changing page (clicking on
each bot individually).

Signed-off-by: Pamplemousse <xav.maso@gmail.com>