### PR TITLE
Remove the advertising of Element Clients in the FAQ

### DIFF
--- a/gatsby/src/pages/clients.js
+++ b/gatsby/src/pages/clients.js
@@ -36,7 +36,7 @@ const ClientsMatrix = ({ data }) => {
       <p>To connect to the Matrix federation, you will use a client. These are some of the most popular Matrix clients available today, and more are available at  <a href="/docs/projects/try-matrix-now/">try-matrix-now</a>.
           To get started using Matrix, pick a client and join <a href="https://matrix.to/#/#matrix:matrix.org">#matrix:matrix.org</a>.
           To see more clients in a features matrix, see the <a href="/clients-matrix">Clients Matrix</a>.</p>
-      <h2>Mobile</h2>
+      <h2 id="mobile">Mobile</h2>
       <div className="mxgrid">
         {clients
           .filter(c =>

--- a/gatsby/src/pages/faq.js
+++ b/gatsby/src/pages/faq.js
@@ -1016,30 +1016,10 @@ const Faq = ({ data }) => {
                 Where can I find a mobile app?
               </h4>
               <p>
-                <a href="https://element.io">Element</a> is available for Android and
-                iOS.
-              </p>
-              <p>
-                The iOS version can be downloaded from the{" "}
-                <a href="https://itunes.apple.com/us/app/vector.im/id1083446067">
-                  Apple store
-                </a>
-                .
-              </p>
-              <p>
-                The Android version can be downloaded from the{" "}
-                <a href="https://play.google.com/store/apps/details?id=im.vector.app">
-                  Google Play store
-                </a>{" "}
-                or{" "}
-                <a href="https://f-droid.org/repository/browse/?fdid=im.vector.alpha">
-                  F-Droid
-                </a>
-                . If you are not sure which one to choose, install Element from the{" "}
-                <a href="https://play.google.com/store/apps/details?id=im.vector.app">
-                  Google Play store
-                </a>
-                .
+                A list of Mobile clients can be found are available in our{" "}
+                <a href="/faq#mobile">List of Clients</a> or at the{" "}
+                <a href="/docs/projects/try-matrix-now">Try Matrix Now</a>{" "}
+                Section.
               </p>
               <div className="definition-list">
                 <div className="definition-item definition-element">


### PR DESCRIPTION
This instead links to the list of clients as well as the Try Matrix Now section.

Fixes: #1342