### PR TITLE
Update 2018-12-27-fluffychat.mdx

### DIFF
--- a/gatsby/content/projects/2018-12-27-fluffychat.mdx
+++ b/gatsby/content/projects/2018-12-27-fluffychat.mdx
@@ -9,7 +9,7 @@ author: Christian Pauly
 maturity: Released
 language: Flutter
 license: AGPL-3.0-only
-repo: https://gitlab.com/ChristianPauly/fluffychat-flutter
+repo: https://gitlab.com/famedly/fluffychat
 screenshot: /docs/projects/images/fluffychat-screenshot.png
 room: "#fluffychat:matrix.org"
 slug: fluffychat


### PR DESCRIPTION
repo was moved: 
Project 'ChristianPauly/fluffychat-flutter' was moved to 'famedly/fluffychat'. Please update any links and bookmarks that may still have the old path.