### PR TITLE
Add a workflow for zola-check

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -2,9 +2,6 @@ name: Check for broken links every week
 on:
   schedule:
     - cron: "0 12 * * 0"
-  pull_request:
-    branches:
-      - 'zola'
 jobs:
   zola-check:
     runs-on: ubuntu-latest
@@ -12,7 +9,7 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v2
-      - uses: MTRNord/zola-check-manager@v1
+      - uses: MTRNord/zola-check-manager@v1.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           conclusion_level: neutral

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,18 @@
+name: Check for broken links every week
+on:
+  schedule:
+    - cron: "0 12 * * 0"
+  pull_request:
+    branches:
+      - 'zola'
+jobs:
+  zola-check:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MTRNord/zola-check-manager@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          conclusion_level: neutral


### PR DESCRIPTION
The workflow executes zola check and generates check results and file annotations from it.
It also mentions webarchive links if one is available.

This doesn't work on PRs yet, since the workflow doesn't diff results for PRs yet. Also, it currently takes about 3h for this repo currently.

More info on the workflow is here: https://github.com/MTRNord/zola-check-manager/
Example output is: https://github.com/MTRNord/zola-check-manager/runs/12772905612