### PR TITLE
Fix some URLs

### DIFF
--- a/gatsby/content/blog/2022/05/2022-05-06-twim.mdx
+++ b/gatsby/content/blog/2022/05/2022-05-06-twim.mdx
@@ -52,14 +52,14 @@ image:
 > 
 > It's that time of the year again - a new Spec release is on the horizon! Matrix v1.3 is expected to land _sometime this month_, and will include:
 > 
-> * [MSC3440](https://github.com/matrix-spec-proposals/pull/3440) (threads) + related MSCs
-> * [MSC3787](https://github.com/matrix-spec-proposals/pull/3787) (knock+restricted join rules)
-> * [MSC3604](https://github.com/matrix-spec-proposals/pull/3604) (room version 10)
+> * [MSC3440](https://github.com/matrix-org/matrix-spec-proposals/pull/3440) (threads) + related MSCs
+> * [MSC3787](https://github.com/matrix-org/matrix-spec-proposals/pull/3787) (knock+restricted join rules)
+> * [MSC3604](https://github.com/matrix-org/matrix-spec-proposals/pull/3604) (room version 10)
 > * Any other MSCs which have so far been accepted, but not yet made it into the spec.
 > 
 > MSCs which land between now and v1.3 might get incorporated if easy enough, though chances are they'll slip to v1.4 (expected next quarter).
 > 
-> On top of that, the other bit of news is that the `proposal-in-review` label has now been removed from the [matrix-spec-proposals](https://github.com/matrix-spec-proposals) repo and thus all MSCs. This doesn't mean your MSC is no longer in review! We simply found the label redundant along with the other labels in the process (it was attached to all MSCs which hadn't been accepted/merged yet, which means very little) and thus we decided to remove it to reduce noise.
+> On top of that, the other bit of news is that the `proposal-in-review` label has now been removed from the [matrix-spec-proposals](https://github.com/matrix-org/matrix-spec-proposals) repo and thus all MSCs. This doesn't mean your MSC is no longer in review! We simply found the label redundant along with the other labels in the process (it was attached to all MSCs which hadn't been accepted/merged yet, which means very little) and thus we decided to remove it to reduce noise.
 > 
 > ## Random MSC of the Week
 > 


### PR DESCRIPTION
some mscs were linked to https://github.com/matrix-spec-proposals instead of https://github.com/matrix-org/matrix-spec-proposals

<!-- Replace -->
Preview: https://pr1329--matrix-org-previews.netlify.app
<!-- Replace -->
