### PR TITLE
2021-05-07-twim.mdx: New IRC command is !unlink

### DIFF
--- a/gatsby/content/blog/2021/05/2021-05-07-twim.mdx
+++ b/gatsby/content/blog/2021/05/2021-05-07-twim.mdx
@@ -200,7 +200,7 @@ Additionally, [Nico (@deepbluev7:neko.dev)](https://matrix.to/#/@deepbluev7:neko
 >
 > * Allow third-party bridged users to change their nickname with the self-serve command `!irc nick anothername` (thanks vranki)
 >
-> * Allow room moderators and bridge admins to unlink rooms using an `!unlink` command
+> * Allow room moderators and bridge admins to unlink rooms using the `!unlink` command
 > * Add support for specifying the paste bin limit in room state with the `org.matrix.appservice-irc.config` event type.
 >
 > Please test it and flag any issues you have upgrading:

--- a/gatsby/content/blog/2021/05/2021-05-07-twim.mdx
+++ b/gatsby/content/blog/2021/05/2021-05-07-twim.mdx
@@ -200,7 +200,7 @@ Additionally, [Nico (@deepbluev7:neko.dev)](https://matrix.to/#/@deepbluev7:neko
 >
 > * Allow third-party bridged users to change their nickname with the self-serve command `!irc nick anothername` (thanks vranki)
 >
-> * Allow room moderators and bridge admins to unlink rooms using an `!unbridge` command
+> * Allow room moderators and bridge admins to unlink rooms using an `!unlink` command
 > * Add support for specifying the paste bin limit in room state with the `org.matrix.appservice-irc.config` event type.
 >
 > Please test it and flag any issues you have upgrading:


### PR DESCRIPTION
I had gotten that wrong. It should say `!unlink` instead of `!unbridge`.

https://github.com/matrix-org/matrix-appservice-irc/pull/1298