### PR TITLE
List all docs under the legacy section

### DIFF
--- a/content/docs/legacy/_index.md
+++ b/content/docs/legacy/_index.md
@@ -2,6 +2,7 @@
 title = "Legacy documentation"
 template = "docs/legacy_index.html"
 page_template = "docs/legacy.html"
+sort_by = "title"
 weight = 900
 [extra]
 emoji = "🕸️"

--- a/content/docs/legacy/_index.md
+++ b/content/docs/legacy/_index.md
@@ -1,8 +1,14 @@
 +++
 title = "Legacy documentation"
+template = "docs/legacy_index.html"
 page_template = "docs/legacy.html"
 weight = 900
 [extra]
 emoji = "🕸️"
 tile = "Legacy documentation"
 +++
+
+This section contains all the outdated documentation from the former matrix.org
+website. This documentation was kept as an archive. Please use documentation
+listed on the [Documentation](/docs) section of this website, except what is
+listed in "Legacy" (which leads to this page).

--- a/templates/docs/legacy_index.html
+++ b/templates/docs/legacy_index.html
@@ -1,0 +1,14 @@
+{% extends "section.html" %}
+{% block content %}
+<article class="content">
+    <header>
+        <h1>{{ section.title }}</h1>
+    </header>
+    {{ section.content | safe }}
+    {% for page in section.pages %}
+    <ul>
+        <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    </ul>
+    {% endfor %}
+</article>
+{% endblock content %}


### PR DESCRIPTION
Note:
- Docs are in no special order, but I don't think that's a big deal since they are legacy docs
- There are no subsection, everything under `legacy` is a page