### PR TITLE
Fix olm/megolm links

### DIFF
--- a/gatsby/content/projects/other/olm.mdx
+++ b/gatsby/content/projects/other/olm.mdx
@@ -14,9 +14,9 @@ home: https://git.matrix.org/git/olm/about/docs/olm.rst
 
 An implementation of the Double Ratchet cryptographic ratchet described by <https://whispersystems.org/docs/specifications/doubleratchet/>, written in C and C++11 and exposed as a C API.
 
-The specification of the Olm ratchet can be found at <https://git.matrix.org/git/olm/about/docs/olm.rst>.
+The specification of the Olm ratchet can be found at <https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/olm.md>.
 
 This library also includes an implementation of the Megolm cryptographic
-ratchet, as specified at <https://git.matrix.org/git/olm/about/docs/megolm.rst>.
+ratchet, as specified at <https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/megolm.md>.
 
 

--- a/gatsby/content/projects/other/olm.mdx
+++ b/gatsby/content/projects/other/olm.mdx
@@ -14,9 +14,9 @@ home: https://git.matrix.org/git/olm/about/docs/olm.rst
 
 An implementation of the Double Ratchet cryptographic ratchet described by <https://whispersystems.org/docs/specifications/doubleratchet/>, written in C and C++11 and exposed as a C API.
 
-The specification of the Olm ratchet can be found at <https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/olm.md>.
+The specification of the Olm ratchet can be found at <https://matrix.org/docs/spec/olm.html>.
 
 This library also includes an implementation of the Megolm cryptographic
-ratchet, as specified at <https://gitlab.matrix.org/matrix-org/olm/-/blob/master/docs/megolm.md>.
+ratchet, as specified at <https://matrix.org/docs/spec/megolm.html>.
 
 


### PR DESCRIPTION
These previously came up with a "no file named docs/[meg]olm.rst on master" message from GitLab.

<!-- Replace -->
Preview: https://pr1291--matrix-org-previews.netlify.app
<!-- Replace -->
