### PR TITLE
Add NewsArticle schema data to the post template

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -12,11 +12,15 @@
     "headline": "{{ page.title }}",
     "datePublished": "{{ page.date | date(format="%Y-%m-%dT%H:%M+00:00") }}",
     "dateModified": "{{ page.updated | date(format="%Y-%m-%dT%H:%M+00:00") }}",
-    "author": [{
+    "author": [
+    {% for author in page.taxonomies.authors %}
+    {
         "@type": "Person",
-        "name": "{{ page.taxonomies.authors | default (value=["unknown author"]) | first }}",
-        "url": "{{ config.base_url | safe }}/authors/{{ page.taxonomies.authors | default (value=['unknown author']) | first | slugify }}"
-    }]
+        "name": "{{ author }}",
+        "url": "{{ config.base_url | safe }}/authors/{{ author | slugify }}"
+    }{% if not loop.last %},{% endif %}
+    {% endfor %}
+    ]
 }
 </script>
 {% endblock head_extra %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,5 +1,25 @@
 {% extends "skel.html" %}
 {% block html_title %}Matrix.org - {{ page.title }}{% endblock html_title %}
+{% block head_extra %}
+{% if page.summary %}
+<meta name="description" content="{{ page.summary | safe }}">
+{% endif %}
+
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    "headline": "{{ page.title }}",
+    "datePublished": "{{ page.date | date(format="%Y-%m-%dT%H:%M+00:00") }}",
+    "dateModified": "{{ page.updated | date(format="%Y-%m-%dT%H:%M+00:00") }}",
+    "author": [{
+        "@type": "Person",
+        "name": "{{ page.taxonomies.authors | default (value=["unknown author"]) | first }}",
+        "url": "{{ config.base_url | safe }}/authors/{{ page.taxonomies.authors | default (value=['unknown author']) | first | slugify }}"
+    }]
+}
+</script>
+{% endblock head_extra %}
 {% block content %}
 <main>
     <article class="content post">


### PR DESCRIPTION
(Note this is against zola not against gatsby)

This implements https://developers.google.com/search/docs/appearance/structured-data/article for the blog articles.