### PR TITLE
Remove outdated Gitter bridge reference

### DIFF
--- a/gatsby/content/docs/2017-03-11-types-of-bridging.mdx
+++ b/gatsby/content/docs/2017-03-11-types-of-bridging.mdx
@@ -50,7 +50,7 @@ Several obstacles exist to the proper implementation of double-puppeted bridges.
 
 ### Hybrid Relaybot Puppet Bridge
 
-This type of bridge is a combination single or double puppet bridge which tries to solve the problem of representing other users by means of the bridgebot technique.
+This type of bridge is a combination single or double puppet bridge which tries to solve the problem of representing other users by means of the bridgebot technique. [mautrix/telegram](https://github.com/mautrix/telegram) works in this way.
 
 ### Server-to-server bridging
 

--- a/gatsby/content/docs/2017-03-11-types-of-bridging.mdx
+++ b/gatsby/content/docs/2017-03-11-types-of-bridging.mdx
@@ -50,7 +50,7 @@ Several obstacles exist to the proper implementation of double-puppeted bridges.
 
 ### Hybrid Relaybot Puppet Bridge
 
-This type of bridge is a combination single or double puppet bridge which tries to solve the problem of representing other users by means of the bridgebot technique. [matrix-appservice-gitter](https://github.com/matrix-org/matrix-appservice-gitter) works in this way.
+This type of bridge is a combination single or double puppet bridge which tries to solve the problem of representing other users by means of the bridgebot technique.
 
 ### Server-to-server bridging
 

--- a/gatsby/src/pages/faq.js
+++ b/gatsby/src/pages/faq.js
@@ -911,12 +911,6 @@ const Faq = ({ data }) => {
                   - for bridging to Discord
                 </li>
                 <li>
-                  <a href="https://github.com/matrix-org/matrix-appservice-gitter">
-                    matrix-appservice-gitter
-                  </a>{" "}
-                  - a bridge to Gitter
-                </li>
-                <li>
                   <a href="https://github.com/matrix-org/matrix-appservice-slack">
                     matrix-appservice-slack
                   </a>{" "}


### PR DESCRIPTION
Remove outdated [`matrix-appservice-gitter`](https://github.com/matrix-org/matrix-appservice-gitter) reference.

Don't want to confuse people on how the new Gitter bridge works as this old bridge doesn't even run anymore.