### PR TITLE
Update keybase project status and fix riot-web maturity

### DIFF
--- a/gatsby/content/projects/2014-06-09-riot.mdx
+++ b/gatsby/content/projects/2014-06-09-riot.mdx
@@ -7,7 +7,7 @@ categories:
 thumbnail: /docs/projects/images/riot-web-small.png
 description: Riot is a glossy web client with an emphasis on performance and usability
 author: Riot.im
-maturity: No longer maintained
+maturity: Not actively maintained
 language: JavaScript
 license: Apache-2.0
 repo: https://github.com/vector-im/riot-web/

--- a/gatsby/content/projects/bridges/matrix-keybase.mdx
+++ b/gatsby/content/projects/bridges/matrix-keybase.mdx
@@ -11,10 +11,12 @@ language: TypeScript
 license: MIT
 repo: https://github.com/Half-Shot/matrix-keybase # your source code repository
 room: "#keybase:half-shot.uk"
-maturity: Early Alpha
+maturity: Not actively maintained
 bridges: Keybase
 thumbnail: /docs/projects/images/keybase-logo.svg
 featured: true
 ---
+
+**The project has been discontinued**.
 
 A bridge that connects a user's <a href="https://keybase.io">Keybase</a> account to their Matrix account.


### PR DESCRIPTION
Only riot-web was using "No longer maintained" instead of "Not actively maintained"

Closes #772 

```bash
matrix.org/gatsby/content/projects$ cat *.mdx */*.mdx | grep maturity: | sed -E 's/\s+#.+//' | sort -u
maturity: Alpha
maturity: Beta
maturity: Early Alpha
maturity: Early Beta
maturity: Late Alpha
maturity: Late Beta
maturity: Not actively maintained
maturity: Released
maturity: Stable
```