### PR TITLE
Vertically space reading content more and consistently

### DIFF
--- a/gatsby/src/components/Subline.js
+++ b/gatsby/src/components/Subline.js
@@ -1,11 +1,11 @@
-import styled from 'styled-components'
+import styled from 'styled-components';
 
 const Subline = styled.div`
   font-size: ${props => props.theme.fontSize.small};
   color: ${props => props.theme.colors.grey.light};
   ${props => props.sectionTitle && 'margin-top: -3rem'};
-  ${props => props.sectionTitle && 'margin-bottom: 4rem'};
+  ${props => (props.sectionTitle && 'margin-bottom: 4rem') || 'margin-bottom: 1em;'};
   ${props => props.sectionTitle && 'text-align: center'};
-`
+`;
 
-export default Subline
+export default Subline;

--- a/gatsby/static/css/webflow-overrides.css
+++ b/gatsby/static/css/webflow-overrides.css
@@ -33,6 +33,29 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
 }
 
+p:not(:last-child),
+blockquote:not(:last-child),
+figure:not(:last-child),
+ul:not(:last-child),
+ol:not(:last-child) {
+  margin-bottom: 1em;
+}
+
+/* Reset webflow.js defaults */
+p:last-child,
+blockquote:last-child,
+figure:last-child,
+ul:last-child,
+ol:last-child {
+  margin-bottom: 0;
+}
+
+blockquote {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+
 .mximagine {
   font-size: 18px;
   font-weight: normal;
@@ -253,6 +276,10 @@ label {
 
 .mxcontent {
   width: 100%;
+}
+
+.mxcontent__main {
+  line-height: 1.8em;
 }
 
 .mxclientcard {

--- a/gatsby/static/css/webflow-overrides.css
+++ b/gatsby/static/css/webflow-overrides.css
@@ -278,10 +278,6 @@ label {
   width: 100%;
 }
 
-.mxcontent__main {
-  line-height: 1.8em;
-}
-
 .mxclientcard {
   margin: 2px;
   background:#f4f4f4;


### PR DESCRIPTION
Vertically space reading content more and consistently.

This is only a basic pass to make a blog post more readable. Lots more to improve in future iterations.

The screenshots from Windows are a lot better to review imo because they aren't retina huge but didn't want to scare anyone off with the unfamiliar font so macOS is available. Might be easier to check this out locally and compare to the live version of the site.

<details>

<summary>Screenshots from macOS</summary>

## A more text based blog post

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/117381952-eb447800-aea2-11eb-8981-542dfe848121.png) | ![](https://user-images.githubusercontent.com/558581/117381862-a4ef1900-aea2-11eb-9482-3cdad4dd0290.png)



## TWIM

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/117382156-77ef3600-aea3-11eb-9dc2-9b891b456869.png) | ![](https://user-images.githubusercontent.com/558581/117381889-bc2e0680-aea2-11eb-83bd-daaf0163044a.png)

</details>



<details>

<summary>Screenshots from Windows</summary>

## A more text based blog post

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/117382507-4d51ad00-aea4-11eb-9e71-95530bca814d.png) | ![](https://user-images.githubusercontent.com/558581/117382717-c0f3ba00-aea4-11eb-857c-a108071b2e10.png)

## TWIM

Before | After
--- | ---
![](https://user-images.githubusercontent.com/558581/117382533-593d6f00-aea4-11eb-90f5-f4b2d85ffb6d.png) | ![](https://user-images.githubusercontent.com/558581/117382750-d10b9980-aea4-11eb-9c22-6cfc85cab02a.png)

</details>

