### PR TITLE
Fix description of MSC3887 in TWIM 2023-03-03

### DIFF
--- a/gatsby/content/blog/2023/03/2023-03-03-twim.mdx
+++ b/gatsby/content/blog/2023/03/2023-03-03-twim.mdx
@@ -32,6 +32,10 @@ image:
 > * [MSC3758: Add `event_property_is` push rule condition kind](https://github.com/matrix-org/matrix-spec-proposals/pull/3758) (merge)
 > 
 > **Accepted MSCs:**
+>
+> * *No MSCs were accepted this week.*
+>
+> **Closed MSCs:**
 > 
 > * [MSC3887: List matching push rules](https://github.com/matrix-org/matrix-spec-proposals/pull/3887)
 > 


### PR DESCRIPTION
MSC3887 was incorrectly marked as *Accepted*, when in reality it had been *Closed*.