### PR TITLE
👷 Port CI to Github Actions

### DIFF
--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Fetch the latest spec build, and apply styling to it.
+  # This step also sets up the OpenAPI UI.
   build-spec:
     name: "📖 Spec"
     runs-on: ubuntu-latest
@@ -37,6 +39,8 @@ jobs:
           name: styled-docs-artifact
           path: styled-docs.tar.gz
 
+  # Run jekyll. We run this in a custom docker image.
+  # See dockerfile in the `.buildkite` directory.
   build-jekyll:
     name: "🌐 Jekyll"
     runs-on: ubuntu-latest
@@ -58,6 +62,8 @@ jobs:
           name: spec-artifact
           path: jekyll-site.tar.gz
 
+  # Run gatsby. We also use a custom docker image for this, to avoid
+  # installing the entirety of npmjs for each build.
   build-gatsby:
     name: "🌐 Gatsby"
     runs-on: ubuntu-latest
@@ -104,6 +110,8 @@ jobs:
           name: guides-artifact
           path: implementation-guides/implementation-guides.tar.gz
 
+  # Merge the three sets of outputs together, together
+  # with the existing static stuff in `content`.
   package:
     name: "📦 Package"
     runs-on: ubuntu-latest

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -1,6 +1,35 @@
 name: "🌐 Build the matrix.org website"
 on: [workflow_dispatch, push, pull_request]
 jobs:
+  build-spec:
+    name: "📖 Spec"
+    runs-on: ubuntu-latest
+    container: "python:3.6"
+    steps:
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: "📥 matrix-doc OpenAPI artifact download"
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: main.yml
+          workflow_conclusion: success
+          repo: ${{ github.repository_owner }}/matrix-doc
+          branch: ${{ github.ref }}
+          name: openapi-artifact
+      - name: "📖 Update docs"
+        run: |
+          python3 -m venv env
+          env/bin/pip install requests
+          . env/bin/activate; scripts/update_docs.sh
+      - name: "📦 Tarball creation"
+        run: tar -czf styled-docs.tar.gz content/docs
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: styled-docs-artifact
+          path: styled-docs.tar.gz
   build-jekyll:
     name: "🌐 Jekyll"
     runs-on: ubuntu-latest

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -4,6 +4,7 @@ on:
     branches: master
   pull_request:
   workflow_dispatch:
+
 jobs:
   build-spec:
     name: "📖 Spec"
@@ -34,6 +35,7 @@ jobs:
         with:
           name: styled-docs-artifact
           path: styled-docs.tar.gz
+
   build-jekyll:
     name: "🌐 Jekyll"
     runs-on: ubuntu-latest
@@ -54,6 +56,7 @@ jobs:
         with:
           name: spec-artifact
           path: jekyll-site.tar.gz
+
   build-gatsby:
     name: "🌐 Gatsby"
     runs-on: ubuntu-latest
@@ -73,6 +76,7 @@ jobs:
         with:
           name: gatsby-artifact
           path: gatsby/gatsby-site.tar.gz
+
   build-guides:
     name: "📖 Implementation guides"
     runs-on: ubuntu-latest
@@ -98,6 +102,7 @@ jobs:
         with:
           name: guides-artifact
           path: implementation-guides/implementation-guides.tar.gz
+
   package:
     name: "📦 Package"
     runs-on: ubuntu-latest

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -1,0 +1,23 @@
+name: "🌐 Build the matrix.org website"
+on: [workflow_dispatch, push, pull_request]
+jobs:
+  build-gatsby:
+    name: "🌐 Gatsby"
+    runs-on: ubuntu-latest
+    container:
+      image: "matrixdotorg/matrixdotorg-gatsby:latest"
+    steps:
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+      - name: "🚧 Gatsby build"
+        run: ln -s /opt/gatsby/node_modules . && gatsby build
+        working-directory: gatsby
+      - name: "📦 Tarball creation"
+        run: tar -czf gatsby-site.tar.gz public
+        working-directory: gatsby
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: gatsby-artifact
+          path: gatsby/gatsby-site.tar.gz
+

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -1,6 +1,26 @@
 name: "🌐 Build the matrix.org website"
 on: [workflow_dispatch, push, pull_request]
 jobs:
