### PR TITLE
Add request not to send reports regarding SPF/DMARC.

### DIFF
--- a/gatsby/src/pages/security-disclosure-policy.js
+++ b/gatsby/src/pages/security-disclosure-policy.js
@@ -249,7 +249,7 @@ const HallOfFame = () => {
                 <li>Review the report, verify the vulnerability and respond with confirmation and/or further information requests; we typically reply within 24 hours. </li>
                 <li>Once the reported security bug has been addressed we will notify the Researcher, who is then welcome to optionally disclose publicly.</li>
             </ul>
-            <p>The following is a list of known issues and/or things we do not consider to be an issue. Please <i>do not</i> send reports regarding the following:</p>
+            <p>The following is a list of known issues and/or things we do not consider to be an issue. Please <em>do not</em> send reports regarding the following:</p>
             <ul>
                 <li>Issues relating to SPF or DMARC.</li>
             </ul>

--- a/gatsby/src/pages/security-disclosure-policy.js
+++ b/gatsby/src/pages/security-disclosure-policy.js
@@ -249,6 +249,10 @@ const HallOfFame = () => {
                 <li>Review the report, verify the vulnerability and respond with confirmation and/or further information requests; we typically reply within 24 hours. </li>
                 <li>Once the reported security bug has been addressed we will notify the Researcher, who is then welcome to optionally disclose publicly.</li>
             </ul>
+            <p>The following is a list of known issues and/or things we do not consider to be an issue. Please <i>do not</i> send reports regarding the following:</p>
+            <ul>
+                <li>Issues relating to SPF or DMARC.</li>
+            </ul>
             <p>The Matrix.org Foundation does not ordinarily provide bug bounties, though organisations building on top of Matrix may do so in future.</p>
             <p>We maintain a Hall of Fame to recognise those who have responsibly disclosed security issues to us in the past.</p>
 


### PR DESCRIPTION
Just needs a sanity check. Tested locally, looks good to me.

<!-- Replace -->
Preview: https://pr1127--matrix-org-previews.netlify.app
<!-- Replace -->
