### PR TITLE
Add Cloudron as installation method

### DIFF
--- a/gatsby/content/projects/2014-08-12-synapse.mdx
+++ b/gatsby/content/projects/2014-08-12-synapse.mdx
@@ -37,4 +37,7 @@ You can get Synapse on [Yunohost](https://github.com/YunoHost-Apps/synapse_ynh)
 
 Synapse is available in the [FreedomBox](https://freedombox.org) distribution (version 0.14.0 or later).
 
+Cloudron has 1-click packages for [Synapse](https://www.cloudron.io/store/org.matrix.synapse.html) and [Element](https://www.cloudron.io/store/im.riot.cloudronapp.html).
+The packages are built from [this repo](https://git.cloudron.io/cloudron/matrix-synapse-app).
+
 There is also a [handy spreadsheet](https://matrix.org/docs/projects/other/hdd-space-calc-for-synapse.html) to calculate HDD space for your Synapse instance.


### PR DESCRIPTION
We (Cloudron team) have been maintaining packages for Synapse and Element for quite a while now. We also have many users of Synapse on our platform (https://forum.cloudron.io/category/50/matrix-synapse-element). Would be great to have Cloudron listed as an installation option alongside others.