### PR TITLE
Changed some branding and spelling

### DIFF
--- a/gatsby/content/docs/2015-08-14-getting_involved.mdx
+++ b/gatsby/content/docs/2015-08-14-getting_involved.mdx
@@ -8,16 +8,16 @@ section: Introduction
 
 Matrix is an ecosystem consisting of several apps written by lots of people. We at Matrix.org have written one server and a few clients, and people in the community have also written several clients, servers, and Application Services. We are collecting [a list of all known Matrix-apps][try-matrix-now].
 
-You have a few options when it comes to getting involved: if you just want to use Matrix, you can [register an account on a public server using a public webclient](#reg). If you have a virtual private server (VPS) or similar, you might want to [run a server and/or client yourself](#run). If you want to look under the hood, you can [checkout the code and modify it - or write your own client or server](#checkout). Or you can write an [Application Service](#as), for example a bridge to an existing ecosystem.
+You have a few options when it comes to getting involved: if you just want to use Matrix, you can [register an account on a public server using a public web client](#reg). If you have a virtual private server (VPS) or similar, you might want to [run a server and/or client yourself](#run). If you want to look under the hood, you can [checkout the code and modify it - or write your own client or server](#checkout). Or you can write an [Application Service](#as), for example a bridge to an existing ecosystem.
 
 We very much welcome [contributions](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md) to any of our projects, which you can find in our [github space](https://github.com/matrix-org/).
 
 <a class="anchor" id="reg"></a>
 
-## Access Matrix via a public webclient/server
+## Access Matrix via a public web client/server
 
-The easiest thing to do if you want to just have a play, is to use the [Riot.im
-webclient](https://riot.im). You can use it as a guest, or register for an
+The easiest thing to do if you want to just have a play, is to use the [Element
+web client](https://app.element.io/). You can use it as a guest, or register for an
 account. For details of other clients, see
 [try-matrix-now].
 
@@ -31,8 +31,8 @@ You can clone our open source projects and run clients and servers yourself. Her
 
 You can run your own Matrix client; there are [numerous clients
 available][try-matrix-now]. You can easily [run your
-own copy](https://github.com/vector-im/vector-web#getting-started) of the
-Riot.im web client.
+own copy](https://github.com/vector-im/element-web#getting-started) of the
+Element web client.
 
 ### Running your own homeserver:
 


### PR DESCRIPTION
Changed some Riot/Vector branding and links to Element. Also added spaces in some instances of the word web client.