### PR TITLE
Add node-red-contrib-matrixbot to Other

### DIFF
--- a/gatsby/content/projects/other/node-red-contrib-matrixbot.mdx
+++ b/gatsby/content/projects/other/node-red-contrib-matrixbot.mdx
@@ -1,0 +1,17 @@
+---
+layout: projectimage
+title: Node-RED-contrib-matrixbot
+categories:
+ - other
+description: Node-RED nodes to read and send messages and files to Matrix chatrooms.
+author: Plague Doctor
+home: https://gitlab.com/Plague_Doctor/node-red-contrib-matrixbot
+language: javascript
+license: GPL-3.0-or-later
+repo: https://gitlab.com/Plague_Doctor/node-red-contrib-matrixbot
+maturity: Beta
+---
+
+This package extends the original 'node-red-contrib-matrixbot' created by mlopezr (https://github.com/mlopezr/node-red-contrib-matrixbot).
+
+Now you can send files and photos to your chatrooms directly from Node-RED.


### PR DESCRIPTION
Node-RED nodes to read and send messages and files (photos) to Matrix chatrooms.