### PR TITLE
Privacy Notice: Correct Element Privacy Policy URL

### DIFF
--- a/gatsby/content/legal/2019-08-22-privacy_notice.mdx
+++ b/gatsby/content/legal/2019-08-22-privacy_notice.mdx
@@ -117,7 +117,7 @@ Under GDPR you have a right to request a copy of your data in a commonly-accepte
 
 **The information we collect is purely for the purpose of providing your communication service via Matrix. We do \*\***not\***\* profile users or their data on the Service.**
 
-Be aware that while we do not profile users on the Service, third party Matrix clients may gather usage data. The Element app (the Matrix client provided by Element) optionally gathers opt-in anonymised usage data in order to improve the app. This data is retained for not longer than 13 months. For more details on how your data is processed by Element, please review its [privacy policy.](element.io/privacy)
+Be aware that while we do not profile users on the Service, third party Matrix clients may gather usage data. The Element app (the Matrix client provided by Element) optionally gathers opt-in anonymised usage data in order to improve the app. This data is retained for not longer than 13 months. For more details on how your data is processed by Element, please review its [privacy policy.](https://element.io/privacy)
 
 #### 2.2.1 Information you provide to us:
 


### PR DESCRIPTION
Without the schema this is seen as a relative link: https://matrix.org/legal/element.io/privacy

## Note
In the [original document](https://github.com/vector-im/policies/blob/master/docs/matrix-org/privacy_notice.md) this is not a link.

<!-- Replace -->
Preview: https://pr1216--matrix-org-previews.netlify.app
<!-- Replace -->
