### PR TITLE
Make SchildiChat Web/Desktop actually appear under clients

### DIFF
--- a/gatsby/content/projects/clients/schildichat-desktop.mdx
+++ b/gatsby/content/projects/clients/schildichat-desktop.mdx
@@ -1,24 +1,26 @@
 ---
 layout: projectimage
 title: SchildiChat Web/Desktop
+slug: schildichat
 categories:
- - client
+    - client
+thumbnail: /docs/projects/images/schildichat-desktop.png
 description: Based on Element, with a more traditional instant messaging experience.
 author: su-ex, SpiritCroc
-home: https://schildi.chat/
+maturity: Stable
 language: JavaScript
 license: Apache-2.0
 repo: https://github.com/SchildiChat/schildichat-desktop
-room: "#schildichat-web:matrix.org"
-slug: schildichat
-thumbnail: /docs/projects/images/schildichat-desktop.png
+home: https://schildi.chat/
 screenshot: /docs/projects/images/schildichat-desktop.png
-maturity: Stable
+room: "#schildichat-web:matrix.org"
+SDK: matrix-js-sdk, matrix-react-sdk
 platforms:
-    - Windows
     - Linux
     - Mac
+    - Windows
     - Web
+featured: true
 features:
     Room directory: yes
     Room tag showing: yes


### PR DESCRIPTION
Till now it's missing although added.