### PR TITLE
[Zola] Add small nix env

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/b3a8f7ed267e0a7ed100eb7d716c9137ff120fe3.tar.gz") {}
+}:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.zola
+  ];
+}


### PR DESCRIPTION
As suggested at the matrix room.

It is pinned to the stable release that was currently listed at https://status.nixos.org/ which contains zola 0.15.3 most recent zola is 0.16.1 which is only available in unstable at this time.

This allows to get a fresh env with zola by using `nix-shell`