### PR TITLE
docs: mention up-to-date tutorial more aggressively

### DIFF
--- a/gatsby/content/blog/2015/04/904.mdx
+++ b/gatsby/content/blog/2015/04/904.mdx
@@ -6,6 +6,8 @@ categories:
 author: Matthew Hodgson
 ---
 
+<h2>Note: This blog post is outdated, and an up-to-date tutorial is located <a href="https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.md">on the synapse project repo</a></h2>
+
 Synapse has had support for exporting a comprehensive range of metrics via HTTP since 0.8.1 - we added this to help quantify the benefits of all the performance work which is going on currently in advance of Synapse 0.9. If you're interested in monitoring your own synapse and seeing what's going on using something like Prometheus, Leo just wrote a quick tutorial on getting up and running:
 
 <h4>How to monitor Synapse metrics using Prometheus</h4>

--- a/gatsby/content/blog/2015/04/904.mdx
+++ b/gatsby/content/blog/2015/04/904.mdx
@@ -56,4 +56,4 @@ And the end result looks something like...
 
 ...amongst many many other system & application metrics.
 
-You can grab the latest version of the tutorial at <a href="https://github.com/matrix-org/synapse/blob/develop/docs/metrics-howto.rst">https://github.com/matrix-org/synapse/blob/develop/docs/metrics-howto.rst</a> - thanks to Leo for writing it up.  Any questions, let us know!
+You can grab the latest version of the tutorial at <a href="https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.md">https://github.com/matrix-org/synapse/blob/master/docs/metrics-howto.md</a> - thanks to Leo for writing it up.  Any questions, let us know!


### PR DESCRIPTION
Currently, there is only a small note at the bottom of the article, which also is a dead link, that there is an up-to-date version of this tutorial.
This commits adds a more aggressive note at the beginning of the tutorial, as very few of the configs in the article stayed that way until today,
but the blog post itself shows up in search engines pretty high up