### PR TITLE
Fix link to book source code

### DIFF
--- a/implementation-guides/server/book.toml
+++ b/implementation-guides/server/book.toml
@@ -7,7 +7,7 @@ title = "Matrix Homeserver Implementation Guide"
 
 [output.html]
 theme = "../theme"
-git-repository-url = "https://github.com/matrix-org/matrix.org/tree/master/server"
+git-repository-url = "https://github.com/matrix-org/matrix.org/tree/master/implementation-guides/server"
 
 [preprocessor.links]
 


### PR DESCRIPTION
Was missing `implementation-guides` folder from the source code link.