### PR TITLE
Remove copy-pasted error

### DIFF
--- a/gatsby/content/blog/2022/09/2022-09-16-twim.mdx
+++ b/gatsby/content/blog/2022/09/2022-09-16-twim.mdx
@@ -274,7 +274,7 @@ Next-gen crypto-included SDK for developing Clients, Bots and Appservices; writt
 > Both will be available, also together, in the upcoming release 0.6 of matrix-sdk, which we expect to land before the end of the month. It was slightly pushed back as the [`sync event` changes turned out to be more of a rabbit hole](https://github.com/matrix-org/matrix-rust-sdk/pull/1022) than anticipated.
 > 
 > 
-> 👉 Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.https://secondhome.io/location/lisboa/
+> 👉 Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
 
 ## Dept of Ops 🛠
 


### PR DESCRIPTION
When copying the text over, a link to a coworking space was copy-pasted, too. This remove the unrelated link.

<!-- Replace -->
Preview: https://pr1445--matrix-org-previews.netlify.app
<!-- Replace -->
