### PR TITLE
Update "Riot->Element" in article title and remove backslashes

### DIFF
--- a/gatsby/content/docs/2016-05-05-client-server.mdx
+++ b/gatsby/content/docs/2016-05-05-client-server.mdx
@@ -97,7 +97,7 @@ them. To create a room:
         "room_id": "!asfLdzLnOdGRkdPZWu:localhost"
     }
 
-The \"room alias\" is a human-readable string which can be shared with
+The "room alias" is a human-readable string which can be shared with
 other users so they can join a room, rather than the room ID which is a
 randomly generated string. You can have multiple room aliases per room.
 
@@ -177,8 +177,8 @@ https://jsfiddle.net/gh/get/jquery/1.8.3/matrix-org/matrix.org/tree/master/jekyl
 
 ### Getting all state
 
-If the client doesn\'t know any information on the rooms the user is
-invited/joined on, they can get all the user\'s state for all rooms:
+If the client doesn't know any information on the rooms the user is
+invited/joined on, they can get all the user's state for all rooms:
 
     curl -XGET "https://localhost:8448/_matrix/client/r0/sync?access_token=YOUR_ACCESS_TOKEN"
 

--- a/gatsby/src/pages/docs/develop.js
+++ b/gatsby/src/pages/docs/develop.js
@@ -35,7 +35,7 @@ const GuidesDevelop = ({ data }) => {
 
   }
   addArticleToGroup("Introduction", "Enter the Matrix", "Brendan Abolivier", "https://brendan.abolivier.bzh/enter-the-matrix/");
-  addArticleToGroup("Introduction", "Obtain Access Tokens from Riot", "TravisR", "https://t2bot.io/docs/access_tokens/");
+  addArticleToGroup("Introduction", "Obtain Access Tokens from Element", "TravisR", "https://t2bot.io/docs/access_tokens/");
   addArticleToGroup("Introduction", "Testing the matrix.org client-server API using cURL", "Rick Cogley", "https://gist.github.com/RickCogley/69f430d4418ae5498e8febab44d241c9");
   addArticleToGroup("Encryption", "An introduction to end-to-end encryption in Matrix and Riot", "Hubert Chathi", "https://www.uhoreg.ca/blog/20170910-2110");
   return (<Layout navmode="develop">


### PR DESCRIPTION
* Travis has renamed his article after the Riot->Element rebranding.

## Also changed
* In the article "Client Server API" the backslashes are visible.

## Unrelated notes
* I find the Feedback overlay to be incredibly annoying. Dismissing it brings it back several times even when staying on the same article. As a reader on a mobile phone, I wish it wasn't a floating overlay but a form at the bottom of the page.