### PR TITLE
Changed the copyright year in the footer from 2020 to 2021

### DIFF
--- a/gatsby/src/components/Footer.js
+++ b/gatsby/src/components/Footer.js
@@ -59,7 +59,7 @@ const Footer = () => (
           <img src="/images/twitter.svg" alt="" className="mxfooter__icon" />
         </a>
       </div>
-      <p className="mxfooter__text">© 2020 The Matrix.org Foundation C.I.C.</p>
+      <p className="mxfooter__text">© 2021 The Matrix.org Foundation C.I.C.</p>
     </div>
   </div>
 


### PR DESCRIPTION
![Screen Shot 2021-02-01 at 11 51 47 AM](https://user-images.githubusercontent.com/19155609/106455279-e0cda900-6483-11eb-8c69-51e94ef07ddc.png)
