### PR TITLE
Add Heisenbridge to IRC bridges

### DIFF
--- a/gatsby/content/projects/bridges/heisenbridge.mdx
+++ b/gatsby/content/projects/bridges/heisenbridge.mdx
@@ -1,0 +1,19 @@
+---
+layout: project
+title: Heisenbridge
+categories:
+ - bridge
+description: a bouncer-style Matrix IRC bridge
+author: hifi
+home: https://github.com/hifi/heisenbridge
+language: Python
+license: MIT
+repo: https://github.com/hifi/heisenbridge
+room: "#heisenbridge:vi.fi"
+thumbnail: /images/irc.png
+maturity: Alpha
+featured: true
+bridges: IRC
+---
+
+A bouncer-style Matrix IRC bridge with focus on simplicity for personal use on your own homeserver. No complex configuration files or databases required.


### PR DESCRIPTION
:airplane: Whoosh, a challenger appears! :partying_face: 

I looked up other projects along the template to get it set up like the other bridges were so it shows up below matrix-appservice-irc. I don't know if it's allowed to add the featured flag so advice if I need to revise this.

Thanks.