### PR TITLE
[BLOG] A typo on the latest blog (emailed suggestion)

### DIFF
--- a/gatsby/content/blog/2021/06/2021-06-30-synapse-1.37.1-released.mdx
+++ b/gatsby/content/blog/2021/06/2021-06-30-synapse-1.37.1-released.mdx
@@ -17,7 +17,7 @@ We're happy to say that Synapse 1.37.1 [fixes this](https://github.com/matrix-or
 
 **Please upgrade to Synapse 1.37.1 as soon as possible, in order to increase resilience to any other traffic spikes.**
 
-**Also, we highly recommend that you disable open registration or, if you keep it enabled, use SSO or require email validation to avoid abusive signups. Empirically a CAPTCHA is not enough. Otherwise you may find your server blocked all over the place if it is hosting spambots.**
+**Also, we highly recommend that you disable open registration or, if you keep it enabled, use SSO or require email validation to avoid abusive signups. Empirically adding a CAPTCHA is not enough. Otherwise you may find your server blocked all over the place if it is hosting spambots.**
 
 **Finally, if your server has open registration, PLEASE check whether spambots have been registered on your server, and deactivate them.  Once deactivated, you will need to contact abuse@matrix.org to request that blocks on your server are removed**.
 


### PR DESCRIPTION
From an e-mail with the subject: "[BLOG] A typo on the latest blog"

In my opinion this is not adding a lot of meaning. It seems pretty clear that a CAPTCHA would be added.
Still I want to bring this suggestion to you, as an e-mail proposed to make this change.