### PR TITLE
Add matrix-feeder

### DIFF
--- a/gatsby/content/projects/bots/matrix-feeder.mdx
+++ b/gatsby/content/projects/bots/matrix-feeder.mdx
@@ -1,0 +1,17 @@
+---
+layout: project
+title: matrix-feeder
+categories:
+ - bot
+description: Matrix feeder is a matrix bot that monitors defined channels for media and posts them to another channel.
+author: dragonchaser
+home: https://github.com/dragonchaser/matrix-feeder
+language: Javascript
+license: MIT
+repo: https://github.com/dragonchaser/matrix-feeder # your source code repository
+maturity: Beta
+featured: true
+---
+Matrix feeder is a matrix bot that monitors defined channels for media and posts them to another channel.
+Just invite the bot to the channels of your choice and posted media will be relayed.
+


### PR DESCRIPTION
This PR adds `matrix-feeder` to the bots site.
Matrix-feeder is a monitoring bot that can be added to multiple rooms and will relay media to a predefined room.
**URL:** https://github.com/dragonchaser/matrix-feeder