### PR TITLE
Fetch `main` build of spec, rather than `master`

### DIFF
--- a/scripts/fetch-buildkite-artifact
+++ b/scripts/fetch-buildkite-artifact
@@ -23,7 +23,7 @@ parser.add_argument(
 
 parser.add_argument(
     "--build-filter",
-    default="branch=master&state=passed",
+    default="branch=main&state=passed",
     help="Query string for the build filter. Default: %(default)s",
 )
 


### PR DESCRIPTION
cf https://github.com/matrix-org/matrix-doc/issues/3367