### PR TITLE
Update Matrix room for Ditto Chat

### DIFF
--- a/gatsby/content/projects/clients/ditto.mdx
+++ b/gatsby/content/projects/clients/ditto.mdx
@@ -9,7 +9,7 @@ maturity: Alpha
 language: JavaScript
 license: Apache-2.0
 repo: https://gitlab.com/ditto-chat/ditto-mobile
-room: "#ditto:elequin.io"
+room: "#ditto:ditto.chat"
 home: https://dittochat.org/
 platforms:
     - iOS


### PR DESCRIPTION
As stated on https://dittochat.org/ > Connect > Matrix Room

The corrected room (elequin.io) does not seem to work anymore.