### PR TITLE
Make the LINE bridge appear

### DIFF
--- a/gatsby/content/projects/bridges/matrix-puppeteer-line.mdx
+++ b/gatsby/content/projects/bridges/matrix-puppeteer-line.mdx
@@ -12,6 +12,7 @@ repo: https://src.miscworks.net/fair/matrix-puppeteer-line.git
 room: "#matrix-puppeteer-line:miscworks.net"
 thumbnail: /docs/projects/images/line-logo.png
 maturity: Early Beta
+featured: true
 bridges: LINE
 ---
 


### PR DESCRIPTION
Make the LINE bridge appear

As pointed out @LecrisUT, https://github.com/matrix-org/matrix.org/pull/1019#issuecomment-890634897


http://localhost:8000/bridges/#line

<img width="1025" alt="" src="https://user-images.githubusercontent.com/558581/129654829-3af47447-15b2-4995-aa18-567aa4b55584.png">
