### PR TITLE
Added listing for matrix-faq bot

### DIFF
--- a/gatsby/content/projects/bots/hwittenborn-matrix-faq.mdx
+++ b/gatsby/content/projects/bots/hwittenborn-matrix-faq.mdx
@@ -1,0 +1,29 @@
+---
+layout: projectimage
+title: hwittenborn / matrix-faq
+categories:
+ - bot
+description: Bot to provide a list of FAQs to users
+author: Hunter Wittenborn
+language: Python
+license: GPL-3.0-or-later
+repo: https://github.com/hwittenborn/matrix-faq
+maturity: Late Beta
+featured: true
+---
+
+matrix-faq is a bot that allows for predefined messages to be sent with shorter, command-like aliases.
+
+For example, you could run the following command in a Matrix room:
+
+```sh
+!faq projects
+```
+
+Which could then return the following text:
+```
+Projects I'm currently working on:
+
+- Foo (github.com/user/foo)
+- Bar (github.com/user/bar)
+```


### PR DESCRIPTION
This bot serves the same function as [Matrixcoffee/FAQBot](https://matrix.org/docs/projects/bot/faq-bot) from an end-user perspective of actually interacting with the bot, but the backend for configuration has some notable differences, such as allowing the specification of a prefix (not sure if FAQBot allows that or not) and specifying the FAQ messages in Markdown instead of Org Mode.