### PR TITLE
Use Element instead of riot.im in some links

### DIFF
--- a/gatsby/content/projects/clients/element.mdx
+++ b/gatsby/content/projects/clients/element.mdx
@@ -10,7 +10,7 @@ author: Element
 maturity: Stable
 language: JavaScript
 license: Apache-2.0
-repo: https://github.com/vector-im/riot-web/
+repo: https://github.com/vector-im/element-web/
 home: https://element.io/
 screenshot: /docs/projects/images/riot-web-large.png
 room: "#element-web:matrix.org"
@@ -58,7 +58,7 @@ features:
 
 [Element](https://element.io) is a glossy Matrix client for the web built on top of [matrix-react-sdk](https://matrix.org/docs/projects/sdk/matrix.org-react-sdk.html) with an emphasis on performance and usability.
 
-You can use it at [https://app.element.io](https://app.element.io), read more at [https://riot.im](https://riot.im) and get the source from [GitHub](https://github.com/vector-im/vector-web)!
+You can use it at [https://app.element.io](https://app.element.io), read more at [https://element.io/](https://element.io) and get the source from [GitHub](https://github.com/vector-im/element-web)!
 
 There is also a [desktop version](https://element.io/get-started).
 


### PR DESCRIPTION
![Screenshot_20210416_145325](https://user-images.githubusercontent.com/25768714/115027053-827d6780-9ec3-11eb-9950-46de98b9cd07.png)
