### PR TITLE
Fix Synapse support room reference in FAQ

### DIFF
--- a/gatsby/src/pages/faq.js
+++ b/gatsby/src/pages/faq.js
@@ -734,11 +734,11 @@ const Faq = ({ data }) => {
                 .
               </p>
               <p>
-                If you host a{" "}
-                <a href="https://matrix.to/#/#synapse-community:matrix.org">
-                  #synapse-community:matrix.org
-                </a>
-                .
+                If you host a Synapse homeserver, you can get support in the{" "}
+                <a href="https://matrix.to/#/#synapse:matrix.org">
+                  #synapse:matrix.org
+                </a>{" "}
+                room.
               </p>
               <div className="definition-list">
                 <div className="definition-item definition-room">

--- a/scripts/_url-directory.md
+++ b/scripts/_url-directory.md
@@ -62,7 +62,6 @@
 [#SimpleMatrix:matrix.ffslfl.net]: https://matrix.to/#/#SimpleMatrix:matrix.ffslfl.net
 [#smsmatrix:matrix.org]: https://matrix.to/#/#smsmatrix:matrix.org
 [#spectral:encom.eu.org]: https://matrix.to/#/#spectral:encom.eu.org
-[#synapse-community:matrix.org]: https://matrix.to/#/#synapse-community:matrix.org
 [#synapse-netcore-workers:t2bot.io]: https://matrix.to/#/#synapse-netcore-workers:t2bot.io
 [#synapse-py3:matrix.org]: https://matrix.to/#/#synapse-py3:matrix.org
 [#synapse:matrix.org]: https://matrix.to/#/#synapse:matrix.org


### PR DESCRIPTION
The sentence was missing several words, and using a non-published
address for the room.  Make it a complete sentence and change the link
to use the canonical address.