### PR TITLE
Hang link anchors off to the side so heading text aligns with body

### DIFF
--- a/gatsby/static/css/webflow-overrides.css
+++ b/gatsby/static/css/webflow-overrides.css
@@ -33,6 +33,17 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: bold;
 }
 
+.anchor {
+  margin-left: -20px;
+  padding-right: 4px;
+}
+
+@media (max-width: 767px) {
+  .anchor {
+    margin-left: 0;
+  }
+}
+
 p:not(:last-child),
 blockquote:not(:last-child),
 figure:not(:last-child),
@@ -51,8 +62,20 @@ ol:last-child {
 }
 
 blockquote {
+  /* Add some space for the heading anchors to hang off into */
+  padding-left: 28px;
+
   font-size: inherit;
   line-height: inherit;
+}
+
+/* Override the media query which inlines the anchor again.
+   In a blockquote, we still have space on the left for it
+   to float off to the side.
+*/
+blockquote .anchor {
+  margin-left: -20px;
+  padding-right: 4px;
 }
 
 


### PR DESCRIPTION
Hang link anchors off to the side so heading text aligns with body


Before | After
--- | ---
<img width="557" alt="Screen Shot 2021-05-13 at 8 02 52 PM" src="https://user-images.githubusercontent.com/558581/118205560-3cfe7c80-b426-11eb-980b-79ebf0835f8f.png"> | <img width="555" alt="Screen Shot 2021-05-13 at 8 01 53 PM" src="https://user-images.githubusercontent.com/558581/118205557-3bcd4f80-b426-11eb-9ac8-cb896f8a6dee.png">



Responsive:

![](https://user-images.githubusercontent.com/558581/118205359-c8c3d900-b425-11eb-8f8e-45bd874be192.gif)

