### PR TITLE
Fix typo CI for TWIM 20220812

### DIFF
--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -8,7 +8,7 @@ extend-exclude = [
 	"/gatsby/content/blog/2022/01/2022-01-21-twim.mdx", # pings scoreboard triggers the typo CI
     "/gatsby/content/blog/2022/05/2022-05-13-twim.mdx", # typo found in a url
 	"/gatsby/content/blog/2022/07/2022-07-08-twim.mdx", # whos in that room
-	"/gatsby/content/blog/2022/07/2022-08-12-twim.mdx", # tha'
+	"/gatsby/content/blog/2022/08/2022-08-12-twim.mdx", # tha'
 	"*signed*.txt", # can be removed once https://github.com/crate-ci/typos/issues/401 is fixed
 	"synapse-debian-security-announcement.asc" # has typo but cannot fix due to PGP signature
 ]

--- a/.github/_typos.toml
+++ b/.github/_typos.toml
@@ -6,8 +6,9 @@ extend-exclude = [
 	"/gatsby/content/blog/2020/12/2020-12-18-a-twim.mdx", # contains intentional typos
 	"/gatsby/content/blog/2021/09/2021-09-17-twim.mdx", # contains French, for some reason
 	"/gatsby/content/blog/2022/01/2022-01-21-twim.mdx", # pings scoreboard triggers the typo CI
-        "/gatsby/content/blog/2022/05/2022-05-13-twim.mdx", # typo found in a url
+    "/gatsby/content/blog/2022/05/2022-05-13-twim.mdx", # typo found in a url
 	"/gatsby/content/blog/2022/07/2022-07-08-twim.mdx", # whos in that room
+	"/gatsby/content/blog/2022/07/2022-08-12-twim.mdx", # tha'
 	"*signed*.txt", # can be removed once https://github.com/crate-ci/typos/issues/401 is fixed
 	"synapse-debian-security-announcement.asc" # has typo but cannot fix due to PGP signature
 ]


### PR DESCRIPTION
Broke in https://github.com/matrix-org/matrix.org/pull/1399 due to a stylised 'the': `tha'`.

This PR ignores the entire file from typo checking, and thus the specific false-positive.