### PR TITLE
[Zola] Fix preview image path for the clients page

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -15,8 +15,7 @@
                 {% if client.featured %}
                 <div class="grid-container-third">
                     <div class="block">
-                        {% set preview_url = get_url(path="clients/" ~ client.preview, trailing_slash=false ) %}
-                        <img src="{{ preview_url }}" alt="{{ name }} Preview">
+                        <img src="{{ client.preview }}" alt="{{ name }} Preview">
                         <h3>{{ name }}</h3>
                         <p>{{ client.summary | safe }}</p>
                         <div>


### PR DESCRIPTION
Fixes unnecessary get_url which broke the images.