### PR TITLE
FAQs: Remove hijacked link

### DIFF
--- a/gatsby/src/pages/faq.js
+++ b/gatsby/src/pages/faq.js
@@ -982,11 +982,7 @@ const Faq = ({ data }) => {
               <p>
                 Clients can access any <a href="#definitions">homeserver</a>—you
                 don't have to use matrix.org, though historically it is the
-                largest public homeserver. anchel.nl lists{" "}
-                <a href="https://www.anchel.nl/matrix-publiclist/">
-                  free public homeservers
-                </a>
-                , and a few other resources for getting started.
+                largest public homeserver.
               </p>
               <div className="definition-list">
                 <div className="definition-item definition-homeserver">


### PR DESCRIPTION
Unfortunately, anchel.nl now redirects to the website of another app which appears to be a competitor of Matrix.

Perhaps, it would make sense to replace it with [JoinMatrix's list](https://joinmatrix.org/servers/), but I figured it would be better to first fix this, and later ask permission to the website's owner to mention it in Matrix's FAQs.