### PR TITLE
Fix up implementation guides

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -58,6 +58,7 @@ steps:
       - ./mdbook build server -d /workdir/implementation-guides/implementation-guides/server
       - ./mdbook build client -d /workdir/implementation-guides/implementation-guides/client
       - ./mdbook build application-services -d /workdir/implementation-guides/implementation-guides/application-services
+      - cp index.html /workdir/implementation-guides/implementation-guides/
       - tar -czf implementation-guides.tar.gz implementation-guides
     artifact_paths:
       - implementation-guides/implementation-guides.tar.gz

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -56,6 +56,8 @@ steps:
       - wget https://github.com/rust-lang/mdBook/releases/download/v0.4.1/mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
       - tar -xf mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
       - ./mdbook build server -d /workdir/implementation-guides/implementation-guides/server
+      - ./mdbook build client -d /workdir/implementation-guides/implementation-guides/client
+      - ./mdbook build application-services -d /workdir/implementation-guides/implementation-guides/application-services
       - tar -czf implementation-guides.tar.gz implementation-guides
     artifact_paths:
       - implementation-guides/implementation-guides.tar.gz

--- a/implementation-guides/application-services/book.toml
+++ b/implementation-guides/application-services/book.toml
@@ -6,7 +6,7 @@ src = "src"
 title = "Matrix Application Services Implementation Guide"
 
 [output.html]
-theme = "../theme"
+theme = "theme"
 git-repository-url = "https://github.com/matrix-org/matrix.org/tree/master/implementation-guides/application-services"
 
 [preprocessor.links]

--- a/implementation-guides/client/book.toml
+++ b/implementation-guides/client/book.toml
@@ -6,7 +6,7 @@ src = "src"
 title = "Matrix Client Implementation Guide"
 
 [output.html]
-theme = "../theme"
+theme = "theme"
 git-repository-url = "https://github.com/matrix-org/matrix.org/tree/master/implementation-guides/client"
 
 [preprocessor.links]

--- a/implementation-guides/index.html
+++ b/implementation-guides/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html lang="en" class="sidebar-visible no-js light">
+    <head>
+        <!-- Book generated using mdBook -->
+        <meta charset="UTF-8">
+        <title>Matrix Implementation Guides</title>
+
+
+        <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#ffffff" />
+
+        <link rel="shortcut icon" href="server/favicon.svg">
+        <link rel="stylesheet" href="server/css/variables.css">
+        <link rel="stylesheet" href="server/css/general.css">
+        <link rel="stylesheet" href="server/css/chrome.css">
+
+        <!-- Fonts -->
+        <link rel="stylesheet" href="FontAwesome/css/font-awesome.css">
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" rel="stylesheet" type="text/css">
+        <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500" rel="stylesheet" type="text/css">
+
+    </head>
+    <body>
+
+
+        <div id="page-wrapper" class="page-wrapper">
+            <div id="content" class="content">
+
+                <h1>Matrix Implementation Guides</h1>
+
+                The current guides are:
+
+                <ul>
+                    <li><a href="application-services">Application Services</a></li>
+                    <li><a href="client">Client</a></li>
+                    <li><a href="server">Server</a></li>
+                </ul>
+
+            </div>
+        </div>
+
+    </body>
+</html>

--- a/implementation-guides/server/book.toml
+++ b/implementation-guides/server/book.toml
@@ -6,7 +6,7 @@ src = "src"
 title = "Matrix Homeserver Implementation Guide"
 
 [output.html]
-theme = "../theme"
+theme = "theme"
 git-repository-url = "https://github.com/matrix-org/matrix.org/tree/master/implementation-guides/server"
 
 [preprocessor.links]

--- a/implementation-guides/theme/index.hbs
+++ b/implementation-guides/theme/index.hbs
@@ -12,7 +12,6 @@
         <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff" />
-        <meta http-equiv="Content-Security-Policy" content="Content-Security-Policy: default-src; script-src 'unsafe-inline'; script-src-elem; script-src-attr; style-src 'unsafe-inline'; style-src-elem; style-src-attr; img-src https://matrix.org; font-src; connect-src; media-src; object-src; prefetch-src; child-src; frame-src; worker-src; frame-ancestors; form-action; base-uri; manifest-src; plugin-types; report-uri; report-to" />
 
         <link rel="shortcut icon" href="{{ path_to_root }}{{ favicon }}">
         <link rel="stylesheet" href="{{ path_to_root }}css/variables.css">


### PR DESCRIPTION
1. I forgot to add the new guides to the CI
2. The books built by CI used the wrong theme (and the CSP added there was wrong, but we seem to do CSP in the apache anyway)
3. Add a *very* basic index.html with links to the book, reusing the same CSS as the books. This is really just a place holder. 