### PR TITLE
Fix 'previous' link in categories on pages ≥ 3

### DIFF
--- a/gatsby/src/templates/category.js
+++ b/gatsby/src/templates/category.js
@@ -13,7 +13,7 @@ const Category = ({ pageContext: { category, limit, skip, currentPage }, data: {
   const subline = `${totalCount} post${totalCount === 1 ? '' : 's'} tagged with "${category}"`
 
   const prevTitle = `Page ${currentPage - 1}`
-  const prevSlug = currentPage === 2 ? `/blog/category/${_.kebabCase(category)}/` : `/blog/posts/${currentPage - 1}`
+  const prevSlug = currentPage === 2 ? `/blog/category/${_.kebabCase(category)}/` : `/blog/category/${_.kebabCase(category)}/${currentPage - 1}`
   const prev = currentPage === 1 ? null : { frontmatter: { title: prevTitle }, fields: { slug: prevSlug } }
   const nextTitle = `Page ${currentPage + 1}`
   const nextSlug = `/blog/category/${_.kebabCase(category)}/${currentPage + 1}`


### PR DESCRIPTION
It goes to /posts/ rather than the actual category right now.

See https://matrix.org/blog/category/this-week-in-matrix/33 for example.

<!-- Replace -->
Preview: https://pr1354--matrix-org-previews.netlify.app
<!-- Replace -->
