### PR TITLE
Fixed horizontal overflow in blog

### DIFF
--- a/gatsby/static/css/matrix-org.webflow.css
+++ b/gatsby/static/css/matrix-org.webflow.css
@@ -295,6 +295,7 @@ a {
 }
 
 .mxcontent__main {
+  overflow-wrap: break-word;
   width: 100%;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;


### PR DESCRIPTION
Solves #1313 

Previously, in mobile view, blog pages used to overflow because of long words present in them.

https://user-images.githubusercontent.com/53047854/216037293-1ce3e303-d02b-42b3-a8b1-9aa23d6cbc79.mp4

Now, these long words are wrapped.

![image](https://user-images.githubusercontent.com/53047854/216038443-54cd8cbf-885f-4f6e-a3b9-0420b86a103c.png)


<!-- Replace -->
Preview: https://pr1638--matrix-org-previews.netlify.app
<!-- Replace -->
