### PR TITLE
👷 Cache gatsby builds

### DIFF
--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -79,8 +79,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            public
-            .cache
+            gatsby/public
+            gatsby/.cache
           key: ${{ runner.os}}-gatsby-build-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-gatsby-build-

--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -72,9 +72,24 @@ jobs:
     steps:
       - name: "📥 Source checkout"
         uses: actions/checkout@v2
-      - name: "🚧 Gatsby build"
-        run: ln -s /opt/gatsby/node_modules . && gatsby build
+      - name: "🔗 Link node modules"
+        run: ln -s /opt/gatsby/node_modules . 
         working-directory: gatsby
+      - name: "📝 Cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            public
+            .cache
+          key: ${{ runner.os}}-gatsby-build-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gatsby-build-
+      - name: "🚧 Gatsby build"
+        run: gatsby build
+        working-directory: gatsby
+        env:
+          GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
+          CI: true
       - name: "📦 Tarball creation"
         run: tar -czf gatsby-site.tar.gz public
         working-directory: gatsby

--- a/gatsby/src/pages/docs/projects/try-matrix-now.js
+++ b/gatsby/src/pages/docs/projects/try-matrix-now.js
@@ -199,17 +199,17 @@ const TryMatrixNow = ({data}) => {
                     </div>
             </div>
             </div>
-            <h2 id="clients">Clients</h2>
+            <h2>Clients</h2>
             <MXTryMatrixNowSection items={clients} />
-            <h2 id="servers">Servers</h2>
+            <h2>Servers</h2>
             <MXTryMatrixNowSection items={servers} />
-            <h2 id="sdks">SDKs</h2>
+            <h2>SDKs</h2>
             <MXTryMatrixNowSection items={sdks} />
-            <h2 id="bots">Bots</h2>
+            <h2>Bots</h2>
             <MXTryMatrixNowSection items={bots} />
-            <h2 id="bridges">Bridges</h2>
+            <h2>Bridges</h2>
             <MXTryMatrixNowSection items={bridges} />
-            <h2 id="other">Other</h2>
+            <h2>Other</h2>
             <MXTryMatrixNowSection items={others} />
         </MXContentMain>
     </Layout>)

--- a/gatsby/src/pages/docs/projects/try-matrix-now.js
+++ b/gatsby/src/pages/docs/projects/try-matrix-now.js
@@ -199,17 +199,17 @@ const TryMatrixNow = ({data}) => {
                     </div>
             </div>
             </div>
-            <h2>Clients</h2>
+            <h2 id="clients">Clients</h2>
             <MXTryMatrixNowSection items={clients} />
-            <h2>Servers</h2>
+            <h2 id="servers">Servers</h2>
             <MXTryMatrixNowSection items={servers} />
-            <h2>SDKs</h2>
+            <h2 id="sdks">SDKs</h2>
             <MXTryMatrixNowSection items={sdks} />
-            <h2>Bots</h2>
+            <h2 id="bots">Bots</h2>
             <MXTryMatrixNowSection items={bots} />
-            <h2>Bridges</h2>
+            <h2 id="bridges">Bridges</h2>
             <MXTryMatrixNowSection items={bridges} />
-            <h2>Other</h2>
+            <h2 id="other">Other</h2>
             <MXTryMatrixNowSection items={others} />
         </MXContentMain>
     </Layout>)


### PR DESCRIPTION
This caches the `.cache` and `public` directories, as [suggested by the Gatsby documentation](https://www.gatsbyjs.com/docs/reference/release-notes/v3.0/#incremental-builds-in-oss) (it’s worth noting we are still on 2.24).

From running the workflow several times for that commit, I can see that the cache is saved and restored, but I don’t notice a significant performance improvement. I suggest we merge it (assuming I didn’t break anything) and see how it behaves over a series of commits. I reckon worst case is we don’t save anything.