### PR TITLE
Fix mismatch between talking about the Scala room and linking the Node.js one

### DIFF
--- a/gatsby/content/blog/2020/12/2020-12-07-gitter-now-speaks-matrix.mdx
+++ b/gatsby/content/blog/2020/12/2020-12-07-gitter-now-speaks-matrix.mdx
@@ -12,7 +12,7 @@ Hi all,
 It’s been just over 2 months since we revealed that [Gitter was going to join Matrix](https://matrix.org/blog/2020/09/30/welcoming-gitter-to-matrix) - and
 we are incredibly proud to announce that Gitter has officially turned on true native Matrix connectivity:
 **all public Gitter rooms are now available natively via Matrix, and all Gitter users now natively exist on Matrix.**
-So, if you wanted to join the official Scala language support room at [https://gitter.im/nodejs/node](https://gitter.im/nodejs/node)
+So, if you wanted to join the official Node.js language support room at [https://gitter.im/nodejs/node](https://gitter.im/nodejs/node)
 from Matrix, just head over to [#nodejs_node:gitter.im](https://matrix.to/#/#nodejs_node:gitter.im) and \*boom\*, you’re in!
 
 This means Gitter is now running a Matrix homeserver at gitter.im which exposes all the active public rooms - so if you go to the the room directory in Element (for instance) and select gitter.im as a homeserver, you can jump straight in:
@@ -23,7 +23,7 @@ Once you’re in, you can chat back and forth transparently between users on the
 
 ![Gitter and Matrix going native!](https://matrix.org/blog/img/2020-12-07-gitter-matrix.gif)
 
-So, suddenly all the developer communities previously living only in Gitter ([Scala](https://gitter.im/scala), [Node](https://gitter.im/nodejs/home), [Webpack](https://gitter.im/scala), [Angular](https://gitter.im/angular), [Rails](https://gitter.im/rails) and thousands of others) are now available to anyone anywhere on Matrix - alongside communities bridged from Freenode and Slack; the native Matrix communities for Mozilla, KDE, GNOME communities etc. We’re hopeful that glueing everything together via Matrix will usher in a new age of open and defragmented dev collaboration, a bit like we used to have on IRC, back in the day.
+So, suddenly all the developer communities previously living only in Gitter ([Scala](https://gitter.im/scala), [Node](https://gitter.im/nodejs/home), [Webpack](https://gitter.im/webpack), [Angular](https://gitter.im/angular), [Rails](https://gitter.im/rails) and thousands of others) are now available to anyone anywhere on Matrix - alongside communities bridged from Freenode and Slack; the native Matrix communities for Mozilla, KDE, GNOME communities etc. We’re hopeful that glueing everything together via Matrix will usher in a new age of open and defragmented dev collaboration, a bit like we used to have on IRC, back in the day.
 
 This is also great news for mobile Gitter users - as the original mobile Gitter clients have been in a [holding pattern for over a year](https://gitlab.com/gitlab-org/gitter/webapp/-/issues/2281), and native Matrix support for Gitter means they are now officially deprecated in favour of Element (or indeed any other mobile Matrix client).
 


### PR DESCRIPTION
Fix mismatch between talking about the Scala room and linking the Node.js one

Happened after I suggested using a more active room in https://github.com/matrix-org/matrix.org/pull/899. That person was after showing a room where the community name was different from the room to make the syntax more clear.