### PR TITLE
Add MandM-bridge (Matrix Mumble bridge)

### DIFF
--- a/gatsby/content/projects/bridges/MandM-bridge.mdx
+++ b/gatsby/content/projects/bridges/MandM-bridge.mdx
@@ -1,0 +1,27 @@
+---
+layout: project
+title: MandM-bridge
+categories: 
+ - bridge
+description: Bridges between one matrix room and a murmur channels. 
+author: karlpip
+language: Python
+maturity: Alpha
+repo: https://github.com/karlpip/MandM-bridge
+featured: true
+license: MIT
+room: "#mandm-bridge:og.lushkush.nl"
+bridges: Mumble
+thumbnail: /docs/projects/images/Mumble.png
+---
+
+Bridges between a Murmur server and a Matrix channel.  
+ICE is used to communicate with the Murmur server, matrix-nio is used for Matrix.
+
+&#10003; Bridges text messages bidirectional  
+&#10007; 1:1 chats  
+&#10003; Bridge connect / disconnect notifies to Matrix  
+&#10003; Bridges images from Matrix to Mumble  
+&#10007; Bridges images from Mumble to Matrix  
+&#10003; Configurable selection of which Murmur channels to be bridged.  
+&#10003; Easy to add message handlers to filter or modify messages before bridging.  


### PR DESCRIPTION
Hey guys,

as Murmur does not have gRPC anymore (https://github.com/mumble-voip/mumble/commit/e909c239d7ed2f5473e9085ee5ec7fbc4ed68f26), i've decided to write a bridge which uses the ICE interface to communicate with murmur instead.

It's my first matrix related project so i'm happy to do changes / improvments to the bridge repo if they are required :)

Kind regards
Karl