### PR TITLE
clients: mnotify: update homepage and repo links

### DIFF
--- a/gatsby/content/projects/clients/mnotify.mdx
+++ b/gatsby/content/projects/clients/mnotify.mdx
@@ -5,10 +5,10 @@ categories:
  - client
 description: A simple matrix cli client. Primarily designed for sending notifications.
 author: Stefan Tatschner
-home: https://sr.ht/~rumpelsepp/mnotify
+home: https://codeberg.org/rumpelsepp/mnotify/
 language: Go
 license: GPL-3.0-or-later
-repo: https://git.sr.ht/~rumpelsepp/mnotify
+repo: https://codeberg.org/rumpelsepp/mnotify/
 # room: "#my-first-matrix-projects-room:homeserver.tld" # nb the quotes are needed as rooms start with #
 # thumbnail: /docs/projects/images/upload-a-thumbnail-image-to-the-images-subfolder.png
 # screenshot: /docs/projects/images/upload-a-bigger-image-for-your-project-page-to-the-images-subfolder.png


### PR DESCRIPTION
The repository was moved off of sr.ht.