### PR TITLE
Add link to the community made transcription of the video in TWIM

### DIFF
--- a/gatsby/content/blog/2023/02/2023-02-24-twim.mdx
+++ b/gatsby/content/blog/2023/02/2023-02-24-twim.mdx
@@ -11,6 +11,8 @@ image:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/25wkV2ZCSsM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
+Transcription (Community made): https://en.miki.community/wiki/Matrix_Tutorial_7
+
 
 ## Dept of Spec 📜
 


### PR DESCRIPTION
This is a somewhat experimental proposal.

I started doing these transcriptions and thought it might make sense to add them directly in the TWIM edition the video is featured in instead of a week later as a post. Feel free to suggest changes or to reject it if this is unwanted :)

<!-- Replace -->
Preview: https://pr1670--matrix-org-previews.netlify.app
<!-- Replace -->
