### PR TITLE
Cancel concurrent GHA builds

### DIFF
--- a/.github/workflows/build-matrix.org.yml
+++ b/.github/workflows/build-matrix.org.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# only allow one build per PR: cancel any existing ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Apply styling to the spec documents.
   # This step also sets up the OpenAPI UI.


### PR DESCRIPTION
This is a thing we do on Synapse, and it makes things build faster by not tying up GHA workers with builds we don't care about.

<!-- Replace -->
Preview: https://pr1510--matrix-org-previews.netlify.app
<!-- Replace -->
