### PR TITLE
Update matrix-appservice-bridge

### DIFF
--- a/gatsby/content/projects/2015-08-19-matrix-appservice-bridge.mdx
+++ b/gatsby/content/projects/2015-08-19-matrix-appservice-bridge.mdx
@@ -3,10 +3,11 @@ layout: project
 title: matrix-appservice-bridge
 categories: 
  - as
-author: Kegsay
-language: JavaScript
+author: Kegsay, Matrix.org
+language: TypeScript
 license: Apache-2.0
-maturity: Early Beta
+maturity: Stable
+repo: https://github.com/matrix-org/matrix-appservice-bridge
 ---
 
 This library sits on top of the [core application service library](https://github.com/matrix-org/matrix-appservice-node) and provides an API for setting up bridges quickly.


### PR DESCRIPTION
* It's Stable (v2.5.0) and we use it in our stable Slack and IRC bridges.
* The language changed to TypeScript
* [ ] It could get moved into the `sdk` sub-folder. (does that mess with its URL?)