### PR TITLE
Add gatsby clean as npm script

### DIFF
--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -54,6 +54,7 @@
   "main": "n/a",
   "scripts": {
     "build": "gatsby build",
+    "clean": "gatsby clean",
     "dev": "gatsby develop -o",
     "develop": "gatsby develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
This way one can cleanup with `npm run clean` even though they don’t have gatsby installed system wide (as suggested by the README).