### PR TITLE
Un-feature Pattle and Matrix Dart SDK.

### DIFF
--- a/gatsby/content/projects/clients/pattle.mdx
+++ b/gatsby/content/projects/clients/pattle.mdx
@@ -1,12 +1,12 @@
 ---
 layout: projectimage
 title: Pattle
-categories: 
+categories:
  - client
 thumbnail: /docs/projects/images/pattle_thumb.png
 description: A user-friendly app for Android and iOS made with Flutter
 author: Wilko Manger
-maturity: Alpha
+maturity: No longer mantained
 language: Dart
 license: AGPL-3.0-or-later
 repo: https://git.pattle.im/pattle/app
@@ -15,7 +15,7 @@ room: "#app:pattle.im"
 platforms:
     - Android
     - iOS
-featured: true
+featured: false
 sort_order: 600
 features:
     Room directory: no

--- a/gatsby/content/projects/sdks/matrix-dart-sdk.mdx
+++ b/gatsby/content/projects/sdks/matrix-dart-sdk.mdx
@@ -5,7 +5,7 @@ categories:
   - sdk
 description: An SDK written in Dart to connect to Matrix, usable in Flutter
 repo: https://git.pattle.im/pattle/library/matrix-dart-sdk
-featured: true
+featured: false
 language: Dart
 author: Wilko Manger
 license: MPL-2.0
@@ -15,8 +15,12 @@ e2e: "No"
 thumbnail: /docs/projects/images/dart.png
 screenshot: /docs/projects/images/dart.png
 sort_order: 600
-maturity: Beta
+maturity: No longer maintained
 ---
+
+**Notice: Since this SDK is no longer maintained, its usage is no longer
+recommended. If you're looking for a Matrix SDK in Dart, the [Famedly Matrix
+SDK](https://gitlab.com/famedly/company/frontend/famedlysdk) is a good option.**
 
 An SDK written in Dart to connect to Matrix, usable for Flutter.
 


### PR DESCRIPTION
These are no longer maintained and frequently confuse people, so it's best not to have them linked up front. Pattle is also no longer available in app stores.