+  build-jekyll:
+    name: "🌐 Jekyll"
+    runs-on: ubuntu-latest
+    container:
+      image: "matrixdotorg/matrixdotorg-build:0.2"
+    steps:
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+      - name: "🚧 Jekyll build"
+        run: |
+          . /env/bin/activate
+          ./jekyll/generate.sh
+          cp -rf ./pre-generated/* jekyll/_site/
+      - name: "📦 Tarball creation"
+        run: tar -czf jekyll-site.tar.gz jekyll/_site
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: spec-artifact
+          path: jekyll-site.tar.gz
   build-gatsby:
     name: "🌐 Gatsby"
     runs-on: ubuntu-latest

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -40,4 +40,29 @@ jobs:
         with:
           name: gatsby-artifact
           path: gatsby/gatsby-site.tar.gz
+  build-guides:
+    name: "📖 Implementation guides"
+    runs-on: ubuntu-latest
+    container:
+      image: "buildpack-deps"
+    steps:
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+      - name: "🚧 Build implementation guides"
+        run: |
+          wget https://github.com/rust-lang/mdBook/releases/download/v0.4.1/mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
+          tar -xf mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz
+          ./mdbook build server -d ${GITHUB_WORKSPACE}/implementation-guides/implementation-guides/server
+          ./mdbook build client -d ${GITHUB_WORKSPACE}/implementation-guides/implementation-guides/client
+          ./mdbook build application-services -d ${GITHUB_WORKSPACE}/implementation-guides/implementation-guides/application-services
+          cp index.html ./implementation-guides/
+        working-directory: implementation-guides
+      - name: "📦 Tarball creation"
+        run: tar -czf implementation-guides.tar.gz implementation-guides
+        working-directory: implementation-guides
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: guides-artifact
+          path: implementation-guides/implementation-guides.tar.gz
 

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: 'recursive'
       - name: "📥 matrix-doc OpenAPI artifact download"
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@6f8f427fb41886a66b82ea11a5a15d1454c79415
         with:
           workflow: main.yml
           workflow_conclusion: success

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -20,7 +20,7 @@ jobs:
           workflow: main.yml
           workflow_conclusion: success
           repo: ${{ github.repository_owner }}/matrix-doc
-          branch: ${{ github.ref }}
+          branch: main
           name: openapi-artifact
       - name: "📖 Update docs"
         run: |

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -1,7 +1,8 @@
 name: "🌐 Build the matrix.org website"
 on:
   push:
-    branches: master
+    branches:
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -1,5 +1,9 @@
 name: "🌐 Build the matrix.org website"
-on: [workflow_dispatch, push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
+  workflow_dispatch:
 jobs:
   build-spec:
     name: "📖 Spec"

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -94,4 +94,40 @@ jobs:
         with:
           name: guides-artifact
           path: implementation-guides/implementation-guides.tar.gz
+  package:
+    name: "📦 Package"
+    runs-on: ubuntu-latest
+    needs: [build-spec, build-jekyll, build-gatsby, build-guides]
+    steps:
+      - name: "📥 Source checkout"
+        uses: actions/checkout@v2
+      - name: "📥 Spec artifact download"
+        uses: actions/download-artifact@v2
+        with:
+          name: styled-docs-artifact
+      - name: "📥 Jekyll artifact download"
+        uses: actions/download-artifact@v2
+        with:
+          name: spec-artifact
+      - name: "📥 Gatsby artifact download"
+        uses: actions/download-artifact@v2
+        with:
+          name: gatsby-artifact
+      - name: "📥 Implementation guides artifact download"
+        uses: actions/download-artifact@v2
+        with:
+          name: guides-artifact
+      - name: "📦 Merge archives"
+        run: |
+          tar -xzvf styled-docs.tar.gz
+          tar -xzvf jekyll-site.tar.gz
+          cp -r jekyll/_site/{css,guides,howtos,projects} content/docs
+          tar -C content --strip-components=1 -xzf gatsby-site.tar.gz
+          tar -C content -xzf implementation-guides.tar.gz
+          tar -czf content.tar.gz content
+      - name: "📤 Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: merged-content-artifact
+          path: content.tar.gz
 

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -21,7 +21,7 @@ cd "$(dirname "$(dirname "${SELF}")")"
 
 SITE_BASE="$(pwd)"
 
-if [ -n "$BUILDKITE" ]; then
+if ! [ -z ${BUILDKITE_ACCESS_TOKEN+x} ]; then
   # grab and unpack the latest matrix-docs build from buildkite
   rm -rf assets.tar.gz assets
   scripts/fetch-buildkite-artifact matrix-dot-org matrix-doc assets.tar.gz

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -21,9 +21,8 @@ cd "$(dirname "$(dirname "${SELF}")")"
 
 SITE_BASE="$(pwd)"
 
-# grab and unpack the latest matrix-docs build from buildkite
-rm -rf assets.tar.gz assets
-scripts/fetch-buildkite-artifact matrix-dot-org matrix-doc assets.tar.gz
+# Unpack the latest matrix-docs build
+# It was fetched by Github Actions
 tar -xzf assets.tar.gz
 
 # copy the swagger UI into place

--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -21,8 +21,13 @@ cd "$(dirname "$(dirname "${SELF}")")"
 
 SITE_BASE="$(pwd)"
 
-# Unpack the latest matrix-docs build
-# It was fetched by Github Actions
+if [ -n "$BUILDKITE" ]; then
+  # grab and unpack the latest matrix-docs build from buildkite
+  rm -rf assets.tar.gz assets
+  scripts/fetch-buildkite-artifact matrix-dot-org matrix-doc assets.tar.gz
+fi
+
+# otherwise, assume the latest build was fetched by Github Actions.
 tar -xzf assets.tar.gz
 
 # copy the swagger UI into place


### PR DESCRIPTION
This is intended to replace the existing Buildkite one, but the latter can be removed at a latter point when all the bits are in place. The workflow can be seen working for the gh-actions branch at [the Actions tab](https://github.com/matrix-org/matrix.org/actions).