### PR TITLE
Fix some formatting typos with the Gitter bridge section

### DIFF
--- a/gatsby/content/projects/2016-02-10-matrix-appservice-gitter.mdx
+++ b/gatsby/content/projects/2016-02-10-matrix-appservice-gitter.mdx
@@ -11,7 +11,7 @@ license: Apache-2.0
 repo: https://github.com/matrix-org/matrix-appservice-gitter
 thumbnail: /docs/projects/images/gitter-logo.svg
 bridges: Gitter
-featured: true
+featured: false
 ---
 
 **Note:** This project is now deprecated in favor of the native Gitter bridge

--- a/gatsby/content/projects/2020-01-04-native-gitter-bridge.mdx
+++ b/gatsby/content/projects/2020-01-04-native-gitter-bridge.mdx
@@ -9,12 +9,13 @@ maturity: Released
 language: JavaScript
 license: Apache-2.0
 repo: https://gitlab.com/gitterHQ/webapp
+room: "#gitter:matrix.org"
 thumbnail: /docs/projects/images/gitter-logo.svg
 bridges: Gitter
 featured: true
 ---
 
-This project bridges [Gitter](https://gitter.im) to Matrix and is already hosted for you. It creates portal rooms for every public room on Gitter which you can join via `#org_repo:gitter.im` (just replace the `/` in the Gitter URI with an underscore `_`). For example https://gitter.im/nodejs/node corresponds to [#nodejs_node:gitter.im]](https://matrix.to/#/#nodejs_node:gitter.im).
+This project bridges [Gitter](https://gitter.im) to Matrix and is already hosted for you. It creates portal rooms for every public room on Gitter which you can join via `#org_repo:gitter.im` (just replace the `/` in the Gitter URI with an underscore `_`). For example https://gitter.im/nodejs/node corresponds to [#nodejs_node:gitter.im](https://matrix.to/#/#nodejs_node:gitter.im).
 
 If you're already using [Element](https://element.io), you can browse all of the Gitter rooms in the public room directory (switch to the `gitter.im` server).
 
@@ -22,7 +23,7 @@ If you're already using [Element](https://element.io), you can browse all of the
 ✗ Private Chats  
 ✗ 1:1 Chats  
 ✓ Native feeling usernames/avatar on both sides (virtual users)
-✓ Replies / Threaded conversations
+✓ Replies/Threaded conversations
 ✓ Formatted Messages
 ✓ Mentions
 ✓ Edits


### PR DESCRIPTION
Fix some formatting typos with the Gitter bridge section: https://matrix.org/bridges/#gitter

Part of https://github.com/matrix-org/matrix.org/issues/903

Follow-up to https://github.com/matrix-org/matrix.org/pull/919