### PR TITLE
[Zola] Add lazyloading arguments for youtube embeds

### DIFF
--- a/content/blog/2022/09/2022-09-02-twim/index.md
+++ b/content/blog/2022/09/2022-09-02-twim/index.md
@@ -11,7 +11,7 @@ author = ["Thib"]
 
 ## Matrix Live 🎙
 
-<iframe src="https://www.youtube.com/embed/RzhMDi1aNEM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/RzhMDi1aNEM" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <!-- more -->
 

--- a/content/blog/2022/09/2022-09-09-twim/index.md
+++ b/content/blog/2022/09/2022-09-09-twim/index.md
@@ -10,7 +10,7 @@ author = ["Thib"]
 
 ## Matrix Live 🎙
 
-<iframe src="https://www.youtube.com/embed/wFSmDn-PlYg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/wFSmDn-PlYg" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 A short Matrix Live where we can see the goodness coming to Element very shortly!
 

--- a/content/blog/2022/09/2022-09-16-twim/index.md
+++ b/content/blog/2022/09/2022-09-16-twim/index.md
@@ -11,7 +11,7 @@ author = ["Thib"]
 
 ## Matrix Live
 
-<iframe src="https://www.youtube.com/embed/9uwd35KhWsw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/9uwd35KhWsw" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <!-- more -->
 

--- a/content/blog/2022/09/2022-09-23-twim/index.md
+++ b/content/blog/2022/09/2022-09-23-twim/index.md
@@ -11,7 +11,7 @@ author = ["Thib"]
 
 ## Matrix Live
 
-<iframe src="https://www.youtube.com/embed/MwOh4NvPdtQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/MwOh4NvPdtQ" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <!-- more -->
 

--- a/content/blog/2022/09/2022-09-27-thirdroom/index.md
+++ b/content/blog/2022/09/2022-09-27-thirdroom/index.md
@@ -14,4 +14,4 @@ We're excited to announce the first tech preview of [Third Room](https://thirdro
 To see what it's all about, head over to <https://thirdroom.io/preview> - or come chat in [#thirdroom-dev:matrix.org](https://matrix.to/#/#thirdroom-dev:matrix.org) to learn more!
 
 
-<iframe src="https://www.youtube.com/embed/skC5TYRAgKE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/skC5TYRAgKE" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/blog/2022/09/2022-09-30-twim/index.md
+++ b/content/blog/2022/09/2022-09-30-twim/index.md
@@ -11,7 +11,7 @@ author = ["Thib"]
 
 ## Matrix Live
 
-<iframe src="https://www.youtube.com/embed/cJHlndIcgMM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/cJHlndIcgMM" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <!-- more -->
 


### PR DESCRIPTION
This adds the very new lazy loading argument to the YouTube iframes. ( https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes ) This currently will only work on chrome based browsers ( https://caniuse.com/loading-lazy-attr ) But seems to roll out on next safari and Firefox in the future too. This should allow the page to load faster when this lands in more browsers, since the YouTube embed is huge and slow and really should not blog the page.