### PR TITLE
Fix markdown in /op example

### DIFF
--- a/gatsby/content/docs/2019-04-29-moderation.mdx
+++ b/gatsby/content/docs/2019-04-29-moderation.mdx
@@ -52,7 +52,7 @@ In Riot, Admins are shown in the membership list with a golden shield, and Moder
 
 <br clear="all" />
 
-To change the power level of a given user in Riot, you can use the dropdown in their user info panel, having selected them from the membership list or timeline.  Alternatively you can change their level directly from the message composer by typing `/op @username:domain 50 `or similar`.`
+To change the power level of a given user in Riot, you can use the dropdown in their user info panel, having selected them from the membership list or timeline.  Alternatively you can change their level directly from the message composer by typing `/op @username:domain 50` or similar.
 
 Power levels are used to define who has permission to do what actions in a room.  By default, the power levels for a public chatroom are as shown below:
 


### PR DESCRIPTION
Small fix. Found this while browsing https://matrix.org/docs/guides/moderation#power-levels, the backticks were out of control.