### PR TITLE
Make the scroll targets adjust for the navigation bar

### DIFF
--- a/gatsby/static/css/matrix-org.webflow.css
+++ b/gatsby/static/css/matrix-org.webflow.css
@@ -46,6 +46,15 @@ h6 {
   font-weight: 500;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    scroll-margin-top: 74px;
+}
+
 a {
   color: #0098d4;
   text-decoration: none;

--- a/gatsby/static/css/matrix-org.webflow.css
+++ b/gatsby/static/css/matrix-org.webflow.css
@@ -63,9 +63,9 @@ h6 {
   h4,
   h5,
   h6 {
-    /* Offsets the anchor scroll position by the navbar height + 10px buffer.
-    The mobile navbar is 4px smaller in height than the regular navbar. The breakpoint the navbar changes at is 991px */
-    scroll-margin-top: 70px;
+    /* The mobile version of the navbar correctly pushes the elements down.
+       Therefor we dont need to have the offset. We however need to unset this as otherwise the 74px is applied. */
+    scroll-margin-top: inherit;
   }
 }
 

--- a/gatsby/static/css/matrix-org.webflow.css
+++ b/gatsby/static/css/matrix-org.webflow.css
@@ -52,7 +52,21 @@ h3,
 h4,
 h5,
 h6 {
-    scroll-margin-top: 74px;
+  /* Offsets the anchor scroll position by the navbar height + 10px buffer */
+  scroll-margin-top: 74px;
+}
+
+@media (max-width: 991px) {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    /* Offsets the anchor scroll position by the navbar height + 10px buffer.
+    The mobile navbar is 4px smaller in height than the regular navbar. The breakpoint the navbar changes at is 991px */
+    scroll-margin-top: 70px;
+  }
 }
 
 a {


### PR DESCRIPTION
This should fix #1152

Apparently this css feature is rather (if not brand) new, but it is supported by all major browsers (including safari!): https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin#browser_compatibility







<!-- Replace -->
Preview: https://pr1437--matrix-org-previews.netlify.app
<!-- Replace -->
