### PR TITLE
Remove outdated E2E clients list and link to updated one

### DIFF
--- a/gatsby/content/faq/encryption.mdx
+++ b/gatsby/content/faq/encryption.mdx
@@ -13,20 +13,7 @@ End-to-End Encryption is fully supported in Matrix. New rooms have encryption en
 
 #### Which matrix clients support E2E?
 
-End-to-end encryption is currently available in:
-
-- [Element Web](https://github.com/vector-im/element-web/)
-  - and [matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk)
-  - and [matrix-react-sdk](https://github.com/matrix-org/matrix-react-sdk)
-- [Element Android](https://github.com/vector-im/element-android/)
-  - and <a href="https://github.com/matrix-org/matrix-android-sdk2">matrix-android-sdk2</a>
-- [Element iOS](https://github.com/vector-im/element-ios/)
-  - and [matrix-ios-sdk](https://github.com/matrix-org/matrix-ios-sdk)
-- [Nheko](https://github.com/Nheko-Reborn/nheko)
-- [Mirage](https://github.com/mirukana/mirage)
-- [FluffyChat](https://fluffychat.im/en/) for Android, iOS, Desktop and Web
-- [Seaglass](https://github.com/neilalexander/seaglass)
-- there is a [weechat plugin available](https://github.com/poljar/weechat-matrix) (Python protocol script)
+To see the availability of features like E2E in clients, please see https://matrix.org/clients-matrix/#features
 
 E2E is available in [matrix-nio](https://github.com/poljar/matrix-nio), a Client-Server library for Python.
 

--- a/gatsby/content/faq/encryption.mdx
+++ b/gatsby/content/faq/encryption.mdx
@@ -13,7 +13,7 @@ End-to-End Encryption is fully supported in Matrix. New rooms have encryption en
 
 #### Which matrix clients support E2E?
 
-To see the availability of features like E2E in clients, please see https://matrix.org/clients-matrix/#features
+To see the availability of features like E2E in clients, see https://matrix.org/clients-matrix/#features.
 
 E2E is available in [matrix-nio](https://github.com/poljar/matrix-nio), a Client-Server library for Python.
 


### PR DESCRIPTION
I noticed that this information is duplicated.