### PR TITLE
Remove expired Github profile link.

### DIFF
--- a/gatsby/content/blog/2019/10/2019-10-04-twim.mdx
+++ b/gatsby/content/blog/2019/10/2019-10-04-twim.mdx
@@ -73,7 +73,7 @@ Check out the [announcement post](https://matrix.org/blog/2019/10/03/matrix-apps
 
 [tulir](https://matrix.to/#/@tulir:maunium.net) said:
 
-> mautrix-telegram will soon be able to bridge animated stickers to matrix as images or videos, thanks to [a pull request](https://github.com/tulir/mautrix-telegram/pull/366) by [@Eramde](https://github.com/Eramde)
+> mautrix-telegram will soon be able to bridge animated stickers to matrix as images or videos, thanks to [a pull request](https://github.com/tulir/mautrix-telegram/pull/366) by Eramde.
 
 ## Dept of Clients 📱
 


### PR DESCRIPTION
The mentioned user deleted their profile and it was subsequently registered by another as a broken link hijacking POC. No risk, but may confuse someone in the unlikely event that they follow it.