### PR TITLE
Add SS proxy URL to .well-known client

### DIFF
--- a/content/.well-known/matrix/client
+++ b/content/.well-known/matrix/client
@@ -4,5 +4,8 @@
     },
     "m.identity_server": {
         "base_url": "https://vector.im"
+    },
+    "org.matrix.msc3575.proxy": {
+        "url": "https://slidingsync.lab.matrix.org"
     }
 }


### PR DESCRIPTION
This allows clients to discover official trusted sliding sync proxy URLs, as per the MSC: https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#unstable-prefix