### PR TITLE
[minor] Remove references to 2019 in Moderation guide

### DIFF
--- a/gatsby/content/docs/2019-04-29-moderation.mdx
+++ b/gatsby/content/docs/2019-04-29-moderation.mdx
@@ -19,7 +19,7 @@ A large open communication network (much like email or the web itself) comes wit
 *   ensuring that server administrators can enforce terms of service on how their servers are used
 *   ensuring that users themselves are empowered to filter out content they do not wish to see.
 
-We consider effective content management to be the single biggest remaining risk to the long-term success of Matrix as a project, and we’re investing as much time as we can into building out and improving our moderation & reputation tools.  We would like to focus on this even more during 2019, and are currently looking for dedicated funding to achieve this - please email us at funding-at-matrix.org if you have the interest and resources to sponsor this work.
+We consider effective content management to be the single biggest remaining risk to the long-term success of Matrix as a project, and we’re investing as much time as we can into building out and improving our moderation & reputation tools.  We would like to focus on this even more, and are currently looking for dedicated funding to achieve this - please email us at funding-at-matrix.org if you have the interest and resources to sponsor this work.
 
 
 ## Moderating rooms
@@ -327,7 +327,7 @@ This model should also be robust against voting rings and sybil attacks, as sybi
 
 Similarly, moderators for a given room could choose to publish their official reputation data in order to quantify the code-of-conduct for their room - perhaps deriving it from an existing reputation source (e.g. the matrix core team could publish one for the rooms they moderate), or simply by seeding it based on the moderators’ upvotes/downvotes within that room or community.
 
-Thus users could choose which content filters to adopt, and visualise how they are applied, and curate whatever view of Matrix they desire.  Obviously this is very much an area of active research, but we are hoping to find financial support to experiment with implementing this during 2019.
+Thus users could choose which content filters to adopt, and visualise how they are applied, and curate whatever view of Matrix they desire.  Obviously this is very much an area of active research, but we are hoping to find financial support to experiment with implementing this.
 
 After all, the challenge of filtering objectionable/misleading content on the internet is not specific to Matrix, nor even to decentralised systems, and we hope that this work will be directly applicable elsewhere.  It is also becoming more of a legal concern, with certain governments mandating content filtering rules to messaging providers - meaning that servers running in affected territories may be legally obligated to provide their users with content filtering tools of this nature.
 


### PR DESCRIPTION
2019 has been and gone, so remove future-tense references to 2019. The actual validity of the information should be verified by a contributor who is familiar with moderation features.