### PR TITLE
Update link to element Fedora COPR repository

### DIFF
--- a/gatsby/content/projects/clients/element.mdx
+++ b/gatsby/content/projects/clients/element.mdx
@@ -66,7 +66,7 @@ There is also a [desktop version](https://element.io/get-started).
 
 Element was previously known as Riot ("riot-web".) Several packages were made available:
 
-Taw has created RPM package builds for Fedora, CentOS, and Red Hat Enterprise Linux which are available via [GitHub](https://github.com/taw00/riot-rpm/) and [Fedora COPR](https://copr.fedorainfracloud.org/coprs/taw/Riot/).
+Taw has created RPM package builds for Fedora, CentOS, and Red Hat Enterprise Linux which are available via [GitHub](https://github.com/taw00/element-rpm/) and [Fedora COPR](https://copr.fedorainfracloud.org/coprs/taw/element/).
 
 Josué Tille has contributed a [Yunohost app](https://github.com/Josue-T/riot_ynh).
 


### PR DESCRIPTION
The riot COPR is out of date. Link to the new element one.