### PR TITLE
Updates to the mx-puppet-discord project

### DIFF
--- a/gatsby/content/projects/bridges/mx-puppet-discord.mdx
+++ b/gatsby/content/projects/bridges/mx-puppet-discord.mdx
@@ -9,7 +9,7 @@ language: TypeScript
 license: Apache-2.0
 # pick your license from https://spdx.org/licenses/
 # valid categories are client, server, as (application service), sdk (client sdk), bot, and other
-repo: https://github.com/matrix-discord/mx-puppet-discord # your source code repository
+repo: https://gitlab.com/mx-puppet/discord/mx-puppet-discord # your source code repository
 room: "#mx-puppet-bridge:sorunome.de"
 thumbnail: /docs/projects/images/discord-logo.svg
 maturity: Late Alpha # Options are: Released, Stable, Late Beta, Beta, Early Beta, Late Alpha, Alpha, Early Alpha, or Not actively maintained

--- a/gatsby/content/projects/bridges/mx-puppet-discord.mdx
+++ b/gatsby/content/projects/bridges/mx-puppet-discord.mdx
@@ -25,8 +25,8 @@ bridges: Discord
 &#10003; Formatted Messages  
 &#10003; Media/files  
 &#10003; Redactions/Deletions  
-&#10003; Presence  (Discord &#8594; Matrix only)  
-&#10003; Typing notifications (Discord &#8594; Matrix only)  
+&#10003; Presence  (both ways)  
+&#10003; Typing notifications (both ways)  
 &#10003; Replies  
 &#10003; Edits  
 &#10003; Reactions  
@@ -34,6 +34,7 @@ bridges: Discord
 &#10003; Multi-user  
 &#10003; Friends management  
 &#10003; Initiate chats from matrix  
-&#10007; History  
+&#10007; History   
+&#10007; Threads  
 
 This bridge is part of the [mx-puppet-bridge](https://github.com/Sorunome/mx-puppet-bridge) suite of puppeting bridges.


### PR DESCRIPTION
mx-puppet-discord does supports presence and typing notifications both ways since nov 2020.
See https://github.com/matrix-discord/mx-puppet-discord/commit/0a21bb8ad5b9c41ad346de99df5a38d384d9c9ef
And Discord has threads now, which mx-puppet-discord does not support.







<!-- Replace -->
Preview: https://pr1222--matrix-org-previews.netlify.app
<!-- Replace -->
