### PR TITLE
Set matrix-rocketchat to not actively maintained

### DIFF
--- a/gatsby/content/projects/bridges/matrix-rocketchat.mdx
+++ b/gatsby/content/projects/bridges/matrix-rocketchat.mdx
@@ -5,12 +5,12 @@ categories:
  - bridge
 description: This is an application service that bridges Matrix to Rocket.Chat, written in Rust.
 author: exul
-maturity: Beta
+maturity: Not actively maintained
 language: Rust
 license: MIT
 repo: https://github.com/exul/matrix-rocketchat
 screenshot: /docs/projects/images/matrix-rocketchat.png
-featured: true
+featured: false
 bridges: RocketChat
 reponame: matrix-rocketchat
 thumbnail: /docs/projects/images/rocketchat-logo.png


### PR DESCRIPTION
As written on https://github.com/exul/matrix-rocketchat the project is not actively maintained anymore.