### PR TITLE
Remove confusing "{project} on matrix.org" text

### DIFF
--- a/gatsby/src/components/MXProjectHeader.js
+++ b/gatsby/src/components/MXProjectHeader.js
@@ -12,7 +12,6 @@ const MXProjectHeader = ({ project, imageSize }) => {
         </div>
         <div style={{ "float": "left", "marginRight": "20px" }}>
             <h3 id={"title-" + kebabCase(project.title)}>{project.title}</h3>
-            <a href={project.slug}>{project.title} on matrix.org</a><br />
             <a href={project.repo}>{project.repo}</a><br />
             <a href={"https://matrix.to/#/" + project.room}>{project.room}</a><br />
             {project.example_mxid &&


### PR DESCRIPTION
It looks like it was originally added as a part of the new SDKs page, but later leaked into bridges when that page was updated. For bridges, it's very confusing as there's no link and it can be interpreted as the bridge being hosted on matrix.org. For SDKs, it just links to a page that has the exact same content as the current page, so I don't think it's necessary at all (e.g. on https://matrix.org/sdks/#mautrix-go it links to https://matrix.org/docs/projects/sdk/mautrix-go)

![image](https://user-images.githubusercontent.com/4224639/161445483-4ec5c8be-f8c5-42ed-af55-6738b9454a6f.png)
![image](https://user-images.githubusercontent.com/4224639/161445486-196ab863-8830-4594-92a3-7cd0bb55bee4.png)


<!-- Replace -->
Preview: https://pr1306--matrix-org-previews.netlify.app
<!-- Replace -->
