### PR TITLE
Warn about deprecated article and stop linking to it

### DIFF
--- a/gatsby/content/docs/2016-05-05-client-server.mdx
+++ b/gatsby/content/docs/2016-05-05-client-server.mdx
@@ -5,6 +5,10 @@ section: Client-Server API
 sort_order: 1000
 ---
 
+## Warning
+
+This guide is badly outdated and should not be used anymore! It is only kept for posterity.
+
 ## How to use the client-server API
 
 If you haven't already, get a homeserver up and running on
@@ -26,8 +30,8 @@ will need when accessing other APIs:
     curl -XPOST -d '{"username":"example", "password":"wordpass", "auth": {"type":"m.login.dummy"}}' "https://localhost:8448/_matrix/client/r0/register"
 
     {
-        "access_token": "QGV4YW1wbGU6bG9jYWxob3N0.AqdSzFmFYrLrTmteXc", 
-        "home_server": "localhost", 
+        "access_token": "QGV4YW1wbGU6bG9jYWxob3N0.AqdSzFmFYrLrTmteXc",
+        "home_server": "localhost",
         "user_id": "@example:localhost"
     }
 
@@ -59,8 +63,8 @@ ID:
     curl -XPOST -d '{"type":"m.login.password", "user":"example", "password":"wordpass"}' "https://localhost:8448/_matrix/client/r0/login"
 
     {
-        "access_token": "QGV4YW1wbGU6bG9jYWxob3N0.vRDLTgxefmKWQEtgGd", 
-        "home_server": "localhost", 
+        "access_token": "QGV4YW1wbGU6bG9jYWxob3N0.vRDLTgxefmKWQEtgGd",
+        "home_server": "localhost",
         "user_id": "@example:localhost"
     }
 
@@ -88,7 +92,7 @@ them. To create a room:
     curl -XPOST -d '{"room_alias_name":"tutorial"}' "https://localhost:8448/_matrix/client/r0/createRoom?access_token=YOUR_ACCESS_TOKEN"
 
     {
-        "room_alias": "#tutorial:localhost", 
+        "room_alias": "#tutorial:localhost",
         "room_id": "!asfLdzLnOdGRkdPZWu:localhost"
     }
 

--- a/gatsby/src/pages/docs/guides.js
+++ b/gatsby/src/pages/docs/guides.js
@@ -30,10 +30,6 @@ const Guides = ({data}) => {
           <strong><a href="/faq/">the FAQ</a></strong>, where we try to answer all your questions relating to Matrix</td>
       </tr>
       <tr>
-        <td>Understand the CS API</td>
-        <td><strong><a href="/docs/guides/client-server-api">How to use the client-server API</a></strong>, which explains in detail how to use the CS API.<br />Useful if you want to write a client (or modify an existing one) - or if you’re just interested in how it works “under the hood”</td>
-      </tr>
-      <tr>
         <td>Get started with the CS API using …</td>
         <td>&nbsp;</td>
       </tr>


### PR DESCRIPTION
Came across this today because sbd. posted about trying some of the curl requests from the article against Conduit and that failed because a lot of it is deprecated and Conduit doesn't implement it.

Only just noticing that my editor also removing some trailing spaces, I can remove those if you want.