### PR TITLE
Fix malformed link

### DIFF
--- a/gatsby/content/blog/2022/12/2022-12-01-foundation-membership.mdx
+++ b/gatsby/content/blog/2022/12/2022-12-01-foundation-membership.mdx
@@ -40,7 +40,7 @@ Are you a non-profit organisation with a mission to provide secure and sovereign
 
 Are you an individual who strongly supports the mission of Matrix and wants to see it thrive and become the open backbone of the world’s communications? Become a member, and support the future of Matrix. 
 
-In short, this finally gives the wider world a way to contribute concretely to the significant costs of funding folks to work fulltime on core Matrix development - which now covers over 243(!) projects in [github.com/matrix-org](github.com/matrix-org). Core Matrix work ranges from: 
+In short, this finally gives the wider world a way to contribute concretely to the significant costs of funding folks to work fulltime on core Matrix development - which now covers over 243(!) projects in [github.com/matrix-org](https://github.com/matrix-org). Core Matrix work ranges from: 
 
 - managing the Matrix spec itself 
 - maintaining the reference client SDKs and encryption and getting them independently audited


### PR DESCRIPTION
This PR fixes a malformed link (relative to absolute) to the GitHub matrix.org project.