### PR TITLE
Fix typos in the TWIM announcement for the matrix-widget-api

### DIFF
--- a/gatsby/content/blog/2022/09/2022-09-30-twim.mdx
+++ b/gatsby/content/blog/2022/09/2022-09-30-twim.mdx
@@ -366,7 +366,7 @@ A browser-based open metaverse client
 
 [Dominik Henneke](https://matrix.to/#/@dhenneke:matrix.org) reports
  
-> We from [Nordeck](https://nordeck.net/) added support for [retrieving related events](https://github.com/matrix-org/matrix-widget-api/pull/72) in Widgets into the matrix-widget-api over the last weeks. With the existing APIs we could not reliable read all the data from the room, as the room timeline is lazily loaded in Element. To learn more about the issue, have a look at the related [MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/3869). With this weeks [Element release 1.11.6](https://github.com/vector-im/element-web/releases/tag/v1.11.6) this feature has now landed. This change improves using the room as a data storage for Matrix Widgets, which allows us to build cool tools. We keep your updated once we publish our widgets as Open Source.
+> We from [Nordeck](https://nordeck.net/) added support for [retrieving related events](https://github.com/matrix-org/matrix-widget-api/pull/72) in Widgets into the matrix-widget-api over the last weeks. With the existing APIs we could not reliable read all the data from the room, as the room timeline is lazily loaded in Element. To learn more about the issue, have a look at the related [MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/3869). With this weeks [Element release 1.11.6](https://github.com/vector-im/element-web/releases/tag/v1.11.6) this feature has now landed. The change improves using the room as a data storage for Matrix Widgets, which allows us to build cool tools. We keep you updated when we publish our widgets as Open Source.
 
 ## Dept of SDKs and Frameworks 🧰
 


### PR DESCRIPTION
Just some minor fixes to improve the news.

<!-- Replace -->
Preview: https://pr1474--matrix-org-previews.netlify.app
<!-- Replace -->
