### PR TITLE
Update Gitter bridge section to point to the new native bridge

### DIFF
--- a/gatsby/content/projects/2016-02-10-matrix-appservice-gitter.mdx
+++ b/gatsby/content/projects/2016-02-10-matrix-appservice-gitter.mdx
@@ -1,11 +1,11 @@
 ---
 layout: project
 title: matrix-appservice-gitter
-categories: 
- - bridge
+categories:
+  - bridge
 description: This project bridges to Matrix, via the AS API on the Matrix side, and a Gitter user on the Gitter side.
 author: LeoNerd
-maturity: Early Beta
+maturity: Not actively maintained
 language: JavaScript
 license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-appservice-gitter
@@ -13,6 +13,8 @@ thumbnail: /docs/projects/images/gitter-logo.svg
 bridges: Gitter
 featured: true
 ---
+
+**Note:** This project is now deprecated in favor of the native Gitter bridge
 
 This project bridges [Gitter](https://gitter.im) to Matrix, via the AS API on the Matrix side, and a Gitter user on the Gitter side.
 

--- a/gatsby/content/projects/2020-01-04-native-gitter-bridge.mdx
+++ b/gatsby/content/projects/2020-01-04-native-gitter-bridge.mdx
@@ -1,0 +1,37 @@
+---
+layout: project
+title: Native Gitter bridge
+categories:
+  - bridge
+description: Bridges Gitter to the Matrix network
+author: Gitter
+maturity: Released
+language: JavaScript
+license: Apache-2.0
+repo: https://gitlab.com/gitterHQ/webapp
+thumbnail: /docs/projects/images/gitter-logo.svg
+bridges: Gitter
+featured: true
+---
+
+This project bridges [Gitter](https://gitter.im) to Matrix and is already hosted for you. It creates portal rooms for every public room on Gitter which you can join via `#org_repo:gitter.im` (just replace the `/` in the Gitter URI with an underscore `_`). For example https://gitter.im/nodejs/node corresponds to [#nodejs_node:gitter.im]](https://matrix.to/#/#nodejs_node:gitter.im).
+
+If you're already using [Element](https://element.io), you can browse all of the Gitter rooms in the public room directory (switch to the `gitter.im` server).
+
+✓ Public Chats  
+✗ Private Chats  
+✗ 1:1 Chats  
+✓ Native feeling usernames/avatar on both sides (virtual users)
+✓ Replies / Threaded conversations
+✓ Formatted Messages
+✓ Mentions
+✓ Edits
+✓ Redactions/Deletions
+✓ Status `/me` messages
+✓ Media/Files  
+✗ Reactions
+✗ Backfilling history  
+✗ Read Receipts  
+✗ Typing notifications
+
+If you're curious about the bridge, there is a great overview of the capabilities and future plans in [this Matrix blog post](https://matrix.org/blog/2020/12/07/gitter-now-speaks-matrix).


### PR DESCRIPTION
Update [Gitter bridge section](https://matrix.org/bridges/) to point to the new native bridge

Fix https://github.com/matrix-org/matrix.org/issues/903