### PR TITLE
Update URL to my French introduction to Matrix

### DIFF
--- a/gatsby/src/pages/docs/guides.js
+++ b/gatsby/src/pages/docs/guides.js
@@ -118,7 +118,7 @@ const Guides = ({data}) => {
         <td>English</td>
       </tr>
       <tr>
-        <td><a href="https://zinz.dev">Introduction à Matrix et guide d'utilisation</a></td>
+        <td><a href="https://guide.zinz.dev">Introduction à Matrix et guide d'utilisation</a></td>
         <td><a href="https://luxeylab.net">Adrien Luxey</a></td>
         <td>French</td>
       </tr>


### PR DESCRIPTION
I changed the URL of my guide. A redirect exists, but it passes through an additional nginx reverse proxy. Putting the proper URL in the guide will maximize its availability!

Original PR (when I added my guide) : https://github.com/matrix-org/matrix.org/pull/731