### PR TITLE
[Zola] Change to visual studio style codeblocks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,15 +20,15 @@ taxonomies = [
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
 highlight_code = true
-highlight_theme = "inspired-github"
+highlight_theme = "visual-studio-dark"
 
 [link_checker]
 skip_prefixes = [
     # This page is not a real page. You need to open https://circu.li/fdroid/repo/index-v1.json for a response
-    "https://circu.li/fdroid/"
+    "https://circu.li/fdroid/",
 ]
 
 skip_anchor_prefixes = [
     # Spec page does not have anchors in the html it seems. (Probably loading using js.) This causes a false positive
-    "https://spec.matrix.org/v1.3/changelog/"
+    "https://spec.matrix.org/v1.3/changelog/",
 ]

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -87,93 +87,6 @@ ol:last-child {
     margin-bottom: 0;
 }
 
-:not(pre)>code {
-    background-color: #fdfdfd;
-    box-sizing: border-box;
-    margin-bottom: 1em;
-}
-
-:not(pre)>code {
-    position: relative;
-    padding: .2em;
-    border-radius: 0.3em;
-    color: #c92c2c;
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    display: inline;
-    white-space: normal;
-}
-
-code[class*="language-"],
-pre[class*="language-"] {
-    color: black;
-    background-attachment: scroll;
-    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-    font-size: 1em;
-    text-align: left;
-    white-space: pre;
-    word-spacing: normal;
-    word-break: normal;
-    word-wrap: normal;
-    line-height: 1.5;
-    tab-size: 4;
-    hyphens: none;
-}
-
-pre {
-    white-space: normal;
-    padding: .5rem;
-    overflow: auto;
-
-    &[class*="language-"]>code {
-        position: relative;
-        border-left: 10px solid #358ccb;
-        box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
-        background-color: #fdfdfd;
-        background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-        background-size: 3em 3em;
-        background-origin: content-box;
-        background-attachment: local;
-    }
-
-    code[class*="language"] {
-        max-height: inherit;
-        height: inherit;
-        padding: 0 1em;
-        display: block;
-        overflow: auto;
-    }
-
-    // The line numbers already provide some kind of left/right padding
-    &[data-linenos] {
-        padding: .5rem 0;
-    }
-
-
-    table {
-        width: 100%;
-        border-collapse: collapse;
-    }
-
-    mark {
-        // If you want your highlights to take the full width.
-        display: block;
-        // The default background colour of a mark is bright yellow
-        background-color: rgba(254, 252, 232, 0.9);
-    }
-
-    table {
-        td {
-            padding: 0;
-
-            // The line number cells
-            &:nth-of-type(1) {
-                text-align: center;
-                user-select: none;
-            }
-        }
-    }
-}
-
 .content {
     width: 100%;
     max-width: 960px;
@@ -318,4 +231,34 @@ main {
         justify-content: flex-start;
         align-items: center;
     }
+}
+
+pre {
+    padding: 1rem;
+    overflow: auto;
+}
+
+// The line numbers already provide some kind of left/right padding
+pre[data-linenos] {
+    padding: 1rem 0;
+}
+
+pre table td {
+    padding: 0;
+}
+
+// The line number cells
+pre table td:nth-of-type(1) {
+    text-align: center;
+    user-select: none;
+}
+
+pre mark {
+    display: block;
+    background-color: rgba(254, 252, 232, 0.9);
+}
+
+pre table {
+    width: 100%;
+    border-collapse: collapse;
 }


### PR DESCRIPTION
The changes to the CSS are removing the old style and adding the recommendations from https://www.getzola.org/documentation/content/syntax-highlighting/#styling-codeblocks