### PR TITLE
Tweak Jekyll styles for readability

### DIFF
--- a/jekyll/_sass/_base.scss
+++ b/jekyll/_sass/_base.scss
@@ -17,7 +17,6 @@ body {
     font-family: $base-font-family;
     font-size: $base-font-size;
     line-height: $base-line-height;
-    font-weight: 300;
     color: $text-color;
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;

--- a/jekyll/css/docs_overrides.css
+++ b/jekyll/css/docs_overrides.css
@@ -1,5 +1,5 @@
 a.toc-backref {
-    color: #666;
+    color: #333;
 }
 
 ul {

--- a/jekyll/css/site_overrides.css
+++ b/jekyll/css/site_overrides.css
@@ -1,6 +1,6 @@
 p {
     line-height: 1.5;
-    color: #666;
+    color: #333;
 }
 
 a.anchor {  


### PR DESCRIPTION
Over in https://github.com/matrix-org/matrix-doc/issues/2805 I suggested making some changes to the spec CSS to make it more readable. But some of the relevant CSS is coming from the Jekyll builder over here. Specifically:

* `font-weight: 300` makes the text harder to read than a normal weight
* `color: #666` is worse for contrast than `#333`, and `#333` is the [style guide recommendation](https://matrix-org.webflow.io/style-guide)

Before these changes, the spec looks like:

<img width="955" alt="before1" src="https://user-images.githubusercontent.com/432915/95395879-7aa98e80-08b4-11eb-9324-140acaae75a4.png">

After these changes, the spec should look like:

<img width="955" alt="after1" src="https://user-images.githubusercontent.com/432915/95396194-379beb00-08b5-11eb-8051-0d1f4fbc1e8b.png">


Unfortunately I'm not sure how to build the Jekyll site locally to test this properly, but I'm happy to do so if you can give me some pointers.


