### PR TITLE
Created 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,45 @@
+/* This file was created so as to provide a different redirection route in case of a broken/missing link */
+<!DOCTYPE html>
+<link href="https://fonts.googleapis.com/css2?family=Anton&display=swap" rel="stylesheet">
+<html>
+<style>
+body{
+  background-image: url('https://static.vecteezy.com/system/resources/previews/000/151/795/non_2x/hallway-matrix-background-vector.jpg');
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-size: cover;
+}
+.big-font{
+  color: white;
+  font-family: 'Anton', sans-serif;
+  font-size: 80px;
+}
+.small-font{
+  color: white;
+  font-family: 'Anton', sans-serif;
+  font-size: 50px;
+}
+a:link {
+  color: white;
+}
+a:visited {
+  color: white;
+}
+
+a:hover {
+  color: hotpink;
+}
+
+a:active {
+  color: white;
+}
+</style>
+<body>
+<div class="big-font">
+<center><h1> Error 404 </h1></center>
+</div>
+<div>
+<center><h2 class="small-font"> OOPS! There seems to be a glitch in the <a href="https://matrix.org/">[ Matrix ]</a></h2></center>
+
+</body>
+</html>


### PR DESCRIPTION
The default "Not Found" page on matrix-org breaks the consistency across other pages.
I've created a new Error 404 Page that gives the user a better route for redirection to the home-page.
Old View -
![Screen Shot 2020-10-06 at 6 31 26 PM](https://user-images.githubusercontent.com/56473490/95204781-2cd44e00-0802-11eb-91f7-ec6567b9203f.png)
Updated View -
![Screen Shot 2020-10-06 at 6 31 58 PM](https://user-images.githubusercontent.com/56473490/95204862-470e2c00-0802-11eb-89ef-746d07968ad5.png)
* The [Matrix] text turns pink once the user hovers over it, giving them an option to click on it and get redirected to matrix.org