### PR TITLE
Docs: Replace Hello-Matrix with JoinMatrix

### DIFF
--- a/gatsby/content/docs/introduction.mdx
+++ b/gatsby/content/docs/introduction.mdx
@@ -42,7 +42,7 @@ To start chatting on Matrix you’ll need to sign up for a user account.
 
 On Matrix a user account is associated with a single server, referred to as a
 *homeserver*. You can find a [small list of some publicly-available homeservers
-to choose from here](https://www.hello-matrix.net/public_servers.php).
+to choose from here](https://joinmatrix.org/servers/).
 
 The simplest way to sign up and try Matrix out is to use Element, a web-based
 client. Go to [app.element.io](https://app.element.io/) to get started - this will


### PR DESCRIPTION
Since Hello-Matrix has been abandoned for a while now, making any updates to the list impossible. (The pings are still running though.)

For reference, Hello-Matrix currently features 14 homeservers,

* 4 of which are no longer operational:
  * chat.privacytools.io
  * junta.pl
  * alternanet.fr
  * matrix.allmende.io
* 1 of which is in the process of shutdown: feneas.org
* 1 of which is private: hackerspace.be

<!-- Replace -->
Preview: https://pr1221--matrix-org-previews.netlify.app
<!-- Replace -->
