### PR TITLE
fix: update Nix link

### DIFF
--- a/gatsby/content/projects/servers/synapse.mdx
+++ b/gatsby/content/projects/servers/synapse.mdx
@@ -31,7 +31,7 @@ There is a FreeBSD package port [available as net-im/py-matrix-synapse/](https:/
 
 Synapse is also on the [Open Build Service](https://obs.infoserver.lv/project/show/matrix-synapse).
 
-Synapse is available for the [Nix package manager](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/misc/matrix-synapse.nix).
+Synapse is available for the [Nix package manager](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/matrix/synapse.nix).
 
 You can get Synapse on [Yunohost](https://github.com/YunoHost-Apps/synapse_ynh)
 


### PR DESCRIPTION
The link to the Nix package was incorrect.