### PR TITLE
[Zola] Remove width and height attributes in youtube embeds to make sure these are responsive

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -42,3 +42,6 @@ loca = "loca" # loca.lt
 onl = "onl" # supercable.onl
 ons = "ons" # add-ons
 whos = "whos" # whos-in-this-room
+
+# Name
+Brose = "Brose"

--- a/content/blog/2015/05/2015-05-18-matrix-wins-best-of-show-at-webrtc-world.md
+++ b/content/blog/2015/05/2015-05-18-matrix-wins-best-of-show-at-webrtc-world.md
@@ -21,14 +21,14 @@ It turns out that all the demo excitement was worth it in the end, as the jury s
 
 Meanwhile, the slides from the demo presentation can be found here: <a href="/blog/wp-content/uploads/2015/05/2015-05-12-Matrix-Demo-Miami.pdf">Building bridges between islands of communication</a>, and you can see the full video of our Demo here:
 
-<iframe src="https://www.youtube.com/embed/OMzDklvDS3c" frameBorder="0" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/OMzDklvDS3c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ...and the actual video stream that the drone transmitted before I crashed it (recorded on Janus) is at...
 
-<iframe src="https://www.youtube.com/embed/NpBStIIq6fM" frameBorder="0" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/NpBStIIq6fM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Finally, our grand finale was meant to be combining the two demos, and showing OpenWebRTC decoding the H.264 from the Drone in hardware on an iPhone - using Matrix of course to set up the call and control the drone.  Alas a TURN-related bug got in the way of this working, but we just fixed it up in the office this morning, and I'm proud to show the first ever Parrot Bebop -> Janus -> Matrix -> OpenWebRTC video stream!! (and very exciting it is too...)
 
-<iframe src="https://www.youtube.com/embed/KsJOqLcpzNM" frameBorder="0" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/KsJOqLcpzNM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Huge thanks again to Dave for doing the Matrix integration with Janus, Stefan and Rob from OpenWebRTC for all the help on the OWR side, and Manu & Giom for porting the OpenWebRTC pull request to MatrixKit and landing it in iOS Console Develop for the demo!

--- a/content/blog/2015/06/2015-06-01-matrix-wins-most-entertaining-demo-at-kamailio-world.md
+++ b/content/blog/2015/06/2015-06-01-matrix-wins-most-entertaining-demo-at-kamailio-world.md
@@ -15,11 +15,11 @@ It was great to catch up with old acquaintances - and meet many new ones! There 
 
 <a href="http://matrix.org/blog/wp-content/uploads/2015/06/2015-05-29-Matrix-KamailioWorld.pptx">Here are the slides</a> of Matthew's presentation, (<a href="http://matrix.org/blog/wp-content/uploads/2015/06/2015-05-29-Matrix-KamailioWorld.pdf">also available as .pdf</a>) and a video of the presentation:
 
-<iframe src="https://www.youtube.com/embed/E0uMm04MIuk" frameBorder="0" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/E0uMm04MIuk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 A video from the dangerous demo event is available here:
 
-<iframe src="https://www.youtube.com/embed/D7jZSYkXqt4?start=2630" frameBorder="0" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/D7jZSYkXqt4?start=2630" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 The Parrot Drone we use in the demo has a 14 megapixel fisheye camera with advanced stabilization techniques which means that you can't actually see what happened when everybody went "ooh" - I assure you the "flip" command does exactly what you would expect!
 

--- a/content/blog/2015/06/2015-06-16-global-tadhack-matrix-hacks.md
+++ b/content/blog/2015/06/2015-06-16-global-tadhack-matrix-hacks.md
@@ -24,9 +24,9 @@ We awarded our two prizes to Igor for his use of OpenMarket's SMS AS, which adds
 
 Below you can watch our two winners' presentations:
 
-<iframe src="https://www.youtube.com/embed/chp8K8Wn6v8" frameBorder="0" allowFullScreen></iframe>
+<div class="video-container"><iframe src="https://www.youtube.com/embed/chp8K8Wn6v8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
-<iframe src="https://www.youtube.com/embed/6ybaaMPUVx0" frameBorder="0" allowFullScreen></iframe>
+ <div class="video-container"><iframe src="https://www.youtube.com/embed/6ybaaMPUVx0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 
 The <a href="http://blog.tadhack.com/">TADHack blog</a> has a list of all the winners: <a href="http://blog.tadhack.com/2015/06/16/tadhack-location-winner/">local winners</a> and <a href="http://blog.tadhack.com/2015/06/15/tadhack-global-winners/">global winners</a>. In total $36k worth of prizes were won!
 

--- a/content/blog/2015/06/2015-06-16-global-tadhack-matrix-hacks.md
+++ b/content/blog/2015/06/2015-06-16-global-tadhack-matrix-hacks.md
@@ -24,9 +24,9 @@ We awarded our two prizes to Igor for his use of OpenMarket's SMS AS, which adds
 
 Below you can watch our two winners' presentations:
 
-<div class="video-container"><iframe src="https://www.youtube.com/embed/chp8K8Wn6v8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+<iframe src="https://www.youtube.com/embed/chp8K8Wn6v8" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
- <div class="video-container"><iframe src="https://www.youtube.com/embed/6ybaaMPUVx0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+<iframe src="https://www.youtube.com/embed/6ybaaMPUVx0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 The <a href="http://blog.tadhack.com/">TADHack blog</a> has a list of all the winners: <a href="http://blog.tadhack.com/2015/06/16/tadhack-location-winner/">local winners</a> and <a href="http://blog.tadhack.com/2015/06/15/tadhack-global-winners/">global winners</a>. In total $36k worth of prizes were won!
 

--- a/content/blog/2015/12/2015-12-25-the-matrix-holiday-special.md
+++ b/content/blog/2015/12/2015-12-25-the-matrix-holiday-special.md
@@ -40,7 +40,7 @@ Meanwhile, huge kudos to Tor who was crazy enough to <a href="https://github.com
 
 A few days after Jardin Entropique we made it to <a href="https://www.leandus.de/">Lean DUS</a> - a great tech meetup in Düsseldorf organised by <a href="http://sipgate.de">Sipgate</a>, who were kind enough to invite us to speak.  This was a chance to give a full update on Matrix (as of July!) and talk some more about Olm and plans for end-to-end encryption.  This one got recorded - and you can see it below.  There's also an official page with full videos, slide deck and photos up at <a href="https://www.leandus.de/2015/08/weil-und-hodgson/">https://www.leandus.de/2015/08/weil-und-hodgson/</a>.
 
-<iframe src="https://player.vimeo.com/video/134821506" width="500" height="281" frameBorder="0" webkitallowfullscreen mozallowfullscreen allowFullScreen></iframe>
+<iframe src="https://player.vimeo.com/video/134821506" frameBorder="0" webkitallowfullscreen mozallowfullscreen allowFullScreen></iframe>
 
 <a href="https://vimeo.com/134821506">Lean Dus #9 - End to end encryption for decentralised communication mit Matthew Hodgson</a> from <a href="https://vimeo.com/sipgate">sipgate</a> on <a href="https://vimeo.com">Vimeo</a>.
 

--- a/content/blog/2017/04/2017-04-04-opening-up-cyberspace-with-matrix-and-webvr.md
+++ b/content/blog/2017/04/2017-04-04-opening-up-cyberspace-with-matrix-and-webvr.md
@@ -51,7 +51,7 @@ Needless to say, the demo's open sourced under the Apache License like all thing
 
 The demo is quite high-bandwidth and hardware intensive, so here's a video of it in action, just in case:
 
-<iframe src="https://www.youtube.com/embed/nk0nMlVXkbk" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/nk0nMlVXkbk" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 Now, it's important to understand that here we're using Matrix as a standard communications API for VR, but we're not using Matrix to store any VR world data (yet).  The demo uses plain A-Frame via aframe-react to render its world: we are not providing an API which exposes the world itself onto the network for folks to interact with and extend.  This is because Matrix is currently optimised for storing and synchronising two types of data structure: decentralised timelines of conversation data, and arbitrary decentralised key-value data (e.g. room names, membership, topics).
 

--- a/content/blog/2017/08/2017-08-24-the-librem-5-from-purism-a-matrix-native-smartphone.md
+++ b/content/blog/2017/08/2017-08-24-the-librem-5-from-purism-a-matrix-native-smartphone.md
@@ -25,7 +25,7 @@ So, if you're interested in being first to own the world's first ever Matrix-nat
 
 Finally, for more context, here's a special mid-week episode of Matrix "Live", featuring Matthew and Todd Weaver, the CEO of Purism, discussing the Librem 5 and what it means for both Purism and Matrix!
 
-<iframe src="https://www.youtube.com/embed/hwFjWDAyG38" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/hwFjWDAyG38" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 As always, feedback on this project is very welcome - come tell us in <a href="https://matrix.to/#/#matrix:matrix.org">#matrix:matrix.org</a> what you think!  And thank you, if you choose to support this campaign :)
 

--- a/content/blog/2017/10/2017-10-12-announcing-matrix-meetup-in-berlin-october-19th.md
+++ b/content/blog/2017/10/2017-10-12-announcing-matrix-meetup-in-berlin-october-19th.md
@@ -31,4 +31,4 @@ As a taster: the official video of our massive talk from the ETHLDN meetup a few
 
 See you next week! :D
 
-<iframe src="https://www.youtube.com/embed/y0-j4Q77KXM" frameBorder="0" allowFullScreen></iframe>
+<iframe src="https://www.youtube.com/embed/y0-j4Q77KXM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/blog/2018/02/2018-02-05-3d-video-calling-with-matrix-webrtc-and-webvr-at-fosdem-2018.md
+++ b/content/blog/2018/02/2018-02-05-3d-video-calling-with-matrix-webrtc-and-webvr-at-fosdem-2018.md
@@ -76,7 +76,7 @@ However, the dot cloud obviously has some limitations - especially when you zoom
 
 And here's the end result! (complete with trancey soundtrack as the audio we recorded at FOSDEM was unusable)
 
-<iframe src="https://www.youtube.com/embed/XvdZ2orVnrk" width="1120" height="630" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/XvdZ2orVnrk" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 <strong>Conclusion:</strong>
 

--- a/content/blog/2018/04/2018-04-20-this-week-in-matrix-2018-04-20.md
+++ b/content/blog/2018/04/2018-04-20-this-week-in-matrix-2018-04-20.md
@@ -189,7 +189,7 @@ Huge thank you to <a href="http://matrix.to/#/@nouts:matrix.org">nouts</a> who p
 
 Check out Matrix Live, now available at <a class="linkified" href="https://youtu.be/EstVaVUWkdw" rel="noopener">https://youtu.be/EstVaVUWkdw</a>
 
-<iframe src="https://www.youtube.com/embed/EstVaVUWkdw" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/EstVaVUWkdw" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 Thanks for reading the very first This Week in Matrix! There will be another post next week, so if you'd like to be included join us in <a class="linkified" href="https://matrix.to/#/#twim:matrix.org" rel="noopener">#twim:matrix.org</a>. See you next week!
 

--- a/content/blog/2018/05/2018-05-04-this-week-in-matrix-2018-05-04.md
+++ b/content/blog/2018/05/2018-05-04-this-week-in-matrix-2018-05-04.md
@@ -159,4 +159,4 @@ Amber Brown of the <a href="https://twistedmatrix.com/trac/">Twisted project</a>
 
 Matrix Live is now available, where among other things you can see this blog post being written!
 
-<iframe src="https://www.youtube.com/embed/mjVexIiI9hw" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/mjVexIiI9hw" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/05/2018-05-18-this-week-in-matrix-2018-05-18.md
+++ b/content/blog/2018/05/2018-05-18-this-week-in-matrix-2018-05-18.md
@@ -143,4 +143,4 @@ That's all for now! Join us on <a href="https://matrix.to/#/#TWIM:matrix.org">#T
 
 Check out this week's Matrix Live below, and we'll see you next week!
 
-<iframe src="https://www.youtube.com/embed/9OS99m1f4Uo" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/9OS99m1f4Uo" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/06/2018-06-01-this-week-in-matrix-2018-06-01.md
+++ b/content/blog/2018/06/2018-06-01-this-week-in-matrix-2018-06-01.md
@@ -120,4 +120,4 @@ It's now possible to install <a href="https://github.com/mujx/nheko">nheko</a> a
 
 … and that's plenty for the week! Take a look at Matrix Live below, and join us in <a href="https://matrix.to/#/#TWIM:matrix.org">#twim:matrix.org</a> if you have something which should be included.
 
-<iframe src="https://www.youtube.com/embed/8MVMrLsbznk" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/8MVMrLsbznk" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/06/2018-06-08-this-week-in-matrix-2018-06-08.md
+++ b/content/blog/2018/06/2018-06-08-this-week-in-matrix-2018-06-08.md
@@ -41,7 +41,7 @@ We are rich in client announcements this week!
 
 I enjoyed this video enough that I'm embedding it here:
 
-<iframe src="https://www.youtube.com/embed/AuGuxAPuRIM" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/AuGuxAPuRIM" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ### <a href="https://gitlab.com/b0/matrique-go">matrique</a> returns
 
@@ -209,4 +209,4 @@ And here it is. As you may have noticed, I'm leaning much more toward quoting wh
 
 Check out Matrix Live:
 
-<iframe src="https://www.youtube.com/embed/_DQY0qTvyAw" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/_DQY0qTvyAw" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/06/2018-06-29-this-week-in-matrix-2018-06-29.md
+++ b/content/blog/2018/06/2018-06-29-this-week-in-matrix-2018-06-29.md
@@ -117,4 +117,4 @@ From Tobias:
 
 All good things must come to an end, so it is with this blog post! Watch this week's Matrix Live (hosted by yours truly) below, and come see us in <a href="https://matrix.to/#/#TWIM:matrix.org">#twim:matrix.org</a>!
 
-<iframe src="https://www.youtube.com/embed/JWUcLJ8ueRk" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/JWUcLJ8ueRk" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/07/2018-07-13-this-week-in-matrix-2018-07-13.md
+++ b/content/blog/2018/07/2018-07-13-this-week-in-matrix-2018-07-13.md
@@ -126,4 +126,4 @@ New to me, <a href="https://github.com/ChristianPauly/fluffychat">fluffychat</a>
 
 Watch Matrix Live below, and see you next week!
 
-<iframe src="https://www.youtube.com/embed/X1aGj3DFuWI" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/X1aGj3DFuWI" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/07/2018-07-20-this-week-in-matrix-2018-07-20.md
+++ b/content/blog/2018/07/2018-07-20-this-week-in-matrix-2018-07-20.md
@@ -82,4 +82,4 @@ Meanwhile, lots of work on Lazy Loading members on Riot/Web and Riot/iOS, and lo
 
 And finally, all you could ever want to hear about the new State Resolution algorithm on a special edition of Matrix Live, starring Erik & Matthew!
 
-<iframe src="https://www.youtube.com/embed/f6ZdmPSUUBA" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/f6ZdmPSUUBA" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/07/2018-07-27-this-week-in-matrix-2018-07-27.md
+++ b/content/blog/2018/07/2018-07-27-this-week-in-matrix-2018-07-27.md
@@ -114,4 +114,4 @@ Too bad indeed!
 
 See you next week, and don't forget to watch Matrix Live below!
 
-<iframe src="https://www.youtube.com/embed/hOM0y2Q45xY" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/hOM0y2Q45xY" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/08/2018-08-04-this-week-in-matrix-2018-08-03.md
+++ b/content/blog/2018/08/2018-08-04-this-week-in-matrix-2018-08-03.md
@@ -149,4 +149,4 @@ Meanwhile, Matthew & Amandine have been in San Francisco for the 2018 <a href="h
 
 Edit: <a href="/blog/wp-content/uploads/2018/08/2018-08-01-DWeb-1.pdf">Here are the slides</a> for our "<a href="https://decentralizedwebsummit2018.sched.com/event/Fhlb/workshop-diving-into-decentralized-communication">Diving into Decentralised Communication</a>" workshop, for those interested in a comparison between Matrix/SSB/Mastodon/Status/Vuvuzela/Briar.  They're pretty minimal, as they just formed a framework for discussion, but might still be of interest.
 
-<iframe src="https://www.youtube.com/embed/Fi-klattR2k" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/Fi-klattR2k" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/08/2018-08-17-this-week-in-matrix-2018-08-17.md
+++ b/content/blog/2018/08/2018-08-17-this-week-in-matrix-2018-08-17.md
@@ -72,7 +72,7 @@ Quaternion is looking for a macOS packager - if someone has the chance to help o
 
 > A few days back Palaver has been moved to Gitlab. And I have since released v0.2.0 and v0.2.1. A runnable jar-file of the latest release can be downloaded at <a href="https://gitlab.com/MrCustomizer/palaver/tags/v0.2.1">https://gitlab.com/MrCustomizer/palaver/tags/v0.2.1</a>. The biggest changes in v0.2.x are the replacement of all the web views with native JavaFX components (as I don't feel comfortable embedding a whole browser stack in a desktop application) and support for read markers. There is a short YouTube video demonstrating the read marker implementation:
 
-<iframe src="https://www.youtube.com/embed/YKqHYe2m3t0" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/YKqHYe2m3t0" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ### Riot mobile
 
@@ -178,4 +178,4 @@ This weekend Neil and I will be representing Matrix at <a href="https://oggcamp.
 
 But for now, you can watch Neil host Matrix Live below (using the fan-favourite format of walking around the office), and come chat to us in <a href="https://matrix.to/#/#TWIM:matrix.org">#twim:matrix.org</a>
 
-<iframe src="https://www.youtube.com/embed/nIfeNNTqdbs?rel=0" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/nIfeNNTqdbs?rel=0" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/08/2018-08-24-this-week-in-matrix-2018-08-24.md
+++ b/content/blog/2018/08/2018-08-24-this-week-in-matrix-2018-08-24.md
@@ -201,4 +201,4 @@ Presentations from Ben and Half-Shot seemed to go down well, we all chatted with
 
 Hope you had a good week, hope you enjoyed reading this post! Amandine is back after some needed vacation time, and has this week's Matrix Live below.
 
-<iframe src="https://www.youtube.com/embed/svM5E4RTQuI" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/svM5E4RTQuI" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/09/2018-09-15-this-week-in-matrix-2018-09-14.md
+++ b/content/blog/2018/09/2018-09-15-this-week-in-matrix-2018-09-14.md
@@ -168,4 +168,4 @@ Finally, there's been a massive amount of work on the <a href="https://vector.im
 
 We've had a bit of an accidental hiatus on Matrix Live thanks to getting submerged all the different project endgames happening atm (spec releases, lazy loading, Modular, Riot redesign etc), and for the last few Fridays we've got to midnight and beyond with too much still on the todo list to justify recording a video.  But to avoid completely falling behind, here's a slightly exhausted Saturday morning update instead (warning: Matthew is not a morning person).
 
-<iframe src="https://www.youtube.com/embed/7m5adJ2n_-0" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/7m5adJ2n_-0" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/09/2018-09-21-this-week-in-matrix-2018-09-21.md
+++ b/content/blog/2018/09/2018-09-21-this-week-in-matrix-2018-09-21.md
@@ -185,4 +185,4 @@ Lots of work on Lazy Loading - to be released along with Riot Web.
 
 Thanks for reading, take a look at Matrix Live below!
 
-<iframe src="https://www.youtube.com/embed/pusCGlJaZxU" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/pusCGlJaZxU" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/10/2018-10-12-this-week-in-matrix-2018-10-12.md
+++ b/content/blog/2018/10/2018-10-12-this-week-in-matrix-2018-10-12.md
@@ -104,4 +104,4 @@ If it didn't seem that <a href="https://matrix.to/#/@kitsune:matrix.org">kitsune
 
 Safe travels to <a href="https://matrix.to/#/@cadair:cadair.com">Cadair</a>, who is off to represent Matrix at the <a href="https://summerofcode.withgoogle.com/projects/?sp-search=matrix">GSOC 2018</a> mentors summit. Check out Matrix Live below:
 
-<iframe src="https://www.youtube.com/embed/hu6fgPlpqok?rel=0" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/hu6fgPlpqok?rel=0" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2018/10/2018-10-27-this-week-in-matrix-2018-10-26.md
+++ b/content/blog/2018/10/2018-10-27-this-week-in-matrix-2018-10-26.md
@@ -154,6 +154,6 @@ This week, <a href="https://matrix.to/#/@vabd:weu.informo.network">vabd</a> repo
 
 <a href="https://mozillafestival.org">Mozfest</a> is a tech-focused event happening this weekend in London. Neil and I have been along tonight and we've been chatting to a lot of people about Matrix, decentralisation and all those things we love! Check out our very short and sweet video below!
 
-<iframe src="https://www.youtube.com/embed/ZqfTYwDz9HM" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/ZqfTYwDz9HM" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 This is the start of Season Three of Matrix Live. Matrix Live seasons are variable in length, based on the data available so far. From this season, Matrix Live with change the format slightly, based on feedback. The videos will try to be a bit more interesting, varied, and deep. With this video being the start of a new season, it was meant to be more substantive with us talking to Mozfest-ites, but I lost track of time, so this shorter but still energetic video will hopefully convey the idea.

--- a/content/blog/2018/11/2018-11-02-this-week-in-matrix-2018-11-02.md
+++ b/content/blog/2018/11/2018-11-02-this-week-in-matrix-2018-11-02.md
@@ -95,7 +95,7 @@ To find these channels, join the community at <a href="https://matrix.to/#/+linu
 
 We continue the new season of Matrix Live. This re-booted season has a slightly different format to previous: in each outing, there will be a single deep-dive topic. This week, Matthew and recent-Matrix-arrival Nad discuss UX for E2E encryption key handling. This is an unsurprisingly complex design question, both in terms of how it should behave and how it should look. Nad shared his <a href="/blog/2018/11/02/user-experience-preview-end-to-end-encryption-by-default/">latest thinking in a blog post earlier today</a>, and you can watch the video below.
 
-<iframe src="https://www.youtube.com/embed/XB5jsG0Vpw8" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/XB5jsG0Vpw8" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Farewell
 

--- a/content/blog/2018/11/2018-11-09-this-week-in-matrix-2018-11-09.md
+++ b/content/blog/2018/11/2018-11-09-this-week-in-matrix-2018-11-09.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 We continue the new format for Matrix Live season 3 by chatting with <a href="https://matrix.to/#/@ganfra:matrix.org">Francois</a> from New Vector, to get a sneak preview of the work he's doing on a new version of <a href="https://github.com/matrix-org/matrix-android-sdk">matrix-android-sdk</a>, and how that will impact Riot:
 
-<iframe src="https://www.youtube.com/embed/z6XXDQMPgro" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/z6XXDQMPgro" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Dendrite and Brendan
 
@@ -97,7 +97,7 @@ The room for collaborating on matrix-puppet-bridge bridges is: <a href="https://
 
 > I have made a video about Riot which could fit in the Guides on matrix.org. It's for beginners, in French. It's 6 months old, but I just uploaded it on youtube. Also it's <a href="https://video.taboulisme.com/videos/watch/8375099e-b748-453d-8557-c5218bd872d7">available on peertube</a>.
 
-<iframe src="https://www.youtube.com/embed/TUgQ7Qh754w" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/TUgQ7Qh754w" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## More Things This Week
 

--- a/content/blog/2018/11/2018-11-16-this-week-in-matrix-2018-11-16.md
+++ b/content/blog/2018/11/2018-11-16-this-week-in-matrix-2018-11-16.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 This week we continue Matrix Live Season 3 by talking to community member <a href="https://matrix.to/#/@axx:jaccu.se">axx</a>, Axel Simon from <a href="https://www.laquadrature.net/">La Quadrature du Net</a>, a French advocacy group that promotes digital rights and freedoms of citizens. We talk about the work La Quadrature du Net do, with a focus on the importance of decentralisation and how Matrix helps support this.
 
-<iframe src="https://www.youtube.com/embed/rgaeiQUhsCs" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/rgaeiQUhsCs" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## mxisd v1.2.0 released
 

--- a/content/blog/2018/11/2018-11-30-this-week-in-matrix-2018-11-30.md
+++ b/content/blog/2018/11/2018-11-30-this-week-in-matrix-2018-11-30.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 Longer than usual episode of Matrix Live this week. Amber talks to Neil about the works she's been doing over the last few months to port Synapse from Python 2 to Python 3. Recommended for anyone who's been following along the progress of Synapse, or who wants a good intro on the benefits of Python 3 over Python 2.
 
-<iframe src="https://www.youtube.com/embed/Ad3oqEo5leM" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/Ad3oqEo5leM" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## ZeroPhone
 

--- a/content/blog/2018/12/2018-12-07-this-week-in-matrix-2018-12-07.md
+++ b/content/blog/2018/12/2018-12-07-this-week-in-matrix-2018-12-07.md
@@ -9,7 +9,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live S03E06
 
-<iframe src="https://www.youtube.com/embed/BOyKC-nf-KE" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/BOyKC-nf-KE" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 In which Matthew & Amandine discuss The Matrix.org Foundation, go-live for the French Government deployment for Matrix, and some exciting random diversions into post-1.0 Matrix features which should land once once 1.0 is out the door!
 
@@ -101,7 +101,7 @@ Modular is a Hosted Homeservers product, check out <a href="https://www.modular.
 
 As we mentioned in TWIM last week, <a href="https://matrix.to/#/@MTRNord:matrix.ffslfl.net">MTRNord</a> has been working on designs for <a href="https://gitlab.com/Nordgedanken/SimpleMatrix">SimpleMatrix</a>, a Matrix client for Android in development. This week he has made a video showcasing the new design.
 
-<iframe src="https://www.youtube.com/embed/ci3N9ZSUa6k" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/ci3N9ZSUa6k" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Redecentralize meetup in London
 

--- a/content/blog/2018/12/2018-12-14-this-week-in-matrix-2018-12-14.md
+++ b/content/blog/2018/12/2018-12-14-this-week-in-matrix-2018-12-14.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 Developers and creators of <a href="https://wiki.gnome.org/Apps/Fractal">Fractal</a>, the GNOME Matrix client, have been holding a <a href="https://wiki.gnome.org/Hackfests/FractalDecember2018">Hackfest this week in Seville</a>. Matthew and I caught up with them on video for Matrix Live this week, and discussed the product improvements they've been making and their plans for the next release (due next week!)
 
-<iframe src="https://www.youtube.com/embed/SgyLHi8zZXQ" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/SgyLHi8zZXQ" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Matrix Spec
 

--- a/content/blog/2018/12/2018-12-21-this-week-in-matrix-2018-12-21.md
+++ b/content/blog/2018/12/2018-12-21-this-week-in-matrix-2018-12-21.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 You may have seen that <a href="https://matrix.to/#/@Half-Shot:half-shot.uk">Half-Shot</a> been working fearlessly and tirelessly on bridges for many, many months. In this episode of Matrix Live Half-Shot chats with Matthew about his work, progress and achievements, with a focus on recent <a href="https://github.com/matrix-org/matrix-appservice-purple">matrix-appservice-purple</a> and XMPP work. Audio is not amazing, but worth listening to get acquainted with recent work.
 
-<iframe src="https://www.youtube.com/embed/B0faoVdw0ak" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/B0faoVdw0ak" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 As a note from <a href="https://matrix.to/#/@Half-Shot:half-shot.uk">Half-Shot</a>:
 

--- a/content/blog/2019/01/2019-01-04-this-week-in-matrix-2019-01-04.md
+++ b/content/blog/2019/01/2019-01-04-this-week-in-matrix-2019-01-04.md
@@ -15,7 +15,7 @@ It's been 2019 for several days now, plenty of time to get used to it! Let's get
 
 Several Matrix-ers attended 35C3 in Leipzig last month, you can check out Matrix Live recorded from the conference below (also includes some screenshots and other clips of the event), and also watch a talk given by this author titled <em><a href="https://media.ccc.de/v/35c3-9400-matrix_the_current_status_and_year_to_date">Matrix, the current status and year to date</a></em>.
 
-<iframe src="https://www.youtube.com/embed/FWlKomAY5PM" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/FWlKomAY5PM" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Welcoming Jason Robinson to New Vector
 

--- a/content/blog/2019/01/2019-01-11-this-week-in-matrix-2019-01-11.md
+++ b/content/blog/2019/01/2019-01-11-this-week-in-matrix-2019-01-11.md
@@ -47,7 +47,7 @@ Lots of spec work this week, and a shout out to <a href="https://matrix.to/#/@an
 
 And whilst we have your attention - here's Brendan & Matthew talking through the audit in this week's Matrix Live!
 
-<iframe src="https://www.youtube.com/embed/NaxL-jNvcSA" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/NaxL-jNvcSA" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ### Synapse
 

--- a/content/blog/2019/01/2019-01-18-this-week-in-matrix-2019-01-18.md
+++ b/content/blog/2019/01/2019-01-18-this-week-in-matrix-2019-01-18.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 This week I chatted with Jason Robinson about all things decentralisation, especially his projects <a href="https://github.com/jaywink/socialhome">socialhome</a>, <a href="https://the-federation.info/">the-federation.info</a>, and <a href="https://feneas.org">feneas.org</a>. Jason has been interested in decentralisation for many years, and had a lot to say about how we can look forward to a more decentralised Internet.
 
-<iframe src="https://www.youtube.com/embed/xPoMre1DKjQ" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/xPoMre1DKjQ" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ### Latest MSC updates (from anoa's MSC bot)
 

--- a/content/blog/2019/01/2019-01-25-this-week-in-matrix-2019-01-25.md
+++ b/content/blog/2019/01/2019-01-25-this-week-in-matrix-2019-01-25.md
@@ -9,7 +9,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live S03E12 - Modular.im
 
-<iframe src="https://www.youtube.com/embed/Z7bz4fAJyVE" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/Z7bz4fAJyVE" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 This week I chatted to Rick about the release of <a href="https://www.modular.im/">Modular</a>, Hosted Homeservers and more. We're pleased to be able to announce the availability of a <a href="https://www.modular.im/hipchat">HipChat migration tool</a> to get people into Matrix.
 

--- a/content/blog/2019/02/2019-02-04-matrix-at-fosdem-2019.md
+++ b/content/blog/2019/02/2019-02-04-matrix-at-fosdem-2019.md
@@ -18,13 +18,13 @@ The big news is that <strong>we released <a href="/docs/spec/server_server/r0.1
 
 We spoke about SS API r0.1 at length in <a href="https://fosdem.org/2019/schedule/event/matrix_french_state/">our main stage FOSDEM talk </a>on Saturday - as well as showing off the Riot Redesign, the E2E Encryption Endgame and giving an update on the French Government deployment of Matrix and the focus it's given us on finally shipping Matrix 1.0! For those who weren't there or missed the livestream, here's the talk!  <a href="/blog/wp-content/uploads/2019/02/2019-02-01-FOSDEM-Matrix-1.0.pdf">Slides are available here</a>.
 
-<iframe src="https://www.youtube.com/embed/C2eE7rCUKlE" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/C2eE7rCUKlE" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 > <p lang="en" dir="ltr">Full house for <a href="https://twitter.com/ara4n?ref_src=twsrc%5Etfw">@ara4n</a> talking about <a href="https://twitter.com/matrixdotorg?ref_src=twsrc%5Etfw">@matrixdotorg</a> and the French State <a href="https://twitter.com/fosdem?ref_src=twsrc%5Etfw">@fosdem</a> It was a packed presentation full of lots exciting progress demos. So sorry for practically yanking you offstage in the end! <a href="https://t.co/idshDcSRhv">pic.twitter.com/idshDcSRhv</a></p>&mdash; Rob Pickering (@RobinJPickering) <a href="https://twitter.com/RobinJPickering/status/1091725803715481607?ref_src=twsrc%5Etfw">February 2, 2019</a>
 
 Then, on Sunday we had the opportunity to have a quick <a href="https://fosdem.org/2019/schedule/event/matrix/">20 minute talk in the Real Time Comms dev room</a>, where we gave a tour of some of the work we've been doing recently to scale Matrix down to working on incredibly low bandwidth networks (100bps or less).  It's literally the opposite of the Matrix 1.0 / France talk in that it's a quick deep dive into a very specific problem area in Matrix - so, if you've been looking forward to Matrix finally having a better transport than HTTPS+JSON, here goes!  <a href="/blog/wp-content/uploads/2019/02/2019-02-03-FOSDEM-Low-Bandwidth.pdf">Slides are available here.</a>
 
-<iframe src="https://www.youtube.com/embed/DZBvy4abB1o" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"><span data-mce-type="bookmark" style="display: inline-block; width: 0px; overflow: hidden; line-height: 0;" class="mce_SELRES_start">﻿</span></iframe>
+<iframe src="https://www.youtube.com/embed/DZBvy4abB1o" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 > <p lang="en" dir="ltr">Full house for <a href="https://twitter.com/matrixdotorg?ref_src=twsrc%5Etfw">@matrixdotorg</a> ? <a href="https://twitter.com/hashtag/FOSDEM?src=hash&ref_src=twsrc%5Etfw">#FOSDEM</a> <a href="https://twitter.com/hashtag/RTCsevroom?src=hash&ref_src=twsrc%5Etfw">#RTCsevroom</a> <a href="https://t.co/dDQnD3mzmc">pic.twitter.com/dDQnD3mzmc</a></p>&mdash; Saúl Ibarra Corretgé (@saghul) <a href="https://twitter.com/saghul/status/1091995116649267201?ref_src=twsrc%5Etfw">February 3, 2019</a>
 

--- a/content/blog/2019/02/2019-02-08-this-week-in-matrix-2019-02-08.md
+++ b/content/blog/2019/02/2019-02-08-this-week-in-matrix-2019-02-08.md
@@ -11,7 +11,7 @@ Huge week! Let's go!
 
 ## Matrix Live: Riot Redesign Chat (2019-02-08 - Season 3, Episode 13)
 
-<iframe src="https://www.youtube.com/embed/Fq3Q50RxQyM" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/Fq3Q50RxQyM" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 Riot-web new version coming out so soon. So soon! It looks and runs great, you can use it today at <a href="https://riot.im/develop">https://riot.im/develop</a>. Includes a labs flag for displaying custom tags, which I love. Watch the vid.
 

--- a/content/blog/2019/02/2019-02-15-publishing-the-backend-roadmap.md
+++ b/content/blog/2019/02/2019-02-15-publishing-the-backend-roadmap.md
@@ -74,7 +74,7 @@ Not at all (it's written in board marker). This is simply a way to express our p
 
 Here is a video of myself and Matthew to talk you through the projects
 
-<iframe src="https://www.youtube.com/embed/LfyQ6cNGbLk" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/LfyQ6cNGbLk" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ### Interesting, but I have questions ...
 

--- a/content/blog/2019/02/2019-02-16-this-week-in-matrix-2019-02-15.md
+++ b/content/blog/2019/02/2019-02-16-this-week-in-matrix-2019-02-15.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 As you may have seen, Matrix Live this week features Neil and Matthew <a href="/blog/2019/02/15/publishing-the-backend-roadmap/">discussing the newly announced backend roadmap</a>.
 
-<iframe src="https://www.youtube.com/embed/LfyQ6cNGbLk" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/LfyQ6cNGbLk" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 We also have <a href="https://github.com/matrix-org/synapse/releases/tag/v0.99.1.1">Synapse v0.99.1.1</a> available, as the race to Synapse v1.0 gets closer and closer and closer!
 
@@ -75,7 +75,7 @@ As if this wasn't enough! <a href="https://github.com/poljar/python-olm">python-
 
 In my role as editor of this particular blog post, I enjoy certain luxuries that others might envy. For example, today, I tried a new preview build of FluffyChat. This I installed on my barely-repaired OnePlus One running Ubuntu Touch 16.04.
 
-<iframe src="https://www.youtube.com/embed/OMQf-afRZEU" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/OMQf-afRZEU" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Fractal
 

--- a/content/blog/2019/02/2019-02-22-this-week-in-matrix-2019-02-22.md
+++ b/content/blog/2019/02/2019-02-22-this-week-in-matrix-2019-02-22.md
@@ -9,7 +9,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live S03E15 - Push To Talk and XMPP Gatewaying!
 
-<iframe src="https://www.youtube.com/embed/mpd-pcr2kKc" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/mpd-pcr2kKc" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 (sorry that the audio from Nad & Half-Shot went missing from the recording... :( )
 

--- a/content/blog/2019/02/2019-02-26-bridging-matrix-with-whatsapp-running-on-a-vm.md
+++ b/content/blog/2019/02/2019-02-26-bridging-matrix-with-whatsapp-running-on-a-vm.md
@@ -74,4 +74,4 @@ And that's it! You may need to take a little time to watch the sync happen, part
 
 ## Demo!
 
-<iframe src="https://www.youtube.com/embed/edSgP2dEZ1o" width="960" height="540" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/edSgP2dEZ1o" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>

--- a/content/blog/2019/03/2019-03-08-this-week-in-matrix-2019-03-08.md
+++ b/content/blog/2019/03/2019-03-08-this-week-in-matrix-2019-03-08.md
@@ -19,7 +19,7 @@ From Neil of the Synapse-team
 
 And this week we have Neil and Erik talking about this in more detail on Matrix Live
 
-<iframe src="https://www.youtube.com/embed/dPvis1eEMDM" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/dPvis1eEMDM" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## JeonServer and related project updates
 
@@ -94,7 +94,7 @@ The volume of discussion about installing/configuring Synapse and other Matrix-r
 
 You can check out the video of the bridge in operation here:
 
-<iframe src="https://www.youtube.com/embed/0vDMlBSXGw4" width="640" height="441" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/0vDMlBSXGw4" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Spectral development restart
 

--- a/content/blog/2019/03/2019-03-12-breaking-the-100bps-barrier-with-matrix-meshsim-coap-proxy.md
+++ b/content/blog/2019/03/2019-03-12-breaking-the-100bps-barrier-with-matrix-meshsim-coap-proxy.md
@@ -13,7 +13,7 @@ Last month at FOSDEM 2019 we gave a <a href="https://fosdem.org/2019/schedule/ev
 
 The challenge here was to see if we could demonstrate Matrix working usably over networks running at around 100 bits per second of throughput (where it'd take 2 minutes to send a typical 1500 byte ethernet packet!!) and very high latencies.  You can see the original FOSDEM talk below, or <a href="/blog/wp-content/uploads/2019/02/2019-02-03-FOSDEM-Low-Bandwidth.pdf">check out the slides here.</a>
 
-<iframe src="https://www.youtube.com/embed/DZBvy4abB1o" width="1280" height="720" frameBorder="0" allowFullScreen="allowfullscreen"><span data-mce-type="bookmark" style="display: inline-block; width: 0px; overflow: hidden; line-height: 0;" class="mce_SELRES_start">﻿</span></iframe>
+<iframe src="https://www.youtube.com/embed/DZBvy4abB1o"frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 Now, it's taken us a little while to find time to tidy up the stuff we demo'd in the talk to be (relatively) suitable for public consumption, but we're happy to finally release the four projects which powered the demo:
 <ul>

--- a/content/blog/2019/03/2019-03-15-this-week-in-matrix-2019-03-15.md
+++ b/content/blog/2019/03/2019-03-15-this-week-in-matrix-2019-03-15.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 This week you're stuck with me, but I'm chatting to Ryan, who works on Riot web. Having previously worked at Mozilla, Ryan has a LOT of interesting things to say about Firefox, the browser market, the importance of decentralisation, Matrix being GREAT, and more.
 
-<iframe src="https://www.youtube.com/embed/2LiaUmNdT0s" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/2LiaUmNdT0s" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## arewereadyyet.com: Matrix 1.0-ready Federation
 
@@ -178,7 +178,7 @@ Continuing his theme of Native American languages, <a href="https://matrix.to/#/
 
 It's been possible for some time to set up a Matrix server with FreedomBox, and they just recently released a video tutorial showing the process.
 
-<iframe src="https://www.youtube.com/embed/37uoEbVsbNQ" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/37uoEbVsbNQ" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Around the Internets
 

--- a/content/blog/2019/03/2019-03-22-this-week-in-matrix-2019-03-22.md
+++ b/content/blog/2019/03/2019-03-22-this-week-in-matrix-2019-03-22.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 I chatted with <a href="https://matrix.to/#/@kitsune:matrix.org">Kitsune</a>, maintainer of <a href="https://github.com/QMatrixClient/libqmatrixclient">libQMatrixClient</a>, <a href="https://github.com/QMatrixClient/Quaternion">Quaternion</a> and Spec Core Team member. We talked about the history and future of these projects, platform preferences, the importance of decentralisation and more.
 
-<iframe src="https://www.youtube.com/embed/h9uenfVToaw" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/h9uenfVToaw" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Synapse and the road to 1.0
 

--- a/content/blog/2019/03/2019-03-29-this-week-in-matrix-2019-03-29.md
+++ b/content/blog/2019/03/2019-03-29-this-week-in-matrix-2019-03-29.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 Tom & Matthew talk through the <a href="https://github.com/vector-im/riot-web/projects/16">newly published Riot/Web roadmap</a>! Be sure to read <a href="https://medium.com/@RiotChat/whats-next-for-riot-web-be48f948c801">Tom's blog post which gets into his thinking for the roadmap</a> too.
 
-<iframe src="https://www.youtube.com/embed/-pKHn0pittY" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/-pKHn0pittY" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Matrix.org homeserver notice
 

--- a/content/blog/2019/04/2019-04-05-this-week-in-matrix-2019-04-05.md
+++ b/content/blog/2019/04/2019-04-05-this-week-in-matrix-2019-04-05.md
@@ -9,7 +9,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live S3E20 FluffyChat creator Krille on Matrix, Ubuntu Touch and Matrix-for-Healthcare
 
-<iframe src="https://www.youtube.com/embed/mLgLwLcq9Ys" width="560" height="315" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
+<iframe src="https://www.youtube.com/embed/mLgLwLcq9Ys" frameBorder="0" allowFullScreen="allowfullscreen"></iframe>
 
 ## Synapse, the road to 1.0
 

--- a/content/blog/2020/04/2020-04-09-this-week-in-matrix-2020-04-09.md
+++ b/content/blog/2020/04/2020-04-09-this-week-in-matrix-2020-04-09.md
@@ -24,7 +24,7 @@ Lineup included:
   * [Find the slides here](/media/Enter-Gossipsub-Slidedeck.pdf)
 * [Valère](https://twitter.com/valereonmobile), from Matrix and Riot, who presented on the importance of UX and cross-signing keys in end-to-end encrypted communications.
 
-<iframe title="APVp-20ATLk" width="560" height="315" src="https://www.youtube.com/embed/APVp-20ATLk" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="APVp-20ATLk" src="https://www.youtube.com/embed/APVp-20ATLk" frameBorder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of Spec 📜
 

--- a/content/blog/2020/05/2020-05-15-this-week-in-matrix-2020-05-15.md
+++ b/content/blog/2020/05/2020-05-15-this-week-in-matrix-2020-05-15.md
@@ -12,7 +12,7 @@ image = "https://matrix.org/blog/img/2020-05-15-0k1yx-screenshot2.png"
 
 ## Open Tech Will Save Us 🎙
 
-<iframe title="O3YP1TU-L_8" width="560" height="315" src="https://www.youtube.com/embed/O3YP1TU-L_8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe title="O3YP1TU-L_8" src="https://www.youtube.com/embed/O3YP1TU-L_8" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Second edition of OTWSU took place this week! Chance to watch it if you haven't already, or (pro-tip), watch it again. 
 

--- a/content/blog/2022/10/2022-10-21-this-week-in-matrix-2022-10-21.md
+++ b/content/blog/2022/10/2022-10-21-this-week-in-matrix-2022-10-21.md
@@ -14,7 +14,7 @@ image = "https://matrix.org/blog/img/bCHYAuROdvHGWbkVgNwlNmWh.png"
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/514lQYK2vTQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/514lQYK2vTQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 This week 
 

--- a/content/blog/2022/10/2022-10-28-this-week-in-matrix-2022-10-28.md
+++ b/content/blog/2022/10/2022-10-28-this-week-in-matrix-2022-10-28.md
@@ -10,7 +10,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/oLTOh9Wpec4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/oLTOh9Wpec4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of Spec 📜
 

--- a/content/blog/2022/11/2022-11-04-this-week-in-matrix-2022-11-04.md
+++ b/content/blog/2022/11/2022-11-04-this-week-in-matrix-2022-11-04.md
@@ -1,0 +1,399 @@
++++
+title = "This Week in Matrix 2022-11-04"
+date = "2022-11-04T19:27:03Z"
+path = "/blog/2022/11/04/this-week-in-matrix-2022-11-04"
+
+[taxonomies]
+author = ["Thib"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/uIzk9mrrK1M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Dept of Spec 📜
+
+[Andrew Morgan (anoa)](https://matrix.to/#/@andrewm:element.io) says
+
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> 
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3925: m.replace aggregation with full event](https://github.com/matrix-org/matrix-spec-proposals/pull/3925)
+> * [MSC3924: Capability-style access control for Matrix media](https://github.com/matrix-org/matrix-spec-proposals/pull/3924)
+> * [MSC3923: Bringing Matrix into the IETF process](https://github.com/matrix-org/matrix-spec-proposals/pull/3923)
+> * [MSC3922: Removing SRV records from homeserver discovery](https://github.com/matrix-org/matrix-spec-proposals/pull/3922)
+> 
+> **MSCs in Final Comment Period:**
+> * [MSC3030: Jump to date API endpoint](https://github.com/matrix-org/matrix-spec-proposals/pull/3030) (merge)
+> 
+> **Accepted MSCs:**
+> * [MSC3743: Standardized error response for unknown endpoints](https://github.com/matrix-org/matrix-spec-proposals/pull/3743)
+> 
+> **Closed MSCs:**
+> * [MSC3910: Content tokens for media](https://github.com/matrix-org/matrix-spec-proposals/pull/3910)
+>     * Superseded by [MSC3911](https://github.com/matrix-org/matrix-spec-proposals/pull/3911), [MSC3916](https://github.com/matrix-org/matrix-spec-proposals/pull/3916)
+>     
+> ## Spec Updates
+> 
+> This week we've been continuing our mission to define Matrix as the interoperable standard for instant messaging! With many of our discussions expected to happen next week in this area, we've prepared some drafts for the wider community to review (with even more on the way!). With [MSC3923](https://github.com/matrix-org/matrix-spec-proposals/issues/3923), we're asking for feedback on whether people think the approach is something that could work for Matrix, though there is a cautionary note that there's a lot of TODOs to fill still. 
+> 
+> We hope to have even more news next week, but as a reminder: The IETF process is fairly slow-moving as it takes a lot of time to get through the different stages. Keep an eye on MSCs tagged "IETF" or "MIMI" - or watch this space - for updates on how it's going 🙂
+> 
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC3911: Linking media to events](https://github.com/matrix-org/matrix-spec-proposals/pull/3911)!
+> 
+> This MSC attempts to be an addition to authenticated media in matrix (specifically [MSC3916](https://github.com/matrix-org/matrix-spec-proposals/issues/3916)) where successful authentication would also be conditioned on whether or not the user was able to view an associated event in a Matrix room. In plain english, that means that if the media was sent in a room, then you'd need to be in that room to be able to see the media (even if you tried to load the media outside of a matrix client). This change helps address some concerns about media leaking outside of the room it was sent. It also opens up possibilities to delete media if all associated events have been redacted.
+> 
+> Check it out if you're interested in advancing media in Matrix!
+> 
+> ![](/blog/img/d34255258b4e41fba201cf7715767ace7b19f765.png)
+
+## Dept of Servers 🏢
+
+### Telodendria ([website](https://telodendria.io))
+
+An open source Matrix homeserver implementation written from scratch in ANSI C and designed to be lightweight and simple, yet functional
+
+[Jordan Bancino](https://matrix.to/#/@jordan:bancino.net) reports
+
+> [Telodendria](https://telodendria.io) is moving along slowly but steadily. Here are a few brief things to note for this week:
+> 
+> * **[GitHub](https://github.com/Telodendria/Telodendria):** There's now a read-only Git mirror of the source code hosted on GitHub, which you can browse online, or clone if you want to do local work with it.
+> * **Network & Memory Improvements:** I did a lot of work with my debugger this week and made a number of network and memory improvements that make Telodendria *much* more stable and efficient.
+> * **Data API:** I just have begun writing code for persisting data and caching it. At the current pace, I'd expect to see that done around the end of this year.
+> * **Get Involved:** If you want to speed up development, I'm happy to delegate any of the tasks in [`TODO.txt`](https://github.com/Telodendria/Telodendria/blob/master/TODO.txt) to you.
+> * **Matrix:** As a reminder, Telodendria is organized entirely on Matrix at [#telodendria:bancino.net](https://matrix.to/#/#telodendria:bancino.net). There you'll find a number of rooms for various purposes, including submitting patches, discussing Telodendria, and digesting the official newsletter. Feel free to stop by, even if it's just to say hi and express your interest in the project.
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[Shay](https://matrix.to/#/@shayshay:matrix.org) reports
+
+> Welcome to another Friday! Here in Synapse-land we have been hard at work on this week's release candidate: v1.71.0rc2. It contains bugfixes, a few new features, and continued work on speeding up Synapse. Some notable elements are:
+> 
+> * Legacy Prometheus metric names are now disabled by default, and will be removed altogether in Synapse 1.73.0.
+>   If not already done, server administrators should update their dashboards and alerting rules to avoid using the deprecated metric names.
+> 
+> * Synapse now supports back-channel logouts from OpenID Connect providers.
+> 
+> * Synapse now supports use of Postgres and SQLlite full-text search operators in search queries.
+> 
+> * Synapse now implement MSC3664, Pushrules for relations.
+> 
+> You can read more about v1.71.0rc2 here: https://github.com/matrix-org/synapse/releases
+
+### Swiclops ([website](https://gitlab.futo.org/cvwright/swiclops))
+
+A Matrix user-interactive authentication (UIA) server
+
+[cvwright](https://matrix.to/#/@cvwright:matrix.org) announces
+
+> Announcing the first alpha release of [Swiclops](https://gitlab.futo.org/cvwright/swiclops), a server that handles authentication, registration, and other user management tasks for a Matrix homeserver like Synapse.
+> 
+> Swiclops can be configured to provide user-interactive authentication (UIA) on the Matrix `/login` endpoint, similar to [MSC2835](https://github.com/Sorunome/matrix-doc/blob/soru/uia-on-login/proposals/2835-uia-on-login.md).  This opens up many exciting possibilities for the future, including:
+> 
+> * Requiring acceptance of the latest terms of service at login
+> * Multi-stage authentication protocols, such as WebAuthn or PassKeys, or various password-authenticated key exchange (PAKE) protocols
+> * Two-factor authentication
+> 
+> ## Authentication Modules
+> 
+> * [MSC3231](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/3231-token-authenticated-registration.md) Registration Tokens
+> * Token-based email validation
+> * Cryptographic password-based login that does not expose users passwords to the server
+> * Legacy password auth (ie `m.login.password`)
+> * Terms of service
+> * (Coming soon!) Support for registration with paid subscriptions via the Apple App Store and Google Play Store
+> * (Coming soon!) Support for Apple FaceID and TouchID
+> 
+> ## Source Code
+> 
+> [Swiclops release v0.1.0](https://gitlab.futo.org/cvwright/swiclops/-/tags/v0.1.0)
+> 
+> ## Installation
+> 
+> The easiest way to install Swiclops is by using Ansible and Docker.  We have created an Ansible role for it in a fork of the popular [matrix-docker-ansible-deploy](https://github.com/cvwright/matrix-docker-ansible-deploy/tree/swiclops) playbook.
+
+### Dendrite ([website](https://github.com/matrix-org/dendrite))
+
+Second generation Matrix homeserver
+
+[neilalexander](https://matrix.to/#/@neilalexander:matrix.org) says
+
+> We wouldn't ordinarily make so many releases in one week, but we've been quite busy! Instead of including the entire set of changelogs, please see the releases below which have more details about what's changed:
+> 
+> * [Version 0.10.7](https://github.com/matrix-org/dendrite/releases/tag/v0.10.7) today, which fixes a variety of things in `/sync` amongst other things
+> * [Version 0.10.6](https://github.com/matrix-org/dendrite/releases/tag/v0.10.6) on Tuesday, which optimises history visibility, improves E2EE and tweaks some state resolution code
+> * [Version 0.10.5](https://github.com/matrix-org/dendrite/releases/tag/v0.10.5) on Monday, which adds hCaptcha support, improves E2EE and a range of other fixes
+> 
+> If you have a Dendrite homeserver, staying up-to-date is highly recommended so please upgrade when you can. Otherwise, if you want to play with Dendrite without having to set up your own infrastructure, the `dendrite.matrix.org` homeserver is open for registration (upon completion of a CAPTCHA, so you may need to register using [Element Web](https://app.element.io)).
+> 
+> As always, please feel free to join us in [#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org) for related discussion.
+
+## Homeserver Deployment 📥️
+
+[Ananace](https://matrix.to/#/@ace:kittenface.studio) announces
+
+> This week has been quite calm, only a single update to [my Helm Charts](https://gitlab.com/ananace/charts); element-web being bumped to 1.11.13
+
+## Dept of Clients 📱
+
+### SmallTalk ([website](https://github.com/ouchadam/small-talk))
+
+Minimal Android messenger powered by Matrix
+
+[adam](https://matrix.to/#/@adam:iswell.cool) says
+
+> Quick update from _SmallTalk_ - a tiny native android client, currently in BETA
+> 
+> * Fullscreen zoomable image viewer 
+> * Muting room notifications
+> * Rich text formatting (very WIP)
+> * Bug fixes around Android 13 permissions and being unable to login on non synapse homeservers  	
+> 
+> There's been an effort to make the app chat agnostic through the abstraction of a _chat engine_, this could allow different chat protocols to be used or simply swap out matrix SDK implementations (like the matrix-rust-sdk!) 
+> 
+> More information over at [Github](https://github.com/ouchadam/small-talk) & [#small-talk](https://matrix.to/#/#small-talk:iswell.cool)
+
+### Quadrix ([website](https://github.com/alariej/quadrix))
+
+A Minimal, simple, multi-platform chat client for the Matrix protocol.
+
+[JFA](https://matrix.to/#/@alariej:matrix.org) announces
+
+> Quadrix v1.4.5 has been released and is available for mobiles and desktops in the respective app stores (Google Play, App Store, Mac App Store, Microsoft, Snap Store, Flathub).
+> 
+> The main improvement in this release is the added support for the .well-known API call, which allows to register and login on homeservers using a base domain URL.
+> 
+> Also, the displaying of redacted and edited messages has been improved.
+> 
+> I started testing Quadrix on the Conduit server implementation (thanks to @timo:conduit.rs for a test account on conduit.rs) and noticed right away some major issues. A few fixes are already included in this release.
+> 
+> Finally, for PinePhone users, the Ozone/Wayland switch has now been disabled in the flatpak build for Phosh, because of a compatibility issue between Electron and the on-screen keyboard. On Phosh, the app now runs in XWayland mode (it looks blurry) but at least the OSK works.
+> 
+> Please leave feedback/comments at [#quadrix:matrix.org](https://matrix.to/#/#quadrix:matrix.org) or in the issues at https://github.com/alariej/quadrix (stars welcome :-)
+
+### Nheko ([website](https://nheko-reborn.github.io))
+
+Desktop client for Matrix using Qt and C++17.
+
+[red_sky (nheko.im)](https://matrix.to/#/@red_sky:nheko.im) reports
+
+> You can now respond to notifications on macOS in nheko!  These will be sent as a rich reply.  No need to open up the main client any more to respond to folks.
+> 
+> ![](/blog/img/hrkzyZEHglIvGJgwhuVXGThm.png)
+> 
+> ![](/blog/img/iLmLykvzOOKEWABCzNDlUimh.png)
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) says
+
+> As already mentioned, the Apple Silicon builds are now properly packaged.
+> 
+> Additionally we fixed the pagination issues in our search and you should now be able to find more messages. As part of that we also optimized a few database queries again to reduce disk load when running Nheko (which became more noticeable after we enabled some durability flags on the database last week).
+> 
+> There have also been more fixes to the pushrules code. Test code now outnumbers the actual implementation by 4:1. As an additional feature, we do highlight messages marked as "highlight" via a pushrule (i.e. when someone mentions you) in the timeline by adding a red outline.
+> 
+> As part of the push work I also implemented and fixed a few things in Synapse related to pushrules. If replies are not highlighted for you currently, it might be [this bug](https://github.com/matrix-org/synapse/pull/14356). A longer term fix will be [MSC3664](https://github.com/matrix-org/matrix-spec-proposals/pull/3664), which [I also implemented](https://github.com/matrix-org/synapse/pull/11804). I also [fixed some compatibility issues](https://github.com/matrix-org/synapse/pull/13904) when sending pushrules to clients after the recent Synapse refactoring.
+> 
+> ![](/blog/img/FmctAhwrxtFysdEwfdcTnHjP.png)
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[Danielle](https://matrix.to/#/@daniellekirkwood:one.ems.host) reports
+
+> * This week we’ve released a [hotfix](https://github.com/vector-im/element-web/releases) - there’s important changes in this one so please update when you can.
+> * The team is starting to look at improving our Matrix.to links and flow.
+> * There will be some opportunities to contribute here, so if you’re interested keep your eyes on the Help Wanted tag in GitHub
+> * Following our recent research into Notifications we’re starting to build a picture of the things that would be useful to change. We need clearer definitions around defaults, and flexibility in notifications.
+> 
+> In labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> 
+> * We’ve been updating Threads for a few weeks now and some great improvements have landed. If you’re not feeling any improvements [here’s some tips for checking you’re in the right place](https://github.com/vector-im/element-meta/discussions/803)
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Ștefan](https://matrix.to/#/@stefan.ceriu:matrix.org) reports
+
+> * Version [1.9.10](https://github.com/vector-im/element-ios/releases/tag/v1.9.10) is ready for release and brings a handful of bug fixes throughout the app
+> * The rich text editor now has voice message support as well as other updates and performance enhancements
+> * We’ve been making good progress on ElementX push notification support and we’re getting close to a working solution
+> * ElementX also gained a new timeline scroll mechanism and improved concurrency
+> * We have also been working on improving thread notification counts and read receipts
+> * Work continues on the device manager
+> * This week we also saw the first build of the ElementR iOS app, introducing Rust side crypto support to the existing codebase
+> 
+> ![](/blog/img/jfmCFmjIwBnEOAzXehaWjEOr.png)
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[Danielle](https://matrix.to/#/@daniellekirkwood:one.ems.host) announces
+
+> * This week's release has a new media picker when you’re choosing to upload something to the timeline.
+> * We’ve also been working on multi-select in the new device manager
+> * And… Fixing the share actions in the share dialog
+> * In Labs; We’re building loading and pagination improvements for Threads.
+
+## Dept of Non Chat Clients 🎛️
+
+### Circles ([website](https://www.kombuchaprivacy.com/circles/))
+
+E2E encrypted social networking built on Matrix. Safe, private sharing for your friends, family, and community.
+
+[cvwright](https://matrix.to/#/@cvwright:matrix.org) says
+
+> Circles is a secure, E2E encrypted social network app built on Matrix.  We have a new build (v1.0.6) of our Android beta today.
+> 
+> Circles v1.0.6 is now available from our [beta F-Droid repo](https://circu.li/fdroid/repo), so F-Droid users' clients should start picking it up over the next day or so.  Updates in this release include:
+> 
+> * A new expandable view for long text posts
+> * Animated .webp support
+> * Password strength estimation (using zxcvbn)
+> * Fixed scroll on emoji dialog
+> * Fixed crash on take photo/video
+> 
+> Adventurous users can also install the latest build by grabbing the [APK](https://circu.li/fdroid/repo/app-fdroid-release-1_0_6.apk) directly from our repo.
+> 
+> Interested users can also join us in [#circles:matrix.org](https://matrix.to/#/#circles:matrix.org) to get the latest news about the app.
+
+## Dept of Widgets 🧩
+
+[Oliver Sand](https://matrix.to/#/@oliver.sand:matrix.org) says
+
+> Hello from Nordeck 👋 This week we finally released the first of our widgets as open source: It's the [matrix-poll-widget](https://github.com/nordeck/matrix-poll).
+> 
+> The widget allows to conduct polls in Matrix rooms. But unlike [MSC3381](https://github.com/matrix-org/matrix-spec-proposals/blob/travis/msc/polls/proposals/3381-polls.md) it is designed for more complex scenarios, like polls with multiple parties in a council. You have full control over your data, as it's stored in your Matrix room. It is currently in use in the German public sector.
+> The widget is built using TypeScript, React, and the `matrix-widget-api`. We also extracted a thin layer of code that is shared between our widgets into our [`matrix-widget-toolkit`](https://github.com/nordeck/matrix-widget-toolkit), another project we made open source recently. Our remaining widgets will follow in the next couple of weeks. We keep you updated here.
+> 
+> If you have any questions, reach out to us at our [#nordeck:matrix.org](https://matrix.to/#/#nordeck:matrix.org).
+
+## Dept of VoIP 🤙
+
+### Element Call ([website](https://call.element.io))
+
+Native Decentralised End-to-end Encrypted Group Calls in Matrix, as a standalone web app
+
+[Florian Heese](https://matrix.to/#/@fheese:element.io) says
+
+> Hello from the VoIP team,
+> 
+> We've just released Element Call v0.3.2 which has a whole collection of [new things](https://github.com/vector-im/element-call/releases/tag/v0.3.1). Screen sharing will now work in embedded mode on desktop and it will now show tiles for people it's trying to connect to, so it should make it easier to see what's going wrong in a call. Please continue rageshaking if you see failures: ideally immediately after the failure, from both sides, and please describe what went wrong in as much detail as you can!
+
+## Dept of SDKs and Frameworks 🧰
+
+### Trixnity ([website](https://gitlab.com/trixnity/trixnity))
+
+Multiplatform Kotlin SDK for Matrix
+
+[Benedict](https://matrix.to/#/@benedict:imbitbu.de) reports
+
+> Trixnity release 3.0.0-beta1
+> 
+> We released Trixnity 3.0.0-beta1. This is a major version with many (breaking) changes. We will wait for the 3.0.0 release until we have implemented the Matrix 1.4 spec changes (`m.replace` will be really hacky due to a - in my opinion - [spec bug](https://spec.matrix.org/v1.4/client-server-api/#server-side-replacement-of-content)).
+> 
+> ## Support realm database
+> 
+> We now support realm as a database backend. This allows you to use Trixnity on iOS with a persistent database.
+> 
+> ## Added exchangeable MediaStore
+> 
+> Media is not saved into the database anymore, but in an exchangeable `MediaStore`. It is also streamed, so you can download and upload large files. There is `trixnity-client-media-okio` for a multiplatform file based implementation.
+> 
+> ## Improved StateFlowCache
+> 
+> The `StateFlowCache`, which basically is a reactive cache on top of an arbitrary database does not need a `CoroutineScope` parameter for any read or write operation anymore. It was needed to react to the lifecycle of the consumer, so that not used data could be removed from the cache. This was really error prone, because if the consumer passed a wrong `CoroutineScope` with a too long lifecycle, the cache could grow unlimited. We figured out to solve this with Kotlin `Flow`s, so everything is lazy and the lifecycle can be determined from the Flow consumer!
+> 
+> We also fixed a long standing bug, which could cause to return a `Flow`, which does not emit updated values.
+> 
+> ## Power level caluculation support
+> 
+> We implemented some functions to calculate power levels (e. g. `canBanUser(...)`).
+> 
+> ## Naming change of classes and interfaces
+> 
+> We changed the naming of all interfaces from `IXyz` to `Xyz` and the implementation of it from `Xyz` to `XyzImpl`
+> 
+> ## Server-API improvements
+> 
+> We made some improvements to the various server APIs to allow implementing proxies filtering requests and responses.
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) announces
+
+>  - [matrix-sdk-crypto-nodejs 0.1.0-beta.3](https://github.com/matrix-org/matrix-rust-sdk/releases/tag/matrix-sdk-crypto-nodejs-v0.1.0-beta.3) has been [released to npmjs.com ](https://www.npmjs.com/package/@matrix-org/matrix-sdk-crypto-nodejs) - main change is a fix on the downloader to pick the correct asset from the release and some other smaller fixes
+>  - the new Timeline API now [features the ability to show not-decryptable items](https://github.com/matrix-org/matrix-rust-sdk/pull/1140)
+>  - restore tokens passed via FFI [are now a proper type not just a string anymore](https://github.com/matrix-org/matrix-rust-sdk/pull/1176)
+>  - we've [cleaned up the error types in base](https://github.com/matrix-org/matrix-rust-sdk/pull/1173)
+>  - a [fix on sliding sync](https://github.com/matrix-org/matrix-rust-sdk/pull/1183) allows us to create sliding sync when offline (which locked before)
+>  - the [sdk now uses the server-supplied retry time when available](https://github.com/matrix-org/matrix-rust-sdk/pull/1179)
+>  
+>  👉️ Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+## Dept of Events and Talks 🗣️
+
+[Salt](https://matrix.to/#/@salt:sal.td) reports
+
+> [SeaGL](https://seagl.org) (the Seattle GNU/Linux Conference) will be holding our tenth annual (third virtual) conference online November 4–5, powered by Matrix and our custom bot, [Patch](https://github.com/SeaGL/patch). Join this free—as in freedom and tea—volunteer powered grassroots technical summit, no registration required. This year's theme is "Hang Ten”, in honor of our tenth year!
+> 
+> Keynote speakers include:
+> 
+> * Aeva Black
+> * Ernie Smith
+> * Lorena Mesa
+> * Sumana Harihareswara
+> 
+> We have a packed lineup of [free / libre / open source talks](https://osem.seagl.org/conferences/seagl2022/schedule/events). There are also a number of fun social activities providing opportunities to mingle with your fellow participants. Additional information on the conference and [how to attend](https://seagl.org/attend) is available on our [blog](https://seagl.org/news/2022/11/03/SeaGL-2022-hang-ten).
+> 
+> As previously mentioned, we've been refining the [virtual conference experience](https://seagl.org/news/2022/10/07/Building-a-virtual-SeaGL) for three years and would gladly welcome [new wings and beaks](https://seagl.org/get_involved.html) to our all-volunteer staff!
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|matrix.org|402.5|
+|2|nognu.de|488|
+|3|maescool.be|587.5|
+|4|seymour.family|751.5|
+|5|zemos.net|1062|
+|6|mailstation.de|2588|
+|7|kittenface.studio|3202|
+|8|roeckx.be|3374.5|
+|9|cezeri.tech|3884|
+|10|diasp.in|4767|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|dendrite.matrix.org|138.5|
+|2|matrix.sum7.eu|143.5|
+|3|willian.wang|410.5|
+|4|forlorn.day|714|
+|5|matrix.milkte.ch|2024|
+|6|frai.se|10978.5|
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/11/2022-11-11-this-week-in-matrix-2022-11-11.md
+++ b/content/blog/2022/11/2022-11-11-this-week-in-matrix-2022-11-11.md
@@ -1,0 +1,316 @@
++++
+title = "This Week in Matrix 2022-11-11"
+date = "2022-11-11T18:26:24Z"
+path = "/blog/2022/11/11/this-week-in-matrix-2022-11-11"
+
+[taxonomies]
+author = ["Thib"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/Vn-NZvMcujc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Dept of *Status of Matrix* 🌡️
+
+[andybalaam](https://matrix.to/#/@andybalaam:matrix.org) reports
+
+> A few Matrix folks went to IETF115 this week, and here is my Trip Report: [Can Matrix help messaging standardisation through MIMI?](https://www.artificialworlds.net/blog/2022/11/09/ietf115-trip-report-can-matrix-help-messaging-standardisation-through-mimi/)
+
+## Dept of Spec 📜
+
+[Andrew Morgan (anoa)](https://matrix.to/#/@andrewm:element.io) announces
+
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3926: Disable server-default notifications for bot users by default](https://github.com/matrix-org/matrix-spec-proposals/pull/3926)
+> 
+> **MSCs in Final Comment Period:**
+> * *No MSCs are in FCP.*
+> 
+> **Accepted MSCs:**
+> * [MSC3030: Jump to date API endpoint](https://github.com/matrix-org/matrix-spec-proposals/pull/3030)
+> 
+> ## Spec updates
+> 
+> This week the Spec Core Team has been working with the IETF More Instant Messaging Interoperability (MIMI) working group to define a charter. With a charter, the working group is able to start thinking about implementation and design details, which means talking even more about Matrix!
+> 
+> We had the opportunity to discuss Matrix with several interested people at IETF this week, and are extremely excited for the (long) road ahead: even in the event where Matrix doesn't get accepted, we hope the protocol(s) the working group publishes will be fit for purpose and adopted widely (not to mention our own spec will be better as a result). 
+> 
+> To find out more about what we're doing in this space or to learn more, check out this week's Matrix Live above!
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC3381: Polls (mk II)](https://github.com/matrix-org/matrix-spec-proposals/pull/3381)!
+> 
+> Polls! They are useful for quickly gauging whether a group of people agree, or entirely disagree on a topic or choice. This is an MSC with a fairly long history, but has received experimental implementation in a small number of Matrix clients. The concept uses Extensible Events, and there are plans to rewrite it off the back of changes in [MSC1767](https://github.com/matrix-org/matrix-spec-proposals/pull/1767) (extensible events). But for now, it works and is a fun feature.
+> 
+> It's likely worth waiting for the rewrite before commenting on the MSC with detailed changes, but otherwise feel free to have a read to see how it currently works!
+> ![](/blog/img/cc0b6684df1160e11ec35dd047c327d4c76b7e5b.png)
+
+## Dept of Servers 🏢
+
+### Feta ([website](https://www.feta.bz/))
+
+[geoffledak](https://matrix.to/#/@geoffledak:matrix.org) announces
+
+> ## Feta is a Matrix server distribution for the Raspberry Pi 3 and 4.
+> 
+> It is a an operating system image, based on Raspberry Pi OS Lite and includes the Matrix Synapse server, a self-hosted Element client, Postgres database, and it generates an SSL certificate for your domain using Certbot. The coturn TURN server is also included so voice and video calls work without any additional configuration.
+> 
+> 
+> ## The provided setup script will have your server up and running in a matter of minutes.
+> 
+> All you need to do is configure your DNS settings for your domain, forward some ports through your router, and boot up your Raspberry Pi. Once setup is complete, enjoy your new Matrix server! Synapse, Element, Postgres, coturn, and federation are all preconfigured for you.
+> 
+> Visit https://www.feta.bz/ to download and get more info.
+> 
+> Head on over to [#feta:matrix.org](https://matrix.to/#/#feta:matrix.org) for discussion and updates!
+
+### Telodendria ([website](https://telodendria.io))
+
+An open source Matrix homeserver implementation written from scratch in ANSI C and designed to be lightweight and simple, yet functional
+
+[Jordan Bancino](https://matrix.to/#/@jordan:bancino.net) says
+
+> * **Donations:** Both recurring and one-time donations are now accepted via LiberaPay and Stripe, respectively&mdash;GitHub Sponsors is hopefully coming soon. All funds will go directly to infrastructure and development labor. You can find the donate links on the [website](https://telodendria.io), and the [GitHub mirror](https://github.com/Telodendria/Telodendria).
+> * **Memory/Network Improvements:** Another week brings another round of memory and socket handling improvements.
+> * **Patch Submission:** It's now easier than ever to contribute to Telodendria thanks to the new `send-patch` script. Submitting your changes for review is now only a single command.
+> * **Newsletter:** Catch the full-length newsletter in [#telodendria-newsletter:bancino.net](https://matrix.to/#/#telodendria-newsletter:bancino.net).
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[squah](https://matrix.to/#/@squah:matrix.org) says
+
+> Synapse 1.71.0 has been released! It contains the usual round of bugfixes and performance improvements, plus some new features. Notably, Synapse now supports:
+> 
+> * back-channel logouts from OpenID Connect providers.
+> * Postgres and SQLite full-text search operators in search queries.
+> * MSC3664, push rules for relations.
+> 
+> Server administrators should be aware that:
+> 
+> * legacy Prometheus metric names are now disabled by default, and will be removed altogether in Synapse 1.73.0.
+>   If not already done, server administrators should update their dashboards and alerting rules to avoid using the deprecated metric names.
+> * Synapse 1.71.0 will be the last release to support PostgreSQL 10. Server administrators are encouraged to upgrade their PostgreSQL servers before the next release, if needed.
+> 
+> You can read more about v1.71.0 here: https://github.com/matrix-org/synapse/releases
+> 
+> In the mean time, the team has been working on the remaining parts of faster room joins.
+
+## Dept of Bridges 🌉
+
+### Postmoogle ([website](https://gitlab.com/etke.cc/postmoogle))
+
+An Email to Matrix bridge. 1 room = 1 mailbox.
+
+[Aine](https://matrix.to/#/@aine:etke.cc) announces
+
+> Postmoogle vUnreleased is here!
+> 
+> Yep, no pinned release yet, but there are some exciting features in the `main` branch (`latest` docker image):
+> 
+> **multi-domain support!**
+> 
+> You can have one main email domain (eg: [the-etke.cc](https://etke.cc/)) and multiple additional domains that will be used as aliases ([not-etke.cc](https://etke.cc/), [example.com](https://example.com/)), so you can get more spam to the [user@the-etke.cc](https://example.com/), [user@not-etke.cc](https://example.com/) and [user@example.com](https://example.com/) at the same time!
+> 
+> **bridged thread replies!**
+> 
+> the last planned feature of the roadmap: send reply (reply-to or thread reply) to an email message in the matrix room and it will automatically set all magic stuff (`In-Reply-To` header, subject with `Re: %original message's subject%`, etc) and send email. It's pretty rough implementation, so feedback is appreciated!
+> 
+> [Source code](https://gitlab.com/etke.cc/postmoogle) and say hi in the [#postmoogle:etke.cc](https://matrix.to/#/#postmoogle:etke.cc) room
+
+## Dept of Clients 📱
+
+### Hydrogen ([website](https://github.com/vector-im/hydrogen-web))
+
+Hydrogen is a lightweight matrix client with legacy and mobile browser support
+
+[Midhun](https://matrix.to/#/@rmidhunsuresh:matrix.org) says
+
+> Released [v0.3.4](https://github.com/vector-im/hydrogen-web/releases/tag/v0.3.4) (and [v0.3.3](https://github.com/vector-im/hydrogen-web/releases/tag/v0.3.3)) with a join room UI and lots of bug fixes!
+> Special thanks to [Isaiah Becker-Mayer](https://github.com/ibeckermayer) for his numerous typescript PRs!
+> 
+> Some of the fixes are for:
+> * [an error that can stop sync](https://github.com/vector-im/hydrogen-web/issues/866)
+> * an issue where hydrogen did not verify senders of room keys!
+> * message verification not working in rooms where we haven't sent a message yet
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[kittykat](https://matrix.to/#/@kittykat:matrix.org) announces
+
+> * [1.11.14 is out](https://github.com/vector-im/element-web/releases/tag/v1.11.14), with many improvements to threads!
+> * This week, we fixed some issues, including a bug with media uploads
+> 
+> In labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> * We’ve added more functionality to the rich text editor, it’s catching up slowly with the basic composer
+> * Voice broadcast also has a few new tricks up its sleeve, including improvements to pre-recording and message length
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Ștefan](https://matrix.to/#/@stefan.ceriu:matrix.org) says
+
+> * We have been working hard on improving the Element experience and to that extend we have fixed some crashes, squashed timeline layout issues, improved the device manager and the new rich text editor
+> * Work is also continuing on thread notifications and the new crypto frameworks
+> * ElementX on the other hand received support for offline logins, message editing, video and encrypted messages in the timeline and a brand new underlying navigation mechanism
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[benoit](https://matrix.to/#/@benoit.marty:matrix.org) reports
+
+> * Element Android 1.5.7 has been pushed to production on the PlayStore and should also be available for F-Droid users soon. This version fixes the issue when sharing items to the app, and also fixes the regression observed in 1.5.6 (before it reaches production!) during the first sync with the server.
+> * We are making progress on ElementX, which is a new client using the Matrix Rust SDK and Jetpack Compose. This app is now able to display a timeline and send messages to a room using the wysiwyg composer.
+> 
+> ![](/blog/img/20221111-ex-android.jpg)
+> 
+> ![](/blog/img/20221111-ex-android-list.jpg)
+
+## Dept of SDKs and Frameworks 🧰
+
+### Trixnity ([website](https://gitlab.com/trixnity/trixnity))
+
+Multiplatform Kotlin SDK for Matrix
+
+[Benedict](https://matrix.to/#/@benedict:imbitbu.de) announces
+
+> We released [Trixnity 3.0.0-beta3](https://gitlab.com/trixnity/trixnity/-/releases), which supports the matrix spec 1.4 and new relation types: reply (without fallback), replace, thread (basic support, no separate timelines or client aggregations yet).
+
+### simplematrixbotlib ([website](https://github.com/KrazyKirby99999/simple-matrix-bot-lib))
+
+simplematrixbotlib is an easy to use bot library for the Matrix ecosystem written in Python and based on matrix-nio.
+
+[imbev](https://matrix.to/#/@imbev:matrix.org) reports
+
+> ## Version 2.8.0 released!
+> 
+> This version brings a few improvements.
+> 
+> The sending of video messages has been added. The following handler will send a video after any message from another user:
+> 
+> ```python
+> async def example(room, message):
+>     match = botlib.MessageMatch(room, message, bot)
+>     example_video="./videos/example.mp4"
+>     if match.is_not_from_this_bot():
+>         await bot.api.send_video_message(
+>             room_id=room.room_id, 
+>             video_filepath=example_video)
+> ```
+> 
+> Thanks to moanos and HarHarLinks, there are improvements to the handling of device ids.
+> 
+> Join us in the Matrix room at https://matrix.to/#/#simplematrixbotlib:matrix.org or the Git repository at https://codeberg.org/imbev/simplematrixbotlib !
+> 
+> _Version 3.0 coming soon!_
+
+### Ruma ([website](https://www.ruma.io))
+
+A set of Rust library crates for working with the Matrix protocol. Ruma’s approach to Matrix emphasizes correctness, security, stability and performance.
+
+[Jonas Platte](https://matrix.to/#/@jplatte:flipdot.org) announces
+
+> Since our last update in June (yeah, sorry...), we released Ruma 0.7.0 and a few patch releases including all of the following and more:
+> 
+> * Support for refresh tokens (MSC2918 / Matrix 1.4)
+> * Unstable support for discovering an OpenID Connect Server (MSC2965)
+> * Unstable support for private read receipts
+> * Lots of API refinements, like renaming `AnyRoomEvent` to `AnyTimelineEvent`
+> * Support for Room Version 10
+> * Unstable support for sliding sync
+> 
+> Since this release was released back in September, a bunch of things have also happened that are not released yet:
+> 
+> * Many features were moved out of unstable feature flags because they were stabilized in Matrix 1.4
+> * We made message construction easier than ever with improvements to markdown detection and improvements to reply and edit creation
+> * We refactored and extended the push notification code
+> * We are about to conclude a massive refactoring that should make our codebase look less strange if you are familiar with Rust, and could help compile times as well
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) announces
+
+> This week has seen important strives forward on [sliding sync, which now has a PR up for offline support](https://github.com/matrix-org/matrix-rust-sdk/pull/1193) and the new timeline API, with some [initial unittests](https://github.com/matrix-org/matrix-rust-sdk/pull/1192) and [video messages](https://github.com/matrix-org/matrix-rust-sdk/pull/1196) support merged and [support for file messages coming up](https://github.com/matrix-org/matrix-rust-sdk/pull/1203). On the FFI, we now have support for [logging in Android](https://github.com/matrix-org/matrix-rust-sdk/pull/1199) and work on [moving the iOS binding scripts into our internal xtask cli](https://github.com/matrix-org/matrix-rust-sdk/pull/1201).
+> 
+> As usual a lot of work is been going in the background without any visible, tangible outcome yet. On one side we are making great progress on getting a first async-prototype for uniffi with python working, on the other we have been profiling the sdk on iOS mobile devices for its memory footprint - which is a major blocker for notification support.
+> 
+>  ️👉 Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+## Dept of Events and Talks 🗣️
+
+### FOSDEM
+
+[Thib](https://matrix.to/#/@thib:ergaster.org) announces
+
+> There will be a [Matrix Devroom at FOSDEM](https://fosdem.org/2023/schedule/track/matrix/) next February 🎉
+> We will issue a CfP very _soon™_
+
+## Dept of Interesting Projects 🛰️
+
+### Matrix Plays GameBoy games
+
+[jaller94](https://matrix.to/#/@jaller94:matrix.org) reports
+
+> Using this Lua script and NodeJS bot, you can remotely control any GameBoy (Classic + Color + Advance) game using the mGBA emulator. Invite some friends to the Matrix room and everyone can control the game at once.
+> Yes, the project name is a reference to the famous "Twitch Plays Pokémon" stream which has 1000s of people complete Pokémon games together just by typing into a chat.
+> 
+> This is a bot and does not need an AppService registration.
+> 
+> https://github.com/jaller94/matrix-plays-pokemon
+> 
+> Disclaimer: This is a hobby project of mine. It is neither associated with nor endorsed by my employer or Nintendo. The project does not contain ROMs or other non-free assets.
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|babel.sh|350|
+|2|nognu.de|409|
+|3|trygve.me|548|
+|4|maescool.be|623|
+|5|keks.club|630|
+|6|shortestpath.dev|640.5|
+|7|willian.wang|686|
+|8|rom4nik.pl|775|
+|9|alemann.dev|840.5|
+|10|babel1.eu|898|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|babel.sh|130|
+|2|dendrite.matrix.org|185|
+|3|kumma.juttu.asia|219|
+|4|rustybever.be|327.5|
+|5|forlorn.day|511|
+|6|frai.se|606.5|
+|7|matrix.milkte.ch|1078|
+|8|babel1.eu|1243|
+|9|willian.wang|36298|
+|10|jacksonchen666.com|236505|
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/11/2022-11-16-call-for-participation-for-the-fosdem-2023-matrix-devroom.md
+++ b/content/blog/2022/11/2022-11-16-call-for-participation-for-the-fosdem-2023-matrix-devroom.md
@@ -1,0 +1,63 @@
++++
+title = "Call for Participation for the FOSDEM 2023 Matrix Devroom"
+path = "/blog/2022/11/16/call-for-participation-for-the-fosdem-2023-matrix-devroom"
+
+[taxonomies]
+author = ["Thib"]
+category = ["General"]
++++
+
+This year, the Matrix.org Foundation is excited to host the first ever
+Matrix.org Foundation and Community devroom _in person_ at FOSDEM. Half a day of
+talks, demos and workshops around Matrix itself and projects built on top of
+Matrix.
+
+We encourage people working on the Matrix protocol or building on it in an open
+source project to submit a proposal! Note that companies are welcome to talk
+about the Matrix details of their open source projects, but marketing talks are
+not welcome.
+
+This call for participation is only about the physical devroom. A separate CfP
+will be issued for the online devroom once there are more details about it.
+
+Key dates are:
+
+- Conference dates 4-5 February, 2023 In person
+- Matrix Devroom date: Sunday 5 morning in person, online devroom to be
+  announced
+- Submission deadline: Monday 5th December
+- Announcement of selected talks: Thursday 15th December 
+
+You must be available in person to present your talk for the physical devroom.
+
+## Talk Details
+
+The talks can follow one of thee two formats for the physical devroom
+
+* 20 min talk + 10 min Q&A, for topics that can be covered briefly
+* 50 min talk + 10 min Q&A for more complex subjects which need more focus
+
+We strongly encourage you to prepare a demo when it makes sense, so people can 
+actually see what your work looks like in practice!
+
+Of course, the proposal must respect the FOSDEM terms as well:
+
+> The conference language is English. All content must relate to Free and Open
+  Source Software. By participating in the event you agree to the publication of
+  your recordings, slides and other content provided under the same licence as
+  all FOSDEM content (CC-BY).
+
+## Submitting a Proposal
+
+Proposals must be [submitted on FOSDEM's conference management system Pentabarf](https://penta.fosdem.org/submission/FOSDEM23)
+before ~~December 5~~ December 8 2022. If you are not used to Pentabarf, you can
+follow this [beginners guide to Pentabarf](https://eyskens.me/beginners-guide-to-pentabarf/).
+
+We expect to receive more requests than we have slots available. The devroom
+organisers will be reviewing the proposals and accepting them based on the
+potential positive impact the project has on Matrix (as defined in by the
+Mission section of https://matrix.org/foundation).
+
+If a project proposal has been turned down, it doesn't mean we don't believe it
+has good potential. Maintainers are invited to join the [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org)
+Matrix room to give it some visibility.

--- a/content/blog/2022/11/2022-11-17-matrix-v1-5-release.md
+++ b/content/blog/2022/11/2022-11-17-matrix-v1-5-release.md
@@ -1,0 +1,141 @@
++++
+title = "Matrix v1.5 release"
+date = "2022-11-17T16:56:36Z"
+updated = "2022-11-17T16:44:47Z"
+path = "/blog/2022/11/17/matrix-v1-5-release"
+
+[taxonomies]
+author = ["Travis Ralston"]
+category = ["Releases", "Spec"]
++++
+
+Hey all,
+
+We’ve just released [Matrix 1.5](https://spec.matrix.org/v1.5), a largely maintenance update for the spec. We intentionally haven’t landed any major features in this release as Matrix 1.4, [just shy of 2 months ago](https://matrix.org/blog/2022/09/29/matrix-v-1-4-release), had introduced fairly large features for clients and servers to consider. As with all spec releases, we encourage implementations to gradually update over the next few months rather than expect them to have support for everything on release day.
+
+Matrix 1.5 sees just 2 MSCs get merged, though this is to be expected from a maintenance release. We expect that the next release (in Q1 2023) will have a few more exciting features to it :)
+
+We’ve covered both MSCs below, but read on to the full changelog for the full picture.
+
+
+## MSC3267: Reference relations
+
+Already supported implicitly by the spec up until now, [reference relations](https://spec.matrix.org/v1.5/client-server-api/#reference-relations) are a way to simply reference another event. Usually these sorts of relations are used for events which need to be related to each other, but a dedicated relationship type doesn’t make a lot of sense.
+
+[In-room verification](https://spec.matrix.org/v1.5/client-server-api/#key-verification-framework) and [MSC3381: Polls](https://github.com/matrix-org/matrix-spec-proposals/pull/3381) are examples of how these relations get used.
+
+
+## MSC3905: Clarify appservice interest in user IDs
+
+[MSC3905](https://github.com/matrix-org/matrix-spec-proposals/pull/3905) fixes an issue in the specification where appservices (usually bridges) specifying a users regex without homeserver domain would end up receiving far more event traffic than they would have intended. With the MSC, appservices are now only considered interested in “local” users, regardless of how vague their users namespace is.
+
+Overall this should have no effect on most bridges/appservices, however if an appservice in the wild really does need to listen to all users on all homeservers, it can specify a non-exclusive namespace on all rooms instead.
+
+While writing this MSC into the spec we took some time to clarify the appservice registration requirements more generally: check them out [here](https://spec.matrix.org/v1.5/application-service-api/#registration).
+
+
+## The full changelog
+
+MSCs are how the spec changes in the way it does - adding, fixing, and maintaining features for the whole ecosystem to use. Check out the full changelog below, and the [Spec Change Proposals](https://spec.matrix.org/proposals/) page for more information on how these MSCs got merged (hint: they submitted a proposal, which anyone can do - take a look at the [Matrix Live episode](https://www.youtube.com/watch?v=SFkZz60RRfc) where Matthew covers the proposal process).
+
+### Client-Server API
+
+
+<strong>Backwards Compatible Changes</strong>
+
+
+- Add `m.reference` relations, as per [MSC3267](https://github.com/matrix-org/matrix-spec-proposals/pull/3267). ([#1206](https://github.com/matrix-org/matrix-spec/issues/1206))
+- Add missing documentation for `m.key.verification.request` msgtype for in-room verification. ([#1271](https://github.com/matrix-org/matrix-spec/issues/1271))
+
+
+<strong>Spec Clarifications</strong>
+
+
+- Fix various typos throughout the specification. ([#1260](https://github.com/matrix-org/matrix-spec/issues/1260), [#1265](https://github.com/matrix-org/matrix-spec/issues/1265), [#1276](https://github.com/matrix-org/matrix-spec/issues/1276))
+- Fix naming of `device_one_time_keys_count` in `/sync`. ([#1266](https://github.com/matrix-org/matrix-spec/issues/1266))
+- Improve display of event subtypes. ([#1283](https://github.com/matrix-org/matrix-spec/issues/1283))
+- Improve documentation about ephemeral events. ([#1284](https://github.com/matrix-org/matrix-spec/issues/1284))
+- Define a 400 response from `/_matrix/client/v3/directory/rooms/{roomAlias}`. ([#1286](https://github.com/matrix-org/matrix-spec/issues/1286))
+- Clarify parts of the end-to-end encryption sections. ([#1294](https://github.com/matrix-org/matrix-spec/issues/1294), [#1345](https://github.com/matrix-org/matrix-spec/issues/1345))
+- Various clarifications throughout the specification. ([#1306](https://github.com/matrix-org/matrix-spec/issues/1306))
+- Replace `set_sound` push rule action by `set_tweak`. ([#1318](https://github.com/matrix-org/matrix-spec/issues/1318))
+- Clarify the behavior of `PUT /_matrix/client/v3/pushrules/{scope}/{kind}/{ruleId}`. ([#1319](https://github.com/matrix-org/matrix-spec/issues/1319))
+- Clarify that `.m.rule.master` has a higher priority than any push rule. ([#1320](https://github.com/matrix-org/matrix-spec/issues/1320))
+- Require request field `refresh_token` at endpoint `POST /_matrix/client/v3/refresh`. ([#1323](https://github.com/matrix-org/matrix-spec/issues/1323))
+- Fix a number of broken links in the specification. ([#1330](https://github.com/matrix-org/matrix-spec/issues/1330))
+- Add example read receipt to `GET /_matrix/client/v3/sync` response example. ([#1341](https://github.com/matrix-org/matrix-spec/issues/1341))
+
+
+### Server-Server API
+
+
+<strong>Spec Clarifications</strong>
+
+
+- Fix a number of broken links in the specification. ([#1330](https://github.com/matrix-org/matrix-spec/issues/1330))
+
+
+### Application Service API
+
+
+<strong>Spec Clarifications</strong>
+
+
+- Clarify that application services can only register an interest in local users, as per [MSC3905](https://github.com/matrix-org/matrix-spec-proposals/issues/3905). ([#1305](https://github.com/matrix-org/matrix-spec/issues/1305))
+
+
+### Identity Service API
+
+
+<strong>Spec Clarifications</strong>
+
+
+- Fix a number of broken links in the specification. ([#1330](https://github.com/matrix-org/matrix-spec/issues/1330))
+
+
+### Push Gateway API
+
+
+No significant changes.
+
+
+### Room Versions
+
+
+<strong>Spec Clarifications</strong>
+
+
+- Reword the event auth rules to clarify that users cannot demote other users with the same power level. ([#1269](https://github.com/matrix-org/matrix-spec/issues/1269))
+- Various clarifications to the text on event authorisation rules. ([#1270](https://github.com/matrix-org/matrix-spec/issues/1270))
+- Fix a number of broken links in the specification. ([#1330](https://github.com/matrix-org/matrix-spec/issues/1330))
+
+
+### Appendices
+
+
+No significant changes.
+
+
+### Internal Changes/Tooling
+
+
+<strong>Backwards Compatible Changes</strong>
+
+
+- Update docsy theme to v0.5.0 + matrix.org modifications (https://github.com/matrix-org/docsy/commit/a0032f8db919a6c67ba6cdef2c455f105b6272a2). ([#1295](https://github.com/matrix-org/matrix-spec/issues/1295))
+
+
+<strong>Spec Clarifications</strong>
+
+
+- Improve error messages emitted by `resolve-additional-types` template. ([#1303](https://github.com/matrix-org/matrix-spec/issues/1303))
+- Fix link to API viewer. ([#1308](https://github.com/matrix-org/matrix-spec/issues/1308))
+- Stop rendering the subsections of the Client-Server API and Room Versions specs as their own separate pages. ([#1317](https://github.com/matrix-org/matrix-spec/issues/1317))
+- Use a link checker to ensure that we do not have broken links. ([#1329](https://github.com/matrix-org/matrix-spec/issues/1329), [#1338](https://github.com/matrix-org/matrix-spec/issues/1338))
+- Update instructions to preview Swagger definitions. ([#1331](https://github.com/matrix-org/matrix-spec/issues/1331))
+- Make definition anchors more unique. ([#1339](https://github.com/matrix-org/matrix-spec/issues/1339))
+- Generate the unstable changelogs with towncrier, for consistency. ([#1340](https://github.com/matrix-org/matrix-spec/issues/1340))
+- Update CONTRIBUTING.md to mention that non-content changes to this repo should have an "internal" changelog entry. ([#1342](https://github.com/matrix-org/matrix-spec/issues/1342))
+- Update module summary table with new modules: Event Replacements, Threading and Reference Relations. ([#1344](https://github.com/matrix-org/matrix-spec/issues/1344))
+- Disable RSS generation for the spec. ([#1346](https://github.com/matrix-org/matrix-spec/issues/1346))
+

--- a/content/blog/2022/11/2022-11-18-this-week-in-matrix-2022-11-18.md
+++ b/content/blog/2022/11/2022-11-18-this-week-in-matrix-2022-11-18.md
@@ -1,0 +1,337 @@
++++
+title = "This Week in Matrix 2022-11-18"
+date = "2022-11-18T19:08:39Z"
+path = "/blog/2022/11/18/this-week-in-matrix-2022-11-18"
+
+[taxonomies]
+author = ["Thib"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/5xLqQvt3aig" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Dept of Spec 📜
+
+[Andrew Morgan (anoa)](https://matrix.to/#/@andrewm:element.io) says
+
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> 
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3935: Cute Events against social distancing](https://github.com/matrix-org/matrix-spec-proposals/pull/3935)
+> * [MSC3934: Bulk push rules change endpoint](https://github.com/matrix-org/matrix-spec-proposals/pull/3934)
+> * [MSC3933: Core push rules for Extensible Events](https://github.com/matrix-org/matrix-spec-proposals/pull/3933)
+> * [MSC3932: Extensible events room version push rule feature flag](https://github.com/matrix-org/matrix-spec-proposals/pull/3932)
+> * [MSC3931: Push rule condition for room version features](https://github.com/matrix-org/matrix-spec-proposals/pull/3931)
+> * [MSC3930: Polls push rules/notifications](https://github.com/matrix-org/matrix-spec-proposals/pull/3930)
+> * [MSC3927: Extensible Events - Audio](https://github.com/matrix-org/matrix-spec-proposals/pull/3927)
+> 
+> **MSCs in Final Comment Period:**
+> * *No MSCs are in FCP.*
+> 
+> **Merged MSCs:**
+> * *No MSCs were merged this week.*
+> 
+> ## Spec Updates
+> 
+> ### Matrix v1.5
+> 
+> Matrix v1.5 was released on November 17th, 2022! 🎉
+> 
+> While not as feature-packed as previous releases (v1.5 was intended as a maintenance release), it's still worth checking out! Included are two new MSCs that have landed, as well as loads of little bugfixes and clarifications to the spec text itself. Thanks to [all who helped fix issues](https://github.com/matrix-org/matrix-spec/issues?q=is%3Aissue+label%3Aclarification+is%3Aclosed+closed%3A%3E2022-10-01) since v1.4!
+> 
+> See the [Matrix v1.5 blog post](https://matrix.org/blog/2022/11/17/matrix-v-1-5-release) for all the juicy details.
+> 
+> ### Extensible Events are Shaping Up!
+> 
+> As may be apparent from the new MSCs this week, the SCT has been looking at extensible events to iron out some of the finer details of the system. They're not necessarily in the best position to review at the moment, but keep an eye on this space for when review would be most welcome 🙂  
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC2705: Animated thumbnails for media (and thumbnail content-type requirements)](https://github.com/matrix-org/matrix-spec-proposals/pull/2705)!
+> 
+> This MSC attempts to define a method for clients to indicate to their homeserver that they would like to have animated version if possible when requesting a thumbnail of some media. This would allow clients to provide a toggle to the user for whether media in the timeline should be animated, or whether room and user avatars should be animated, etc. Potentially separate options for each!
+> 
+> Today, there is no way for the client to indicate per-request whether they would like to receive an animated version of a thumbnail. This leaves the choice up to the homeserver, which gives individual users much less control.
+> 
+> The MSC also defines mimetypes that animated thumbnails should return. And it has an implementation in [matrix-media-repo](https://github.com/turt2live/matrix-media-repo)!
+> 
+> Check it out if animated avatars/thumbnails peaks your interest.
+> ![](/blog/img/3f81c91afae13e0d6294abd810e354fb8e86e76b.png)
+
+## Dept of Servers 🏢
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[Shay](https://matrix.to/#/@shayshay:matrix.org) says
+
+> Another week has gone by and we here at Synapse Inc have been working hard on
+> faster room joins, bugfixes, and other fun items to make Synapse faster and
+> better, in addition to releasing v1.72.0rc1. Just a few highlights of the release are:
+> 
+> 
+> * Adding experimental support for MSC3912: Relation-based redactions.
+> 
+> * Adding an Admin API endpoint for user lookup based on third-party ID (3PID).
+> 
+> * Fixing a background database update, introduced in Synapse 1.64.0, which could cause poor database performance.
+> 
+> * Improving the performance of /context in large rooms.
+> 
+> 
+> In addition, please note that we now only support PostgreSQL 11+, as PostgreSQL 10 has reached end-of-life.
+> As always, if you'd like to know more about this release, hop on over to the release page (https://github.com/matrix-org/synapse/releases) and take a look!
+
+## Dept of Clients 📱
+
+### Neochat ([website](https://invent.kde.org/network/neochat))
+
+A client for matrix, the decentralized communication protocol
+
+[Tobias Fella](https://matrix.to/#/@tobiasfella:kde.org) says
+
+> It's been a few weeks since the last update on NeoChat and we've been working hard on bringing new features and fixes. Some notable ones include:
+> * Porting our settings to a nicer style
+> * Various UI Improvements in the Room list and Timeline
+> * Added the ability to configure a Proxy
+> * Creating a significantly nicer UI for switching accounts
+> * Improved the room search, with a more obvious way of searching on a different server
+> * Viewing and Answering polls
+> * The ability to change your display name for a single room
+> * Correctly escaping HTML characters in various places
+> * Fixed file sending on android
+> * Fixed reactions sometimes not showing up
+> * Fixed some problems with viewing custom emojis
+> * Fixed the external room window blocking the main client window
+> * Implemented showing animated images in the timeline
+> ![](/blog/img/a354925f789a4372dbdc74507a8a36ca021f2b14.png)
+
+### FluffyChat ([website](https://fluffychat.im))
+
+[Krille Fear](https://matrix.to/#/@krille:janian.de) announces
+
+> FluffyChat 1.7.0 has been released. It features a new way to work with spaces via a bottom navigation bar. A lot of work has also been done under the hood to make the app faster and more stable. The main color has slightly changed and the design got some finetuning.
+> Please be aware that it can take some time until it receives all app stores. The Snap Store currently waits for a review, while the arm64 version of Flatpak has recently failed to build.
+> Read the full changelog here: https://gitlab.com/famedly/fluffychat/-/blob/main/CHANGELOG.md
+
+### Ement.el ([website](https://github.com/alphapapa/ement.el))
+
+Matrix client for Emacs
+
+[alphapapa](https://matrix.to/#/@alphapapa:matrix.org) announces
+
+> [Ement.el](https://github.com/alphapapa/ement.el), a Matrix client for the [GNU Emacs](https://gnu.org/software/emacs) text editor and Lisp environment, has been updated to v0.5.  Since the last version announced in TWIM, these improvements have been made:
+> 
+> *Additions*
+> - Present "joined-and-left" and "rejoined-and-left" membership event pairs as such.
+> - Process and show rooms' canonical alias events.
+> 
+> *Changes*
+> + The [taxy.el](https://github.com/alphapapa/taxy.el)-based room list, with programmable, smart grouping, is now the default `ement-room-list`.  (The old, `tabulated-list-mode`-based room list is available as `ement-tabulated-room-list`.)
+> - When selecting a room to view with completion, don't offer spaces.
+> - When selecting a room with completion, empty aliases and topics are omitted instead of being displayed as nil.
+> 
+> *Fixes*
+> - Use of send-message filter when replying.
+> - Replies may be written in compose buffers.
+> 
+> Feel free to join us in [#ement.el:matrix.org](https://matrix.to/#/#ement.el:matrix.org)!
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Ștefan](https://matrix.to/#/@stefan.ceriu:matrix.org) reports
+
+> * This week has been exciting for ElementX (our [brand new Element iOS client](https://github.com/vector-im/element-x-ios) based on the [Matrix Rust SDK](https://github.com/matrix-org/matrix-rust-sdk)) which gained a brand new navigation system and a new user notification system, support for displaying file messages in the timeline and playing back video ones, as well as sending states for new messages and an improved bubble layout. 
+> * We have also started working on an iPad specific layout, improved our logging components, improved hardware keyboard handling and fixed a few annoying issues
+> * In Element land we have a made a handful of bug fixes which will hit the store next week and work has been continuing on threads, the new rich text editor, the device manager and our new crypto stack
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[benoit](https://matrix.to/#/@benoit.marty:matrix.org) announces
+
+> * Element Android 1.5.8 RC is available on the PlayStore for testers.
+> * The team is working on the device manager, the Rich Text Editor (to add more edition options: links, quote, etc.), and the voice broadcast.
+> * On the Element Android X side, we are also making progress. We can now change the server (the server has to support sliding sync though). The room list is displayed and the timeline with the Rich Text editor too. We are now working to add more features such as supporting more Event types in the timeline, etc. And the app got a new monochrome icon!
+
+## Dept of Non Chat Clients 🎛️
+
+### Populus Viewer ([website](https://github.com/opentower/populus-viewer))
+
+A Social Annotation Tool Powered by Matrix
+
+[gleachkr](https://matrix.to/#/@gleachkr:matrix.org) says
+
+> Since our last update, Populus viewer has added two features, both a bit overdue:
+> 
+> 1. Populus viewer now supports .well-known discovery, so you just need to know your matrix server name, rather than the full subdomain in order to connect.
+> 2. Populus viewer now supports the "restricted" join rule for annotations, so that annotation membership can be restricted to members of the underlying resource space. This will likely be the default for newly created annotations in the future.
+> 
+> Our server (at populus.open-tower.com) has also been rebuilt and reconfigured a bit, and will likely be converted from a test-bed to a stable home for annotation-based discussions in the coming weeks. As always, if you want to give us feedback, keep track of progress, or talk about the future of social annotation on Matrix, join us at [#opentower:matrix.org](https://matrix.to/#/#opentower:matrix.org)!
+
+## Dept of Encryption 🔐
+
+[uhoreg](https://matrix.to/#/@hubert:uhoreg.ca) announces
+
+> As many of you know, we are working on using MLS, an upcoming IETF standard for end-to-end encryption, in Matrix.  We've set up a page, [Are We MLS Yet](https://arewemlsyet.com/) to track the progress of this project.
+
+## Dept of SDKs and Frameworks 🧰
+
+### Matrix SDK in Elm (alpha)
+
+[Bram](https://matrix.to/#/@bram:noordstar.me) reports
+
+> [Elm](https://elm-lang.org/) is a functional programming language that compiles to JavaScript with the promise that their generated JS code will _NEVER_ raise any runtime errors and show high performance.
+> 
+> Despite the fact that certain implementations like [Cactus Chat](https://cactus.chat/) already [use Elm](https://gitlab.com/cactus-comments/cactus-client), I could not find an SDK for it. That's why I've started to write one: https://git.noordstar.me/bram/Elm-Matrix
+> 
+> The SDK is currently in early development. The `/v3/sync` endpoint is functional and there are already a few other ways to interact with the API, so the repository can already be tested by developers who are familiar with Elm. If you aren't that familiar with the language, it is better to wait until I release the first complete version.
+
+### libcmatrix
+
+[Matthew](https://matrix.to/#/@matthew:matrix.org) announces
+
+> Purism has been chipping away at libcmatrix for their chat app: https://puri.sm/posts/toward-matrix-support-in-chats/
+
+### trinity ([website](https://github.com/bnjbvr/trinity))
+
+[bnjbvr](https://matrix.to/#/@bnjbvr:delire.party) reports
+
+> Trinity is an experimental bot framework written in Rust and using matrix-rust-sdk, as well as
+> commands / modules compiled to WebAssembly, with convenient developer features like modules
+> hot-reload.
+> 
+> Two weeks of updates, because I've been slightly late last week:
+> 
+> * Trinity now uses WebAssembly components as created with
+>   [`cargo-components`](https://github.com/bytecodealliance/cargo-component) and
+>   [`wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen) under the hood for the Matrix
+>   modules. This is quite experimental and early stage, but this allows multiple exciting things in
+>   some not-so-distant future: switch API implementations at runtime, more security by isolating
+>   specific APIs, using source languages for the modules that can be compiled with wit-bindgen, etc.
+> * In particular, we've made a proof-of-concept for a bot module written in C (!) and compiled to
+>   WebAssembly, and we've been very close to having a bot module written in Java using the excellent
+>   [TeaVM](https://github.com/konsoletyper/teavm) project.
+> * New APIs have been added for the modules:
+>     - a simple key-value store, that is backed by the [redb](https://github.com/cberner/redb/) pure
+>       Rust project, which comes with great performance.
+>     - modules can now specific help messages as well as admin commands (that will be available only
+>       to a predefined admin user).
+> * Which then allowed to write a shiny new Mastodon module: configure it in a room with a set of
+>   credentials, a Mastodon URL instance, define which users are allowed to use it, and then post
+>   statuses from the room using `!toot message`.
+> 
+> If you're interested to follow the project, feel free to join [our Matrix
+> room](https://matrix.to/#/#trinity:delire.party) or get the code on
+> [Github](https://github.com/bnjbvr/trinity).
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) announces
+
+> Major breakthroughs have happened behind the scenes this week: we were able to get a simple python3-asyncio to poll our rust-side future and receive its result via uniffi. While there isn't much to show for the outside world, this is a major step towards having async-uniffi. The team is super excited about this development.
+> 
+> Meanwhile in Sliding-Sync-Land, we have debugged the session reset and added [transparent session recovery to the offline-caching PR](https://github.com/matrix-org/matrix-rust-sdk/pull/1193). Together with the latest [PR that hands over the already received timeline events to the new Timeline API](https://github.com/matrix-org/matrix-rust-sdk/pull/1219), this should visibly speed up things and improve overall performance across all major clients using both of these. Further more, the [Timeline API has UTD decryption retry support](https://github.com/matrix-org/matrix-rust-sdk/pull/1215) now. The client interfaces are moving ahead fast.
+> 
+> On the always-on-going-improvement-front, we have upgraded to [ruma](https://github.com/matrix-org/matrix-rust-sdk/pull/1200), merged [the component generation for swift in xtask](https://github.com/matrix-org/matrix-rust-sdk/pull/1201), switched to custom [`cargo` build profiles](https://github.com/matrix-org/matrix-rust-sdk/pull/1208), have a [signaling mutex for crypto now](https://github.com/matrix-org/matrix-rust-sdk/pull/1213), moved [large parts of `deserialized_responses` to `matrix-sdk-base`](https://github.com/matrix-org/matrix-rust-sdk/pull/1212) and made the [`sync_token` accessor private](https://github.com/matrix-org/matrix-rust-sdk/pull/1216).
+> 
+> 👉️ Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+## Dept of Ops 🛠
+
+### ML model for Matrix Spam Detection
+
+[MTRNord](https://matrix.to/#/@mtrnord:midnightthoughts.space) says
+
+> A few weeks ago I started experimenting with extending my moderation tools with a basic ML model that can give me early warnings on common spam.
+> 
+> As a result https://github.com/MTRNord/matrix-spam-ml was made. It contains a basic ML model using tensorflow based on telegram spam from matrix and a standard SMS dataset. It provides a HTTP api which can also be found at https://spam.midnightthoughts.space and a Synapse and mjolnir integration for both sampling training data and using it as automated spam reactions and is planned for the future.
+> 
+> Feel free to hop by in [#matrix-spam-ml:midnightthoughts.space](https://matrix.to/#/#matrix-spam-ml:midnightthoughts.space)  for any further questions :) also please note that the repo is using LFS and as it contains trained models it is pretty huge when cloning with LFS data.
+
+### [axon.sh](https://git.thisisjoes.site/joe/axon.sh)
+
+An interactive command-line administration tool for Synapse written in Bash. Better than typing curl requests!
+
+[joe](https://matrix.to/#/@joe:matrix.thisisjoes.site) says
+
+> [axon.sh version 0.22.0](https://git.thisisjoes.site/joe/axon.sh/releases/tag/v0.22.0) has been released, adding support for retrieving event reports from your homeserver, and looking up local users by third-party ID (requires Synapse 1.72.0rc1 or later).
+> Please try it out and report your experience in [#axon:matrix.thisisjoes.site](https://matrix.to/#/#axon:matrix.thisisjoes.site)!
+
+## Dept of Events and Talks 🗣️
+
+### FOSDEM
+
+[Thib](https://matrix.to/#/@thib:ergaster.org) reports
+
+> This year, the Matrix.org Foundation is excited to host the first ever Matrix.org Foundation and Community devroom _in person_ at FOSDEM. Half a day of talks, demos and workshops around Matrix itself and projects built on top of Matrix.
+> 
+> We have a physical devroom on Sunday 5 morning, and will follow with details for the online devroom as soon as we get them! You can read the CfP for the physical devroom here: https://matrix.org/blog/2022/11/16/call-for-participation-for-the-fosdem-2023-matrix-devroom
+
+## Dept of Interesting Projects 🛰️
+
+### Matrix plays GameBoy games once more
+
+[Bram](https://matrix.to/#/@bram:noordstar.me) announces
+
+> [Last week's TWIM](https://matrix.org/blog/2022/11/11/this-week-in-matrix-2022-11-11#matrix-plays-gameboy-games) presented a [GBA emulator](https://github.com/jaller94/matrix-plays-pokemon) that was written and implemented in JavaScript. Due to some obscure Rust dependencies that weren't compatible with my server setup, I decided to rewrite the program in Python.
+> 
+> The Python implementation can be found at [bram/pyboy-to-matrix](https://git.noordstar.me/bram/pyboy-to-matrix). It only supports GameBoy games (no GBA), but it only needs one process (or Docker container) to run both the emulator and the Matrix bot.
+> 
+> If you're unfamiliar with last week's post, the GameBoy emulator is a program that emulates games and then interacts with you on Matrix. You can send commands and the emulator will show you what happened in the game.
+> 
+> Send me a DM at [@bram:noordstar.me](https://matrix.to/#/@bram:noordstar.me) if you want to see a live demo.
+> 
+> ![](/blog/img/GvfnLIudxTudHNcuTGeRLfnj.png)
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|dmnd.sh|270|
+|2|joeth.uk|439.5|
+|3|matrix.org|483.5|
+|4|babel.sh|617|
+|5|willian.wang|731|
+|6|babel1.eu|738|
+|7|cezeri.tech|741|
+|8|kittenface.studio|906|
+|9|wcore.org|993|
+|10|keks.club|1435|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|dendrite.matrix.org|130|
+|2|babel.sh|214|
+|3|willian.wang|289|
+|4|wcore.org|297|
+|5|frai.se|301|
+|6|forlorn.day|572|
+|7|grin.hu|612|
+|8|valha.la|796.5|
+|9|rustybever.be|869|
+|10|matrix.milkte.ch|911|
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/11/2022-11-22-synapse-1-72-released.md
+++ b/content/blog/2022/11/2022-11-22-synapse-1-72-released.md
@@ -1,0 +1,129 @@
++++
+title = "Synapse 1.72 released"
+path = "/blog/2022/11/22/synapse-1-72-released"
+
+[taxonomies]
+author = ["Mathieu Velten"]
+category = ["Releases"]
++++
+
+It's not Christmas yet, but it's time for a new release! Say hello to [Synapse
+1.72](https://github.com/matrix-org/synapse/releases/tag/v1.72.0).
+
+It seems like this blog didn't self update through AI for the 2 preceding
+updates so this post will cover 1.70 to 1.72, sorry if this is a bit long but
+it's been a while :)
+
+## Announcements
+
+### Dropping support for PostgreSQL 10
+
+PostgreSQL 10 has reached End Of Life: Synapse will no longer support it
+beginning with version 1.72 so please upgrade your database if you have not
+already done so.
+
+### Legacy Prometheus metric names disabled and to be removed
+
+In previous versions of Synapse, some Prometheus metrics were emitted under two
+different names, an older name that was non-compliant with OpenMetrics and
+Prometheus conventions and a new compliant name.
+
+Synapse 1.71 and later have the old metric names switched off by default.
+
+For now it's still possible to get them by using `enable_legacy_metrics: true`,
+however server administrators still using legacy metric names are highly
+encouraged to migrate, as they will be removed in 1.73.
+
+You can find the full list of renamed metrics
+[here](https://matrix-org.github.io/synapse/v1.72/metrics-howto.html#renaming-of-metrics--deprecation-of-old-names-in-12).
+
+### Changes to the events received by application services (interest)
+
+Following the implementation of
+[MSC3905](https://github.com/matrix-org/matrix-spec-proposals/pull/3905),
+Synapse now only considers local users to be interesting to application
+services. In other words, the users namespace regex in an app service's
+registration file is only applied against local users of the homeserver.
+
+Please note, this probably doesn't affect the expected behavior of your
+application service, since an interesting local user in a room still means all
+messages in the room (from local or remote users) will still be considered
+interesting.
+
+You can find a bit more info in the MSC and in the [upgrade
+notes](https://matrix-org.github.io/synapse/v1.71/upgrade.html#changes-to-the-events-received-by-application-services-interest).
+
+## The new stuff
+
+### Threads, threads, threads!
+
+Several MSCs related to threads got implemented:
+- [MSC3856](https://github.com/matrix-org/matrix-spec-proposals/pull/3856)
+  provide an API to fetch threads and related metadata.
+- [MSC3771](https://github.com/matrix-org/matrix-spec-proposals/pull/3771) and
+  [MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773)
+  implementing per thread read receipts and per thread notification counts.
+- [MSC3874](https://github.com/matrix-org/matrix-spec-proposals/pull/3874)
+  allows to filter out messages belonging to threads from the main timeline
+  (still considered experimental). Along with MSC3856, this should noticeably
+  improve performance of rooms that use threads heavily.
+
+This should significantly improve user experience related to threads, being
+through behavior or performance impact.
+
+### Linking events together
+
+Relationships are great, even more between events than humans!
+
+[MSC3664](https://github.com/matrix-org/matrix-spec-proposals/pull/3664) allows
+Matrix clients to be notified in real time of related events, so you can now be
+made quickly aware of this cat emoji reaction that your cat photo clearly
+deserved.
+
+Additionally, Synapse 1.72 includes an implementation of
+[MSC3912](https://github.com/matrix-org/matrix-spec-proposals/pull/3912),
+allowing users to redact the relations of a message alongside the message
+itself. This is particularly helpful in cases like edits, where users usually
+want to see their edits redacted at the same time as the original message. Note
+that this implementation is currently incomplete and still experimental, though,
+so watch this space!
+
+### Faster joins, continued
+
+We continue our journey to get everything going as transparently as possible
+when doing fast remote room joins.
+
+If you missed it you can refer to this previous [blog
+post](https://matrix.org/blog/2022/10/18/testing-faster-remote-room-joins) to
+get a lot more infos, and feel free to grep Synapse changelog and the numerous
+related issues/PRs for all the gory details.
+
+## Everything else
+
+See the full changelogs
+([1.70](https://github.com/matrix-org/synapse/releases/tag/v1.70.0),
+[1.71](https://github.com/matrix-org/synapse/releases/tag/v1.71.0),
+[1.72](https://github.com/matrix-org/synapse/releases/tag/v1.72.0)) for a
+complete list of changes in the releases. Also please have a look at the
+[upgrade
+notes](https://matrix-org.github.io/synapse/v1.72/upgrade#upgrading-to-v1720)
+for this version.
+
+Synapse is a Free and Open Source Software project, and we'd like to extend our
+thanks to everyone who contributed to this release, including (in no particular
+order) [Nico](https://github.com/deepbluev7),
+[sando38](https://github.com/sando38), [realtyem](https://github.com/realtyem),
+[aceArt GmbH](https://github.com/aceArt-GmbH), [Tuomas
+Ojamies](https://github.com/tuojamie), [Ashish
+Kumar](https://github.com/ashfame), [asymmetric](https://github.com/asymmetric),
+[Beeper](https://www.beeper.com/), [Ryan
+Miguel](https://github.com/renegaderyu), [Paul
+Tötterman](https://github.com/ptman), [Abdullah
+Osama](https://github.com/Abdullah0sama), [Finn](https://github.com/thefinn93),
+[Ivan Shapovalov](https://github.com/intelfx), [Dirk
+Klimpel](https://github.com/dklimpel), [Jonathan de
+Jong](https://github.com/ShadowJonathan),
+[MichaIng](https://github.com/MichaIng) and [Aaron
+Raimist](https://github.com/aaronraimist) as well as anyone helping us make
+Synapse better by sharing their feedback and reporting issues.
+

--- a/content/blog/2022/11/2022-11-25-this-week-in-matrix-2022-11-25.md
+++ b/content/blog/2022/11/2022-11-25-this-week-in-matrix-2022-11-25.md
@@ -1,0 +1,341 @@
++++
+title = "This Week in Matrix 2022-11-25"
+date = "2022-11-25T23:46:42Z"
+path = "/blog/2022/11/25/this-week-in-matrix-2022-11-25"
+
+[taxonomies]
+author = ["Thib"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/pCzugZA1ScY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Dept of *Status of Matrix* 🌡️
+
+[Matthew](https://matrix.to/#/@matthew:matrix.org) says
+
+> Interesting paper analysing the impact of decentralisation (and particularly Matrix) on legislation around content moderation: https://www.thecgo.org/research/the-decentralized-web-and-the-future-of-section-230/
+
+## Dept of Spec 📜
+
+[Andrew Morgan (anoa)](https://matrix.to/#/@andrewm:element.io) says
+
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> 
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3939: Account locking](https://github.com/matrix-org/matrix-spec-proposals/pull/3939)
+> * [MSC3938: Remove keyId from `/keys` endpoints](https://github.com/matrix-org/matrix-spec-proposals/pull/3938)
+> 
+> **MSCs in Final Comment Period:**
+> * *No MSCs are in FCP.*
+> 
+> **Accepted MSCs:**
+> * *No MSCs were accepted this week.*
+> 
+> ## Spec Updates
+> 
+> Off the back of the release of Matrix v1.5 last week (see the [blog post](https://matrix.org/blog/2022/11/17/matrix-v-1-5-release) if you missed it), work on the next release has now begun.
+> 
+> Continued review on [MSC3706](https://github.com/matrix-org/matrix-spec-proposals/pull/3706) (extensions to `/send_join` for partial state) and [MSC3852](https://github.com/matrix-org/matrix-spec-proposals/pull/3852) (user agent information on /devices) by the SCT was seen. [MSC3743](https://github.com/matrix-org/matrix-spec-proposals/pull/3743) (standard error responses for unknown endpoints) was also [merged](https://github.com/matrix-org/matrix-spec/pull/1347) to the unstable spec!
+> 
+> Special thanks to several contributors of fixes to the spec this week; including [zecakeh](https://github.com/zecakeh), [HarHarLinks](https://github.com/HarHarLinks), [sumnerevans](https://github.com/sumnerevans), [johannescpk](https://github.com/johannescpk) and [DMRobertson](https://github.com/DMRobertson)!
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC3896: Appservice media](https://github.com/matrix-org/matrix-spec-proposals/pull/3896)!
+> 
+> This MSC calls out the issue that today application services, especially those that bridge third-party networks, need to re-upload all bridged media to the homeserver in order for users to view it. This can create a large strain on disk resources for homeservers that bridge third-party networks and is a problem that is worth considering.
+> 
+> The approach the MSC takes to solving this is to allow application services to reserve an exclusive namespace for MXC URL's, such as `mxc://example.com/_discord_.*`. When a user's client attempted to request a media item that falls within the exclusive namespace, the homeserver would request the media from the application service (which in turn could pull it from the third-party network's CDN) rather than the homeserver's local media repo.
+> 
+> Seems like a cool idea! Check out the MSC and leave your thoughts if you're interested or have suggestions.
+> 
+> ![](/blog/img/30c981e1a8dfa4e91e64ccb22ac1a7bffda4d713.png)
+
+## Dept of Servers 🏢
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[dmr](https://matrix.to/#/@dmrobertson:matrix.org) announces
+
+> It has been a busy week for the Synapse team.
+> 
+> On Tuesday we released Synapse 1.72, including
+> * experimental support for [relation-based redactions](https://github.com/matrix-org/matrix-spec-proposals/pull/3912),
+> * A new admin API to [lookup users by third-party ID](https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#find-a-user-based-on-their-third-party-id-threepid-or-3pid), and
+> * further progress on the [faster joins project](https://github.com/matrix-org/synapse/milestone/10),
+> 
+> plus a batch of bugfixes. As ever, we aim to cut the next release candidate for Synapse 1.73 on the coming Tuesday. It should include the work that landed on develop this week. Of note:
+> 
+> * [continuing](https://github.com/matrix-org/synapse/pull/14404) [work](https://github.com/matrix-org/synapse/pull/14408) on faster joins;
+> * a sprint of work to improve [the performance of /messages requests](https://github.com/matrix-org/synapse/issues/13624#issuecomment-1323948527) and [device list tracking](https://github.com/matrix-org/synapse/pull/14516); and
+> * removing duplicated [prometheus metrics](https://github.com/matrix-org/synapse/issues/11106), which should save server operators using Prometheus a considerable amount of disk space.
+
+## Dept of Bridges 🌉
+
+### Postmoogle ([website](https://gitlab.com/etke.cc/postmoogle))
+
+An Email to Matrix bridge. 1 room = 1 mailbox.
+
+[Aine](https://matrix.to/#/@aine:etke.cc) says
+
+> Postmoogle v0.9.9 is here!
+> 
+> The biggest release so far. Hmm... let me try again
+> 
+> **THE** Biggest Release (so far)!
+> 
+> The last few weeks we at [etke.cc](https://etke.cc) enhanced and optimized Postmoogle to make it as close to common email services as possible (it's not a full Gmail/Outlook/%You-name-it% replacement for a regular user yet, some features are missing, but we're pushing it towards that goal!)
+> 
+> The most notable changes:
+> 
+> * automatic ban list (can be enabled by postmoogle admin) - no more nasty spammers will ever bother your host and if they will - Postmoogle will ~~cut the wires~~ drop TCP connections before even talking with them
+> * automatic greylisting (can be configured by postmoogle admin) - good SMTP software must resend emails (and 99.99% of them do), RFC said.
+> * internal email queue to re-send failed emails (with 45x errors) automatically - because Postmoogle is good SMTP software and it follows RFC
+> * bridging email threads ⇿ matrix threads/reply-tos (for new emails) - that's a hard one. TL;DR: reply to email in matrix room (either by matrix thread or matrix reply-to) = email reply on email side, works both ways
+> * multi-domain mode with the ability to select a domain for sending emails per room/per mailbox (all other domains will act as aliases)
+> * `!pm send` and thread replies send multipart emails by default (both HTML from formatted markdown and plaintext in the same email)
+> * lots of other enhancements and fixes under the moogle
+> 
+> [Source code](https://gitlab.com/etke.cc/postmoogle) and don't forget to say hi in [#postmoogle:etke.cc](https://matrix.to/#/#postmoogle:etke.cc)
+
+## Dept of Clients 📱
+
+### Nheko ([website](https://nheko-reborn.github.io))
+
+Desktop client for Matrix using Qt and C++17.
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) says
+
+> You may have noticed it has been a bit quiet from our side lately. Partially that is because I was just busy fixing issues in our new features on the Synapse side (or implementing MSCs in Synapse). But we also just have been fixing boring old issues in our project, that have been not annoying enough to get attention. For example there was a warning when configuring the project with CMake, which now shouldn't happen anymore, but also is just really boring to talk about.
+> 
+> So maybe some more exciting stuff, in theory, if your distribution builds curl with the correct flags, Nheko now supports connecting to servers over HTTP/3. This in itself is not that useful, but it might improve how Nheko behaves when switching connections or when using mobile data.
+> 
+> Nheko now also shows a completer for /commands (stuff like /me, /react or /sovietflip).
+> 
+> You can also now invert the Enter setting, so that you can send using Shift+Enter (thanks to LordMZTE) and you can update your status message over D-Bus (thanks LorenDB), which allows you to show what song you are listening to or what project you are working on, if you enable the D-Bus API and implement that as an addon in your music player or IDE.
+> 
+> Also lots of boring cleanups going on behind the scenes still, so expect cool stuff to be slower for the next few weeks.
+> 
+> ![](/blog/img/20221125.png)
+
+### Neochat ([website](https://invent.kde.org/network/neochat))
+
+A client for matrix, the decentralized communication protocol
+
+[Tobias Fella](https://matrix.to/#/@tobiasfella:kde.org) says
+
+> You might be aware that we, the NeoChat team, are currently working on implementing end-to-end encryption in NeoChat. If you're interested in that work, you should read the blog post i've written about it at https://tobiasfella.de/posts/neochat-e2ee/
+
+### Hydrogen ([website](https://github.com/vector-im/hydrogen-web))
+
+Hydrogen is a lightweight matrix client with legacy and mobile browser support
+
+[Bruno](https://matrix.to/#/@bwindels:matrix.org) says
+
+> Back after a bit of a hiatus working on call support (coming soon!) and non-hydrogen things which we're wrapping up now. Today and last Friday we've added sticky date headers to the timeline, which just got released in [0.3.5](https://github.com/vector-im/hydrogen-web/releases/tag/v0.3.5). Check it out if you haven't already at https://hydrogen.element.io
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[Danielle 🦺](https://matrix.to/#/@daniellekirkwood:one.ems.host) announces
+
+> * We’ve recently made improvements to the password recovery flow, meaning that you no longer choose your password before verifying your email… We now follow a more conventional approach (and have parity with mobile flows) that will make it easier for those struggling to sign in.
+> * We’ve also continued to add tests and increase overall test coverage!
+> 
+> In labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> 
+> * Rich text editor: We’ve been working on lists and ‘ctr+backspace’ support
+> * Threads: Improvements to performance and notifications continue but this week we’ve mostly put our efforts on testing as we’re prepping for the release of Threads out of Labs!
+
+## Dept of SDKs and Frameworks 🧰
+
+### Trinity ([website](https://github.com/bnjbvr/trinity))
+
+Trinity is an experimental bot framework written in Rust and using matrix-rust-sdk, as well as commands / modules compiled to WebAssembly, with convenient developer features like modules hot-reload.
+
+[bnjbvr](https://matrix.to/#/@bnjbvr:delire.party) reports
+
+> This week, a tritiny update:
+> 
+> * we have experimental support for using Trinity as a library, thanks to @gnunicorn! So experimental that the public API may break at any point without warnings, and it hasn't even been published, but if you feel adventurous, take a look.
+> * Flaki from Suborbital and Yours Truly have had a small and cozy chat about Trinity, where we talk about WebAssembly and Matrix, try to set up a new instance of the bot (!), find a bug (!!) but at the end it works (!!!). [Youtube link](https://www.youtube.com/watch?v=hIbBLs1q99w) if you're teased!
+> 
+> If you're interested to follow the project, feel free to join [#trinity:delire.party](https://matrix.to/#/#trinity:delire.party) or [get the code on Github](https://github.com/bnjbvr/trinity).
+
+### Matrix-Webhooks ([website](https://matrix-webhooks.com))
+
+Matrix-Webhooks goal is to provide Rich, Embedded webhooks for Matrix as an alternative to Discord Webhooks, it's compatible with discord payload and API, so very easy to integrate into services like github, gitlab, grafana, uptime kumi etc ...
+
+[rednaks](https://matrix.to/#/@rednaks:matrix.org) reports
+
+> * You can find the source code here : https://github.com/rednaks/matrix-webhooks
+> * Or you can try it or use it here : https://matrix-webhooks.com/
+> * You can also join our Matrix space where we share announcements, and have general discussions about matrix-webhooks inorder to improve it : https://matrix.to/#/#matrix-webhooks.com:matrix.org
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) announces
+
+> It's been a busy week for the matrix-sdk team. As the week before, a lot of time was (well) spent on fixes and smaller improvements for mobile integration, during which a few bugs and problems where discovered and squashed. While this is ongoing, some of them already found their way back into mainline or at least have PRs pending for it: Like the bug in the read marker tracking which sometimes caused a crash [1](https://github.com/matrix-org/matrix-rust-sdk/pull/1231) [2](https://github.com/matrix-org/matrix-rust-sdk/pull/1233), a problem with [timeline construction being async](https://github.com/matrix-org/matrix-rust-sdk/pull/1235) or some minor fixes on the new [xtask for swift](https://github.com/matrix-org/matrix-rust-sdk/pull/1225). We've also noticed a significant regression in the automatic retry mechanism, which would just continue to spin for ever if the server gave a fully warranted error code back - if you experienced this, [this PR should be solving it for you](https://github.com/matrix-org/matrix-rust-sdk/pull/1237).
+> 
+> A significant milestone was achieved this week on Async UniFFI. After getting a first PoC ready the week before, Ivan packaged it all up and sent [a draft PR upstream](https://github.com/mozilla/uniffi-rs/pull/1409) with async python code calling an async rust code over FFI and interpreting the rusty result. So cool! Swift and kotlin targets are next.
+> 
+> 
+> 👉 Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+### libQuotient ([website](https://github.com/quotient-im/libQuotient))
+
+A Qt5 library to write cross-platform clients for Matrix
+
+[kitsune](https://matrix.to/#/@kitsune:matrix.org) announces
+
+> As that [blog post](https://tobiasfella.de/posts/neochat-e2ee/) by Tobias mentions, releasing libQuotient 0.7 is the immediate next step - and in line with that, 0.7 RC has been published! Not much has changed since two betas; despite a very big piece of E2EE introduced in 0.7 release cycle, things have been mostly ironed out earlier in the year. Packagers are welcome to try their tools on the new release. Be mindful though that E2EE has just been introduced and wasn't widely tested; besides, a few pieces are still missing (read the blog post!); so while it's probably reasonable to switch E2EE on for packaging libQuotient, it's NOT recommended to do the same in client applications, unless accompanied by warnings and disclaimers all over the place. The [release notes](https://github.com/quotient-im/libQuotient/releases/tag/0.7-rc) are still shallow and boring - the longer text will come with the final release.
+
+## Dept of Ops 🛠
+
+### matrix-docker-ansible-deploy ([website](https://github.com/spantaleev/matrix-docker-ansible-deploy))
+
+Matrix server setup using Ansible and Docker
+
+[Slavi](https://matrix.to/#/@slavi:devture.com) says
+
+> [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy) has received lots of optimizations to cut down playbook runtime, sponsored by the [etke.cc managed Matrix hosting service](https://etke.cc). The [etke.cc Ansible playbook](https://gitlab.com/etke.cc/ansible) (which is an extension of `matrix-docker-ansible-deploy`) is growing to support more and more services (besides just Matrix), so the Matrix playbook being leaner prevents runtimes from becoming too slow and improves the customer experience.
+> 
+> The playbook now runs about 2x-5x faster, thanks to:
+> 
+> * various optimizations (using `include_tasks` instead of `import_tasks` in all Ansible roles)
+> * the introduction of additional install-only tags (`--tags=install-all` or `--tags=install-COMPONENT`) which skip slow and often unnecessary to run uninstall tasks
+> 
+> To learn more, see [this changelog entry](https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/CHANGELOG.md#2x-5x-performance-improvements-in-playbook-runtime)
+
+## Dept of Bots 🤖
+
+### Mjölnir ([website](https://github.com/matrix-org/mjolnir))
+
+The moderation bot for Matrix
+
+[Gnuxie](https://matrix.to/#/@gnuxie:matrix.org) announces
+
+> Hi everyone, we have released Mjolnir [v1.6.1](https://github.com/matrix-org/mjolnir/releases/tag/v1.6.1) (via [v1.6.0](https://github.com/matrix-org/mjolnir/releases/tag/v1.6.0))
+> 
+> Which includes:
+> * Always echo policy list changes. List changes are now always enabled, whereas before they where only shown with `config.verboseLogging`. Mjolnir now no longer hides changes made by the same mjolnir account, providing the user with feedback for changes they have made to policy lists after using the ban/unban commands.
+> * Policy lists created by mjolnir will now be done so with support for [MSC3784](https://github.com/matrix-org/matrix-spec-proposals/pull/3784).
+> *  Mjolnir now supports specifying the config file with the argument `--mjolnir-config`. It is highly recommended that you do this as opposed to relying on the environment variable `NODE_ENV`. The documentation for running with [docker](https://github.com/matrix-org/mjolnir/blob/v1.6.1/docs/setup_docker.md) and from [source](https://github.com/matrix-org/mjolnir/blob/v1.6.1/docs/setup_selfbuild.md) have been updated accordingly.
+> * Fix the WordList protection which was matching every message.
+> * Rework the banning and unbanning of entities in PolicyLists.
+> 
+>     - Unbanning no longer searches for rules by `state_key` but by entity.
+>     - Users with longer mxids can now be banned.
+>     - Mjolnir no longer waits for the next client sync before applying server ACL and member bans after using the ban command
+> * Improve the clarity of the unban command. Users marked as banned by the `Flooding` and `FirstMessageIsMedia` protections can now be unbanned with the ban command. Using the unban command without `true` will now warn the user that room level bans will not be overridden.
+> * Replaced `acceptInvitesFromGroup` with `acceptInvitesFromSpace`.
+> * Fix `config.protectAllJoinedRooms` leaking into explicitly protected rooms and mjolnir trying to protect watched lists in some circumstances. You would only have been impacted by this if you ran `latest`.
+
+## Dept of Events and Talks 🗣️
+
+### Matrix Community Summit Berlin 2022 Podcast (German)
+
+[jaller94](https://matrix.to/#/@jaller94:matrix.org) reports
+ 
+> The Community Summit 2022 in Berlin was a lot of fun and we've gotten to know a lot of community members and their projects. Some of these people we were able to interview and will release the recordings as a weekly podcast. From now on, each Friday an episode will be released for a total of 8 episodes.
+> 
+> Today (18th November), we're starting with Alex and Valentin. We talked about the summit, what went well and what activities to add next time. Furthermore, the two shared their passion for home server performance. Give it a listen!
+> 
+> Website: https://anchor.fm/matrix-podcast0
+> 
+> RSS feed: https://anchor.fm/s/cdb34188/podcast/rss
+> 
+> If you don't speak German, stay tuned for English episodes in some of the following weeks,
+> Yan and Christian
+
+### Chaos communication family
+
+[Yan](@yan:datanauten.de) reports
+
+> ### ![Hacking in Parallel ////](https://hip-berlin.de/logo.svg)
+>
+> December 27-30 2022
+>
+> A part of our chaotic decentralized intergalactic community will be a meeting in the rooms of "ETI Schauspielschule Berlin" at Hacking in Parallel//// this year.
+>
+> There are several units and indiduals who will be there spread (into) the matrix ...
+> **You can enter proposals until 2022-11-27 23:42 (Europe/Berlin).** https://pretalx.c3voc.de/hip-berlin-2022/cfp
+>
+> The Matrix space for the event is a good general place to get in touch.
+> https://matrix.to/#/#hip-space:1312.media
+>
+> We also prepare for having a **M**atrix **O**peration **C**~~enter~~haos at the Chaos Communication Camp in Summer. This will take place from August 15 to 19, 2023 at Ziegeleipark Mildenberg near Berlin, Germany.
+> If you want to join forces of the and need a ticket voucher for the HIP. Drop in at:
+> https://matrix.to/#/#matrix-moc:datanauten.de
+>
+> If you can / will not make it with you physical body to Berlin. No worries. You should start [connecting the dots](https://events.ccc.de/2022/11/13/xrelog22-cfp/). 
+>
+> The XRevent.Labs Operation Group invites you to xrelog22. Discussions, lectures, music, art, performance and the joint creation of independent multiverses will take place from December 28 to 30, 2022. We not only want to raise socio-political, ethical and creative questions, but also actively develop own spaces and content for an interactive, cross-reality live experience.
+>
+> Anyone who is interested in joining or visiting us can do so either with pre-registration for the real stage at FTZ - Digital Reality at HAW in Hamburg or virtually in the digital-twin at XRevent platform, or the Intergalactic-Chaos-Communication-Broadcast-Studio, aka icc|bs. Your contributions can be pre-recorded, streamed live via a conference tool or presented in the real space on site. Either way, get in touch and we’ll find a solution. Please test yourself and wear a mask if you visit us in person.
+>
+> Furthermore we offer:
+>
+> -   weekly workshops in advance
+> -   recordable LED pixel walls
+> -   Thirdroom Research Lab
+>
+> Contacts …
+>
+> -   via Mail: [cf23@lab.nrw](mailto:cf23@lab.nrw)
+> -   via CfP: [https://pretalx.c3voc.de/xrelog-2022/](https://pretalx.c3voc.de/xrelog-2022/)
+> -   via XRevent.Labs Lounge: [https://matrix.to/#/#xrevent:matrix.org](https://matrix.to/#/#xrevent:matrix.org)
+
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|babel.sh|429|
+|2|wcore.org|434|
+|3|alemann.dev|474.5|
+|4|nognu.de|593|
+|5|chat.nerdhouse.io|595|
+|6|dendrite.babel.sh|690|
+|7|babel1.eu|843.5|
+|8|willian.wang|911|
+|9|jeroenhd.nl|929|
+|10|kittenface.studio|971|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|babel.sh|120|
+|2|conduit.hazmat.jacksonchen666.com|145|
+|3|dendrite.babel.sh|188|
+|4|wcore.org|348|
+|5|willian.wang|391|
+|6|jacksonchen666.com|749|
+|7|valha.la|828|
+|8|forlorn.day|922|
+|9|evilcyberhacker.net|1629|
+|10|frai.se|41508|
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/12/2022-12-01-funding-matrix-via-the-matrix-org-foundation.md
+++ b/content/blog/2022/12/2022-12-01-funding-matrix-via-the-matrix-org-foundation.md
@@ -1,0 +1,106 @@
++++
+title = "Funding Matrix via the Matrix.org Foundation"
+path = "/blog/2022/12/01/funding-matrix-via-the-matrix-org-foundation"
+
+[taxonomies]
+author = ["Matthew Hodgson"]
+category = ["General"]
+
+[extra]
+image = "https://matrix.org/blog/img/matrix-logo.png"
++++
+
+*TL;DR: you can now officially join the Matrix Foundation as an organisational
+or individual member in order to sustainably support core Matrix development,
+help steer the direction of the protocol and how best to fund it! Organisations
+can join by filling [this form](https://forms.gle/Yy345QkB5pifJJNy6) and we will get back in touch, or individuals can
+now donate directly [here](https://donorbox.org/keep-matrix-exciting) (as a more efficient alternative to Patreon, which
+remains online for Patrons used to it).*
+
+Hi all,
+
+Only two days late for Giving Tuesday (and 4 years late on the Foundation
+scale), we are super excited to announce that we are finally expanding the
+Matrix Foundation into a fully-fledged non-profit fund-raising organisation to
+help support the core Matrix development and the wider open source Matrix
+ecosystem!
+
+Has your organisation been using Matrix to communicate via the open source
+server and clients and you want to ensure that improvements and features still
+keep coming? Become a member, and feed into the roadmap.
+
+Has your company been building on top of Matrix, making the most of its openness
+and flexibility, but you’ve never figured out how to contribute back in order
+to ensure the resilience of the tech which you rely on for the success of your
+business? Become a member, and ensure the core development is funded and that
+Matrix is here to thrive.
+
+Are you about to be designated a gatekeeper by the EU, and have to rapidly figure out how to implement [DMA-compliant interoperability](https://matrix.org/blog/2022/03/29/how-do-you-implement-interoperability-in-a-dma-world) (complete with end-to-end encryption compatibility) into your services? Become a member, and discover how Matrix can solve all your problems, while providing your input too. 
+
+Are you looking to implement DMA interoperability but don't fall into the gatekeeper designation? Become a member, and help ensure Matrix fits your needs too!
+
+Are you a non-profit organisation with a mission to provide secure and sovereign communications to those who need it the most, providing an alternative to the current players? Become a member, and help us take our mission forward.
+
+Are you an individual who strongly supports the mission of Matrix and wants to see it thrive and become the open backbone of the world’s communications? Become a member, and support the future of Matrix. 
+
+In short, this finally gives the wider world a way to contribute concretely to the significant costs of funding folks to work fulltime on core Matrix development - which now covers over 243(!) projects in [github.com/matrix-org](https://github.com/matrix-org). Core Matrix work ranges from: 
+
+- managing the Matrix spec itself 
+- maintaining the reference client SDKs and encryption and getting them independently audited
+- maintaining example server implementations in the form of Synapse and Dendrite
+- writing the test suite
+- publishing the matrix.org website
+- promoting awareness of Matrix
+- running the matrix.org homeserver
+- and so much more... 
+
+In exchange for supporting the Foundation, and beyond providing certainty that our work can continue, organisations and individuals who contribute financially will be able to directly provide input to the trajectory of the core Matrix developments by becoming official members of the Matrix.org Foundation.
+
+## Introducing Foundation Memberships and the Governing Board
+
+Practically speaking, this means that we are going to create a "Governing Board" to the Matrix.org Foundation: a new team, made up of members voted by the overall membership, a subset of the Guardians and a subset of the Spec Core Team. The Governing Board will have the responsibility of determining how Foundation funds are distributed and used, how the Spec Core Team roadmap is prioritised, how to best grow Matrix awareness, etc.
+
+In other words, we are literally expanding the day-to-day steering of the direction of the Matrix Foundation to the wider community. In order to run the Governing Board and the overall work of the Foundation, **we are also hiring an Executive Director**, so please get in touch via [funding@matrix.org](mailto:funding@matrix.org) if you’re a non-profit foundation-running expert! In the interim, while this search proceeds, Matthew and Amandine will fill the role with the support of the other Guardians of Matrix. The Guardians themselves retain their existing function as the Foundation's non-executive board - responsible for safeguarding the overall mission of Matrix, appointing the membership of the Spec Core Team, approving membership applications, and defining the overall changes we’re outlining here.
+
+Membership comes at various levels, each with different rewards:
+
+- Individual memberships (i.e. today’s Patreon supporters):
+  - Ability to vote in the appointment of up to 2 ‘community representatives’ to the Foundation's governing board.
+  - Name on the Matrix.org website
+- Silver member: between £2,000 and £80,000 per year, depending on organisation size
+  - Ability to vote on the appointment of up to 2 ‘Silver representative’ to the Foundation's governing board
+  - Supporter logo on the front page of the new Matrix.org website
+- Gold member: £200,000 / year, adds:
+  - Ability to vote on the appointment of up to 3 ‘Gold representatives’ to the Foundation's governing board.
+  - Press release announcing the sponsorship
+  - 1 original post on the Matrix.org blog per year
+  - Participation in the internal Spec Core Team room
+  - Larger logo on the front page of Matrix.org
+- Platinum member: £500,000 / year, adds:
+  - Ability to vote on the appointment of up to 5 ‘platinum representatives’ to the Foundation's governing board.
+  - 1 sponsored Matrix Live episode per year
+  - Largest logo on the front page of Matrix.org
+
+As the activities of the Foundation increase, we expect to add more benefits to this list, for example discounts on sponsoring a future Matrix Conference, or similar.
+
+Governing Board elections will occur yearly, with the first election planned towards the end of this year once we’ve gathered together the first wave of members and candidates have proposed themselves for election.
+
+For anyone building on Matrix, memberships are a no-brainer as they will ensure the perpetuity and future-proof-ness of the standard. But for anyone supporting the mission of Matrix, this membership can be key to define its future. 
+
+Meanwhile, with Matrix looking increasingly integral to implementing interoperable communication for compliance with the EU’s Digital Markets Act (whether that’s as pure Matrix, or as part of the IETF [MIMI](https://datatracker.ietf.org/doc/draft-ralston-mimi-matrix-transport/) initiative), this is an incredible opportunity for the organisations impacted by DMA to get a front-row seat within the Foundation to ensure that Matrix thrives and solves the challenges posed by the act. To get involved, please apply via the [membership application form](https://forms.gle/Yy345QkB5pifJJNy6).
+
+## So, why is this all happening?
+
+Since 2017, core Matrix development has been funded primarily by Element - the company founded by the team who created Matrix. Over the years, Element has put tens of millions of dollars into Matrix - which in turn has come from both selling Matrix hosting (EMS), on-premise Matrix solutions, and VC investment in Element. To put it in perspective, even though there are over 5000 contributors to [github.com/matrix-org](https://github.com/matrix-org) - over 90% of the actual committed lines of code come from Element employees. Similarly, while we are *enormously* thankful for the past and existing generous donations from the wider Matrix community, today they only come to $6,000 a month, relative to the $400,000 a month that Element has been funding.
+
+Over the last year, we’ve seen a palpable shift within the Matrix ecosystem. Matrix is growing faster than ever. Synapse has improved immeasurably, using less RAM than ever and even sprouting Rust to optimise its hot paths. Element has improved immeasurably too, with an entirely new design on mobile, and tons of new features including threads, voice messages, location share, video rooms and more. Monthly active users reported via Synapse’s phone-home stats have almost doubled and are growing at their fastest ever rate. The number of servers has increased equivalently. We hear about major new commercial Matrix deployments almost every day. However, while usage is going through the roof - we haven’t seen a matching increase in players looking to support the project.
+
+In fact, we’ve seen the opposite: commercial vendors forking the protocol while trying to break up the core team. Matrix tenders lost to “preferred” vendors who know absolutely nothing about Matrix. Vendors selling Matrix hosting or services without contributing anything back to the project at all. Organisations with huge amounts of money (governments, $$B massive enterprises) have enthusiastically launched proprietary Matrix solutions by building on the liberally-licensed Apache reference Matrix implementations… while contributing back nothing. Now, we are enormously grateful for the commercial Matrix deployments who *do* actually work with Element to fund core development or contribute code themselves - but this is very clearly the minority. Obviously it’s great to see folks building on Matrix - but it’s rather galling if it ends up with insufficient funding trickling down to the core Matrix team to be able to build the foundational technology that everyone else is relying on.
+
+Element in particular has staffed up in order to both support the core Matrix ecosystem (the spec, Synapse, Dendrite, Client SDKs, Encryption implementations etc) as well as Element-specific work (the Element apps, EMS, the Element Enterprise Installer, etc). As a result, Element employs roughly twice as many developers as you might expect, and while Matrix is here to stay, this turns out not to be sustainable for Element unless the wider ecosystem helps support the foundational work
+
+We believe the world needs secure decentralised communication more than ever, and ensuring the Foundation can distribute funding to those contributing to the core platform (be that Element or individuals or other organisations) is key to that. So: please consider this a call to arms - if you believe the world needs Matrix, and particularly if you depend on it for your business, please join the Foundation and participate!
+
+Fill in [the form](https://forms.gle/Yy345QkB5pifJJNy6) to apply for membership, or if you are not acting on behalf of an organisation, you can go straight to our [donation page](https://donorbox.org/keep-matrix-exciting).
+
+Matthew, Amandine & the whole Matrix.org Foundation

--- a/content/blog/2022/12/2022-12-02-this-week-in-matrix-2022-12-02.md
+++ b/content/blog/2022/12/2022-12-02-this-week-in-matrix-2022-12-02.md
@@ -1,0 +1,354 @@
++++
+title = "This Week in Matrix 2022-12-02"
+date = "2022-12-02T19:30:33Z"
+updated = "2022-12-02T18:43:48Z"
+path = "/blog/2022/12/02/this-week-in-matrix-2022-12-02"
+
+[taxonomies]
+author = ["Thib"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/Uunj5mDtt1s" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+This episode of Open Tech Will Save Us was a special on Moderation. Our guest was Jim from the Matrix.org Foundation's Trust & Safety Team.
+
+Can moderation be automated? Can it be apolitical? How does it scale? Are decentralised systems inherently more insecure than centrlised ones? Let's find out!
+
+## Dept of *Status of Matrix* 🌡️
+
+[Thib](https://matrix.to/#/@thib:ergaster.org) says
+
+> You can now officially join the Matrix Foundation as an organisational or individual member in order to sustainably support core Matrix development, help steer the direction of the protocol and how best to fund it. In order to run the Governing Board and the overall work of the Foundation, we are also hiring an Executive Director.
+> 
+> Read [the full blog post here](https://matrix.org/blog/2022/12/01/funding-matrix-via-the-matrix-org-foundation)
+
+## Dept of Spec 📜
+
+[Andrew Morgan (anoa)](https://matrix.to/#/@andrewm:element.io) says
+
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3943: Partial joins to nameless rooms should include heroes' memberships](https://github.com/matrix-org/matrix-spec-proposals/pull/3943)
+> 
+> **MSCs in Final Comment Period:**
+> * *No MSCs are in FCP.*
+> 
+> **Accepted MSCs:**
+> * *No MSCs were accepted this week.*
+> 
+> ## Spec Updates
+> 
+> A lot of this week was spent on implementation by the SCT, hence little movement in the bullet points above. However, outside of label changes, we've seen lots of progress on Extensible Events work from Travis as we continue to lay the groundwork for the [IETF MIMI initiative](https://datatracker.ietf.org/doc/draft-ralston-mimi-matrix-transport/).
+> 
+> We also continue to receive lots of fixes to the spec text itself via PRs to https://github.com/matrix-org/matrix-spec. Shout outs to [zecakeh](https://github.com/zecakeh), [dylhack](https://github.com/dylhack), and [uhoreg](https://github.com/uhoreg) for their contributions!
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC3890: Remotely silence local notifications](https://github.com/matrix-org/matrix-spec-proposals/pull/3890)!
+> 
+> This MSC aims to provide a solution to remotely toggling do-not-disturb across your various Matrix clients without needing to set it on each device manually. It does so by using account data which is synced to each client. Upon a client seeing data intended for them, they will silence notifications locally until told to do so otherwise (either remotely or by the user interacting with the client directly).
+> 
+> Quite a neat idea, and adds more powerful functionality to the "device manager" of a client. Also handy if your other clients are things like embedded systems!
+> ![](/blog/img/7626d66d02f53020d38a5f530d76e8a757ab23f2.png)
+
+## Dept of Servers 🏢
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[Shay](https://matrix.to/#/@shayshay:matrix.org) announces
+
+> As we barrel towards the end of the year, the Synapse team is hard at work 
+> making Synapse faster, more stable and filled with features! This week we released v1.73.0rc2. Notable work
+> includes a significant speed-up to the `/messages` path. In addition you can find:
+> 
+> * Improved DB performance by reducing amount of data that gets read in device_lists_changes_in_room.
+> * Support for handling avatar in SSO login. Contributed by @ashfame
+> * Unstable support for an Extensible Events room version (org.matrix.msc1767.10) via MSC1767, MSC3931, MSC3932,
+>   and MSC3933.
+> * A bugfix for a long-standing bug where the List media admin API would fail when processing an image with broken 
+>   thumbnail information
+> 
+> and a whole host of other bugfixes, features and improvements. Head over to https://github.com/matrix-org/synapse/releases
+> to check it out.
+
+## Dept of Bridges 🌉
+
+### Slack Bridge ([website](https://github.com/matrix-org/matrix-appservice-slack))
+
+A Matrix <-> Slack bridge
+
+[Andrew F](https://matrix.to/#/@andrewf:element.io) reports
+
+> It's been a while since the last TWIM update, but the Slack bridge has been steadily improving!  See https://github.com/matrix-org/matrix-appservice-slack/releases/ for a slew of updates.
+> 
+> Highlights include:
+> 
+> * DMs are now consistently assigned with the name & avatar of the Slack user you're chatting with.
+> * Display names of Slack users should be kept up-to-date more reliably.
+> * Support is added for bridging Slack threads with MSC3440 m.thread relations.
+> * The usability of bridge bot admin commands (like `whoami` and `link`) has been improved.
+> * Some cases of inbound Slack messages being dropped have been fixed.
+
+### matrix-hookshot ([website](https://github.com/Half-Shot/matrix-hookshot))
+
+A multi purpose multi platform bridge, formerly known as matrix-github
+
+[Half-Shot](https://matrix.to/#/@Half-Shot:half-shot.uk) reports
+
+> ### Hookshot 2.5.0 is now ready for your eyes and your processors!
+> 
+> This week we bring you the very last (all fingers being crossed) hookshot release not to support e2ee encryption. Our resident expert is busy working away on supporting it and is a couple of bugfixes away from providing it to you all (https://github.com/matrix-org/matrix-hookshot/pull/299#issuecomment-1327124799).
+> 
+> In the meantime, this release was so good we couldn't keep it from you any longer. This release is packed with quality of life improvements, and general bugfixes / stability. Deploy away!
+> 
+> The highlights are:
+> 
+> * GitHub `assign` command now automatically chooses the top issue and/or authenticated user if not provided.
+> * The RSS feed connection no longer feels the need to spam you when GitHub fails to respond within 10s. It now waits for 30s.
+> * Hookshot now supports creating GitLab connections without automatically provisioning a webhook. When this happens, the bot will tell you to talk to your admin to setup the webhook manually.
+> 
+> Checkout the rest [here](https://github.com/matrix-org/matrix-hookshot/releases/tag/2.5.0)
+
+## Dept of Clients 📱
+
+### SchildiChat ([website](https://schildi.chat))
+
+SchildiChat is a fork of Element that focuses on UI changes such as message bubbles and a unified chat list for both direct messages and groups, which is a more familiar approach to users of other popular instant messengers.
+
+[SpiritCroc](https://matrix.to/#/@spiritcroc:spiritcroc.de) reports
+
+> Version 1.5.8.sc62 of SchildiChat-Android got released this week, which adds a few new interesting features on top of Element:
+> 
+> * Reworked reply rendering, to follow the rich replies specification. This improves the following:
+>     - Update the replied-to message in case the original message gets edited or deleted
+>     - Fix replies edited on desktop not being shown as replies on Android
+>     - Fix replies edited on Android being shown on Desktop with the replied-to event twice
+>     - Fix some weird rendering issues, like lists in a reply being completely broken
+>     - Nicer design, using the original sender's color, and a maximum height for the replied-to event
+>     - Render the replied-to event also for media replies, for example when the mautrix-telegram bridge sends an image reply
+>     - In the future, this will also allow us to render replied-to images instead of just writing "Image" in there, but this one is still on the TODO-list since I didn't want to delay a release further.
+> * Render captions as per [MSC2530](https://github.com/matrix-org/matrix-spec-proposals/pull/2530).
+> * We now allow sending all kinds of room-specific or account-specific global custom emotes as per [MSC2545](https://github.com/matrix-org/matrix-spec-proposals/pull/2545) (but you still need to configure them with a different client before sending).
+> 
+> For those about to ask if I'll upstream these changes to Element: I'm currently not planning to do so, but you are free to pick my changes yourself and create a PR. For rich replies, see also [here](https://github.com/vector-im/element-android/issues/3731#issuecomment-1330363453).
+> 
+> ![](/blog/img/bgBGRRdOTHXAVhIPBlUTJwob.png)
+
+### Element ([website](https://element.io))
+
+Everything related to Element but not strictly bound to a client
+
+[Anthony Hughes](https://matrix.to/#/@ashughes:element.io) reports
+
+> ### Community Testing
+> 
+> Help us test Threads on **Wednesday December 7th from 15:00 to 16:30 GMT**! We need the most help testing on Android and iOS but if you can help test on Web/Desktop that's cool too! And don't worry if you can't make it, we'll have folks around most of the day so please come out and help us test whenever you can manage. See you in the community testing room at [#element-community-testing:matrix.org](https://matrix.to/#/#element-community-testing:matrix.org)!
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[kittykat](https://matrix.to/#/@kittykat:matrix.org) says
+
+> We’ve made improvements to replies, search, notifications, user verification and DM creation over the last week
+> 
+> In labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> 
+> * Voice broadcast is continuing to receive more updates and bug fixes!
+> * Threads is nearing release, thank you all who have been trying it out! You can still join the Beta testing in Settings -> Labs to give it a spin!
+> * Also, screensharing in Element Call has had a fix!
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Doug](https://matrix.to/#/@douge:matrix.org) reports
+
+> * 📬 Useful feature time: The spaces button is now badged whenever you have unread messages or invites that aren’t visible in the current space. 
+> * 📝 The Rich Text Editor has seen more bugs and edge cases fixed and support for links and lists is underway.
+> * 🏗️ On the ElementX side we have been working on a Reactions picker, the timeline rewrite is almost finished, work on a split view layout for iPad continues and we’re finishing up a shiny new Room Details screen.
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[benoit](https://matrix.to/#/@benoit.marty:matrix.org) announces
+
+> * Element Android 1.5.10 has been released for testers on the PlayStore (still in review by Google at this time). It should be pushed to production next week. It includes a new full screen mode for the Rich Text Editor and lots of other changes. The full changelog is [here](https://github.com/vector-im/element-android/releases/tag/v1.5.10). 
+> * The team is making progress to integrate the Crypto Rust SDK in the main project and generate the application ElementR.
+> * On Android Element X, which is the new Android app written with Jetpack Compose on top of the Matrix Rust SDK, it is now possible to edit events and to reply to events. Html is also now rendered in the timeline. We will define in the coming weeks what will be the plan for the future regarding this project.
+
+## Dept of Non Chat Clients 🎛️
+
+### Feline Matrix Assistant ([website](https://github.com/FSG-Cat/Cats-PS-Collection/releases/tag/FMA_v1.0))
+
+[Cat](https://matrix.to/#/@cat:feline.support) says
+
+> Announcing [Feline Matrix Assistant](https://github.com/FSG-Cat/Cats-PS-Collection/releases/tag/FMA_v1.0). This is a PowerShell 7 cross platform script that aims to gather a few somewhat common matrix tasks in one place with a somewhat user friendly interface. 
+> 
+> It was designed to enable users on Windows to easily access things like custom powerlevel rooms and manual room upgrades that normally require using Linux to run bash scripts if one does not want to figure out how to make the web requests using their preferred method themselves. 
+> 
+> One of the other reasons i made this is just because i wanted to get more familiar the CS API and because i needed it my self because im currently a Windows user.
+
+### Third Room ([website](https://thirdroom.io))
+
+[Matthew](https://matrix.to/#/@matthew:matrix.org) reports
+
+> The Third Room team have been invited to present Third Room at SIGGRAPH Asia 2022 next week! https://sa2022.siggraph.org/en/presentation/?id=realcur_102&sess=sess143
+
+## Dept of SDKs and Frameworks 🧰
+
+### Yet Another TypeScript Bot SDK
+
+As named per the author, don't blame Thib for this name!
+
+[prefix](https://matrix.to/#/@prefix:arcticfoxes.net) reports
+
+> Why? As an alternative to matrix-bot-sdk, this library will be strongly typed with simplicity in mind to make sure there is no overhead to writing the perfect Matrix bot.
+> 
+>  - This library also focuses on having browser support and no dependencies around NodeJS (and least amount of dependencies in general)
+>  - AppService functionality will be shipped in a separate package as an extension of this base package.
+>  - There is plenty of dependency injection for: Logging, how HTTP comms are done, and caching (come ask about the Redis cache layer!)
+> 
+> Come join our Matrix room to help this library grow and give input!
+> 
+> https://github.com/CatEngineer/matrix
+
+### Trixnity ([website](https://gitlab.com/trixnity/trixnity))
+
+Multiplatform Kotlin SDK for Matrix
+
+[Benedict](https://matrix.to/#/@benedict:imbitbu.de) reports
+
+> [Trixnity 3.0.0](https://gitlab.com/trixnity/trixnity/-/releases/v3.0.0) is released. This release contains all changes of the beta versions. We additionally fixed two bugs regarding encrypted edited messages.
+> 
+> I'm currently working on vodozemac integration. For this I implemented [uniffi-kotlin-multiplatform-bindings](https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings) to bridge Rust and Kotlin Multiplatform.
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) says
+
+> The last few weeks of Sliding Sync in the various mobile clients is showing its fruits: [Sliding Sync offline caching and session recovery](https://github.com/matrix-org/matrix-rust-sdk/pull/1193) was merged this week, giving you the latest state of your sliding sync in milliseconds without ever having touched the network now. You need to activate it via a setting on the SlidingSyncBuilder - FFI is exposed as well. This PR also adds recovery when the server rejected our request upon a failing position, indicating our session was reset. Previously, you needed to reconstruct the entire sliding-sync with all its state yourself, now this does it internally and transparently for the API user. Additionally, we merged [a fix for invited rooms](https://github.com/matrix-org/matrix-rust-sdk/pull/1249), which caused a panic on FFI usage, and have one other [fix to the sliding-sync state post cache coming up](https://github.com/matrix-org/matrix-rust-sdk/pull/1248).
+> 
+> Talking about fixes, the retry code path had a bug, which caused retries even when the API clearly stated we needed to change request, which [is fixed now](https://github.com/matrix-org/matrix-rust-sdk/pull/1237), and the [memory store won't continue to keep all media cached anymore](https://github.com/matrix-org/matrix-rust-sdk/pull/1247). More fixes are being pulled out of the demo branch and coming up as PRs next week.
+> 
+> We can also report amazing news from the Async-UniFFI-front: we have the first async-uniffi-swift code running now. Exciting times!
+> 
+> 
+> 👉 ️ Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+## Dept of Ops 🛠
+
+### Synapse Operator for Kubernetes ([website](https://github.com/opdev/synapse-operator))
+
+[mgoerens](https://matrix.to/#/@mgoerens:matrix.org) announces
+
+> Introducing a new way to run Synapse on top of Kubernetes ! 
+> 
+> The current capabilities of the Synapse Operator:
+> * Deploy Synapse: the operator can generate a default homeserver.yaml, or it can work with a custom homeserver.yaml, provided by the user.
+> * Deploy the Heisenbridge and the mautrix-signal bridge: the operator automatically (re)configures Synapse to add the corresponding app_services.
+> * Deploy a PostgreSQL database for Synapse (depends on the postgres-operator).
+> 
+> Once the operator is deployed, the `Synapse` resource becomes available. Deploying a basic instance goes as simple as:
+> 
+> ```shell
+> $ cat << EOF > synapse.yaml
+> apiVersion: synapse.opdev.io/v1alpha1
+> kind: Synapse
+> metadata:
+>   name: my-synapse
+> spec:
+>   homeserver:
+>     values:
+>       serverName: example.com
+>       reportStats: true
+> EOF
+> $ kubectl apply -f synapse.yaml 
+> synapse.synapse.opdev.io/my-synapse created
+> $ kubectl get pods
+> NAME                          READY   STATUS    RESTARTS   AGE
+> my-synapse-84d56d54df-c699k   1/1     Running   0          63s
+> ```
+> 
+> The operator takes care of the deployment and lifecycle management of the Synapse instance. Similarly, the `Heisenbridge` and `MautrixSignal` resources can also be deployed alongside Synapse and are managed by the operator.
+> 
+> This [operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) is written in Go. To know more about the project, please visit https://github.com/opdev/synapse-operator, there are explanations on how to deploy the operator, and examples demonstrating the main features. Or ping me on Matrix if you want to have a chat about it ! I'd love to collect some feedbacks !
+
+## Dept of Events and Talks 🗣️
+
+### Matrix FOSDEM Devroom
+
+[Thib](https://matrix.to/#/@thib:ergaster.org) announces
+
+> The clock is ticking! We're already in December, only a few days left to submit your talk proposal for our in-person Matrix devroom at FOSDEM. All the details to answer the call are [in our FOSDEM 2023 CfP](https://matrix.org/blog/2022/11/16/call-for-participation-for-the-fosdem-2023-matrix-devroom)
+
+### Matrix User Meetup Berlin
+
+[saces](https://matrix.to/#/@saces:c-base.org) announces
+
+> Next Matrix user meetup 7.12.2022, 8 pm @ c-base
+> 
+> Meet other matrix users, chat about Matrix, the rest, and everything else, discuss your Matrix ideas, sign each other in persona, and maybe spice the evening with a good mate or beer.
+> 
+> Every first Wednesday of the month in the c-base at 8pm ('til the next pandemic).
+> 
+> Matrix room: [#mumb:c-base.org](https://matrix.to/#/#mumb:c-base.org)
+
+[jaller94](https://matrix.to/#/@jaller94:matrix.org) reports
+
+### Matrix Community Summit Berlin 2022 Podcast (English episode)
+
+> Meet Charles (cvwright), Project creator and Lead engineer of Circles. He and I spoke about how he got to know about Matrix, how encryption became more common on the Internet and how he started Circles – an app, built with Matrix, to privately connect with family and friends.
+> 
+> Same [website](https://anchor.fm/matrix-podcast0) and [RSS feed](https://anchor.fm/s/cdb34188/podcast/rss) as last week.
+> 
+> Mastodon toot: https://mastodontech.de/@jaller94/109445133197729074
+> 
+> I hope you enjoy this week's interview and learn what other people in the community are up to.
+> From next week on we're back to episodes in German – but another English episode is on its way!
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|wcore.org|403|
+|2|veri.dev|483|
+|3|ruiter.me|523|
+|4|nognu.de|664|
+|5|willian.wang|676.5|
+|6|kittenface.studio|833|
+|7|coolegrane.farm|1053.5|
+|8|trygve.me|1067|
+|9|justinruiter.nl|1191.5|
+|10|rom4nik.pl|1291|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|dendrite.matrix.org|217|
+|2|kumma.juttu.asia|234|
+|3|wcore.org|238|
+|4|willian.wang|310|
+|5|forlorn.day|687|
+|6|matrix.milkte.ch|1346|
+|7|frai.se|11439|
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/12/2022-12-07-synapse-1-73-released.md
+++ b/content/blog/2022/12/2022-12-07-synapse-1-73-released.md
@@ -1,0 +1,72 @@
++++
+title = "Synapse 1.73 released"
+path = "/blog/2022/12/07/synapse-1-73-released"
+
+[taxonomies]
+author = ["Mathieu Velten"]
+category = ["Releases"]
++++
+
+And here is another update to your beloved Matrix homeserver implementation, [Synapse
+1.73](https://github.com/matrix-org/synapse/releases/tag/v1.73.0).
+
+## Announcements
+
+### Legacy Prometheus metric names removed
+
+When releasing [Synapse 1.69](https://matrix.org/blog/2022/10/17/synapse-1-69-released#upcoming-removal-of-deprecated-prometheus-metric-names)
+a couple of months ago, we also announced the removal of old Prometheus metrics that have been replaced by more aptly named ones. 
+he list of these metrics can be found [here](https://matrix-org.github.io/synapse/v1.73/metrics-howto.html#renaming-of-metrics--deprecation-of-old-names-in-12).
+
+Synapse 1.73 implements the final phase of this plan and entirely removes support for those metrics. As a result,
+the `enable_legacy_metrics` configuration option, which was introduced in
+[Synapse 1.71](https://matrix.org/blog/2022/11/22/synapse-1-72-released#announcements), has also been removed.
+
+Server administrators who are still relying on these legacy metric names are encouraged to update their dashboards at their earliest convenience.
+For more information, please refer to the [upgrade notes](https://matrix-org.github.io/synapse/v1.73/upgrade#legacy-prometheus-metric-names-have-now-been-removed).
+
+## The new stuff
+
+### Performance
+
+A bunch of performance improvements have been included in this release, specifically around
+the [`/messages`](https://spec.matrix.org/v1.5/client-server-api/#get_matrixclientv3roomsroomidmessages) endpoint.
+
+[Improvements to event filtering on the client-server API](https://github.com/matrix-org/synapse/pull/14527) gave the matrix.org homeserver a first nice bump as visible on this graph:
+
+![](/blog/img/2022-12-07-apdex-filter-events-improvement.png)
+
+Various optimizations around [fetching](https://github.com/matrix-org/synapse/pull/14491) [bundled](https://github.com/matrix-org/synapse/pull/14508)
+[aggregations](https://github.com/matrix-org/synapse/pull/14510) resulted in yet another nice improvement:
+
+[![](/blog/img/2022-12-07-bundled-aggregations-improvement.png)](/blog/img/2022-12-07-bundled-aggregations-improvement.png)
+
+Note that the graph from the first image, and the second graph from the second image are [apdexes](https://en.wikipedia.org/wiki/Apdex), which
+is a measure that shows improvement when it goes up (as opposed to e.g. response times, which improve
+when they go down).
+
+### Extensible Events experimental support
+
+Experimental support for Extensible Events has landed in Synapse.
+
+This is exciting since this global rework of events presentation has been in talks
+[for a while](https://github.com/matrix-org/matrix-spec-proposals/pull/1767), and
+having an implementation to experiment with greatly helps bringing the feature
+closer to completion.
+
+Note that this support is still very much experimental as the related MSCs are still
+under review and could change at any time, and therefore not recommended for use
+in production.
+
+## Everything else
+
+See the full [changelog](https://github.com/matrix-org/synapse/releases/tag/v1.73.0), for a
+complete list of changes in the release. Also please have a look at the [upgrade
+notes](https://matrix-org.github.io/synapse/v1.73/upgrade#upgrading-to-v1730) for this version.
+
+Synapse is a Free and Open Source Software project, and we'd like to extend our
+thanks to everyone who contributed to this release, including (in no particular
+order) [schmop](https://github.com/schmop), [Ashish Kumar](https://github.com/ashfame),
+[realtyem](https://github.com/realtyem), and [Brennan Chapman](https://github.com/chapb)
+as well as anyone helping us make Synapse better by sharing their feedback and reporting issues.
+

--- a/content/blog/2022/12/2022-12-09-this-week-in-matrix-2022-12-09.md
+++ b/content/blog/2022/12/2022-12-09-this-week-in-matrix-2022-12-09.md
@@ -1,0 +1,320 @@
++++
+title = "This Week in Matrix 2022-12-09"
+date = "2022-12-09T18:51:53Z"
+path = "/blog/2022/12/09/this-week-in-matrix-2022-12-09"
+
+[taxonomies]
+author = ["Thib"]
+category = ["This Week in Matrix"]
+
+[extra]
+image = "https://matrix.org/blog/img/hEFvBRgPRswjuSDiKEItPSTB.png"
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/RNnOHcMLscw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Dept of Spec 📜
+
+[Andrew Morgan (anoa)](https://matrix.to/#/@andrewm:element.io) says
+
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> 
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3945: Private device names](https://github.com/matrix-org/matrix-spec-proposals/pull/3945)
+> * [MSC3944: Dropping stale send-to-device messages](https://github.com/matrix-org/matrix-spec-proposals/pull/3944)
+> 
+> **MSCs in Final Comment Period:**
+> * *No MSCs are in FCP.*
+> 
+> **Accepted MSCs:**
+> * *No MSCs were merged this week.*
+> 
+> ## Spec Updates
+> 
+> Both new MSCs this week are from [@uhoreg](https://github.com/uhoreg/), and look pretty great from a spec polish perspective (I've been a fan with doing away of public device names for ages). Check them out!
+> 
+> Otherwise, [MSC3898](https://github.com/matrix-org/matrix-spec-proposals/pull/3898) (Native Matrix VoIP signalling) received some review and attention this week.
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC3391: API to delete account data](https://github.com/matrix-org/matrix-spec-proposals/pull/3391)!
+> 
+> This MSC would allow users to actually delete account data they've set 🎉 Currently you cannot delete top-level keys from your account data, only remove their content.
+> 
+> Deleted account data items will come down `/sync` as having their content updated to `{}`, which clients that implement MSC3391 will take to mean that the account data item has been deleted. Clients that don't implement MSC3391 will store the content as `{}`, which commonly means an unused account data item anyhow. 
+> 
+> Yours truly is currently writing an implementation for this in Synapse, and so far implementing the spec as written seems sound!
+> 
+> ![](/blog/img/5f26aac76fd96a868b2b78d881e1ce1b419ef477.png)
+
+## Dept of Servers 🏢
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[Shay](https://matrix.to/#/@shayshay:matrix.org) announces
+
+> It's Friday which means it's time to talk about the newest Synapse release, v1.73.0! A few details:
+> 
+> Please note that this version removes legacy Prometheus metric names entirely. This also means that the `enable_legacy_metrics` configuration option has been removed; it will no longer be possible to re-enable the legacy metric names.
+> 
+> If you use metrics and have not yet updated your Grafana dashboard(s), Prometheus console(s) or alerting rule(s), please consider doing so when upgrading to this version.
+> 
+> In addition, a few notable features and bugfixes are:
+> 
+> * Move MSC3030 `/timestamp_to_event` endpoints to stable `v1` location (`/_matrix/client/v1/rooms/<roomID>/timestamp_to_event?ts=<timestamp>&dir=<direction>`, `/_matrix/federation/v1/timestamp_to_event/<roomID>?ts=<timestamp>&dir=<direction>`).
+> * Reduce database load of Client-Server endpoints which return bundled aggregations.
+> * Fix a long-standing bug where paginating from the start of a room did not work. Contributed by @gnunicorn.
+> * Fix a bug introduced in Synapse 0.9 where Synapse would fail to fetch server keys whose IDs contain a forward slash
+> 
+> plus much more! You can read more about this release here: https://matrix.org/blog/posts.
+
+## Dept of Bridges 🌉
+
+### Valheim Matrix Bridge
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) announces
+
+> So... some people are distracting me by asking me to play Valheim all the time since Mistlands was in public beta (it is released now). To make that easier to synchronize, especially if not everyone can be online all the time, I wrote a small bridge: https://nheko.im/nheko-reborn/valheimmatrix
+> 
+> Your own messages are
+> bridged from Valheim to Matrix, while other peoples messages are bridged
+> (privately) from Matrix to Valheim. This prevents loops and does nice puppeting,
+> but it means everyone needs to run their own bridge. It also means you can see
+> other peoples messages on Matrix, as long as they have the mod enabled, even if
+> you are not signed in yourself.
+> 
+> It is a very hacky experiment, but it works, so... why not show it off? Definitely check out the game, it is great!
+> 
+> ![](/blog/img/FWlHsqdTxwPxGZHHijFblBWI.png)
+
+### Gitter
+
+[madlittlemods (Eric Eastwood)](https://matrix.to/#/@madlittlemods:matrix.org) announces
+
+> It's been a tiny while since I've given an update on the Gitter bridge because I've been focusing on other [feature parity](https://github.com/vector-im/roadmap/issues/26) areas like the [Matrix Public Archive](https://github.com/matrix-org/matrix-public-archive) and [speeding up `/messages` in Synapse](https://github.com/matrix-org/synapse/issues/13356) but there have been a number of changes over this time 🔢
+> 
+> The first big exciting thing is that [Gitter now bridges threaded conversations as native threads on Matrix](https://gitlab.com/gitterHQ/webapp/-/merge_requests/2309) (no more impedance mismatch)!
+> 
+> ![](/blog/img/bxtVGAtpdvMnLgJZGcabRgza.png)
+> 
+> We've also been plugging along on less visible changes during this time like bug-fixes for bridging DM's and fleshing out more of the bridge scenarios like [leaving](https://gitlab.com/gitterHQ/webapp/-/merge_requests/2200) or [deleting a room](https://gitlab.com/gitterHQ/webapp/-/merge_requests/2265) and [bans](https://gitlab.com/gitterHQ/webapp/-/merge_requests/2257) to ensure things stay in sync. We also started [bridging private conversations](https://gitlab.com/gitterHQ/webapp/-/blob/develop/CHANGELOG.md#21460-2022-02-01-bridge-private-rooms-to-matrix) to Matrix behind the scenes back in February so we have a break-away point-in-time to import back from when we do the massive history import to backfill everything. Please note, that you still can't access these private rooms on Matrix but this will come later either in the form of [inviting MXID's from the Gitter side](https://gitlab.com/gitterHQ/webapp/-/issues/2819) or when we give access to the `gitter.im` homeserver itself to self-manage from that side.
+
+## Dept of Clients 📱
+
+### Nheko ([website](https://nheko-reborn.github.io))
+
+Desktop client for Matrix using Qt and C++17.
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) says
+
+> Apart from playing Valheim, I at least also did some productive things! (Apart from everyone else who has been helping squashing bugs and jugendhackt of course.)
+> 
+> Nheko now supports MSC3664. Support for this is automatically enabled if it is enabled server side. This allows you to get notifications for events that relate to another event. For example you might want to get notifications for a reply to one of your messages. So you need to check if the replied to event was sent by you. Similar things can be done for relations like "notify me for reactions to my posts in rooms with less than 20 users".
+> 
+> By default only notifications for replies are enabled. You might not notice a difference, since by default you get notified for them because the fallback includes your username, but not all bridges implement that correctly and for me the reply fallback has been one of the biggest sources of bugs, so I'd like to get rid of it long term. (Also some users disable username mentions, because their name is too generic to be useful, in which case this can help as well since it actually checks the sender.)
+> 
+> Anyway, have fun playing around with this!
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[kittykat](https://matrix.to/#/@kittykat:matrix.org) announces
+
+> ## Element Web/Desktop
+> 
+> Lots of exciting news this week
+> 
+> * matrix-js-sdk now has full strict TypeScript checking turned on!
+> * We fixed lots of bugs, including replies to emotes looking weird
+> * There are also some updates in the works, including bubble layout improvements and the user profile in the right-panel.
+> * We made the unverified sessions dialog come up less often, and added a setting to prevent bold notifications.
+> 
+> And in case that wasn’t enough… now available in labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> 
+> * We merged several fixes for voice broadcasts
+> * Threads is nearing release, thank you all who have been trying it out! You can still join the Beta testing in Settings -> Labs to give it a spin!
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Ștefan](https://matrix.to/#/@stefan.ceriu:matrix.org) reports
+
+> * Threads has made great progress and is nearly ready for release into the wild! There’s a few bugs remaining that we want to smash before we turn the feature on by default for all users. 
+> * Work on Element X is making great progress, we’re even looking at how to improve the iPad and desktop view for users on larger screens.
+> 
+> ![](/blog/img/hEFvBRgPRswjuSDiKEItPSTB.png)
+> ![](/blog/img/ZbSCKoJjDbUSaEVvKFmlgwsH.png)
+
+<iframe src="https://www.youtube.com/embed/73KkfPvgClk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[benoit](https://matrix.to/#/@benoit.marty:matrix.org) announces
+
+> * Element Android 1.5.11 has been released, it includes fixes for some crashes that had been reported via rageshake.
+> * Threads has made great progress and is nearly ready for release into the wild! There’s a few bugs remaining that we want to smash before we turn the feature on by default for all users. 
+> * Please note the release cycle will be slightly different over the holidays!
+> * Work has begun on Android X and fast progress is being made.
+>     * Currently we’re looking at performance on the room list and the timeline view, implementing a memory cache to handle things more efficiently.
+
+### Element ([website](https://element.io))
+
+Everything related to Element but not strictly bound to a client
+
+[kittykat](https://matrix.to/#/@kittykat:matrix.org) says
+
+> We are skipping one release cycle over the festive holidays: all apps will receive a release on 20th December (with threads coming out of Beta!) and the following RC will come out on 10th January leading up to a release on 17th January!
+
+## Dept of Non Chat Clients 🎛️
+
+### Effektio ([website](https://effektio.org))
+
+The one mobile-first, decentralized community organizing app
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) reports
+
+> Earlier this week, [we have release](https://effektio.org/2022/12/06/blockchain-is-dead-long-life-web5-the-effektio-white-paper/) the [EFFEKTIO white paper](https://effektio.org/whitepaper), outlining what we are working on, why we think this matters, where we intend to head with it and what perspective we come from. We’ve published this 30-pager as a Google Doc with comments activated (if you have any feedback on it) as well as with a 2-page executive summary for the busy. You can also join us in [#foyer:effektio.org](https://matrix.to/#/#foyer:effektio.org) if you’d like to discuss it with us.
+> 
+> For a couple of weeks now, we have a fresh [nightly build](https://effektio.org/nightly-build) available whenever changes have been merged within the 24 hours prior. Unfortunately the Android package, with mobile being the main target the UI has been developed for, can’t be installed as is (you need to clone and build it yourself for now), the Desktop App for Linux, Windows and Mac do give you an impression what we are after. Mind you that a) other than the chat all sections are still mainly UI mocked and b) it is still in heavy development: things break sometimes.
+> 
+> On the app itself, we have spent a lot of time on getting the chat right. The app’s core was upgraded to matrix-sdk 0.6+ to get the latest timeline API in, which required quite some refactoring. But allowed us to implement reactions, edits and replies. Encrypted Messages are still somewhat unreliable though. Prior to the nightly builds we’ve also taken some time to clean up the UI to give it a more polished look and make clear which things are simply not enabled yet. On the non-chat side of things, we’ve mostly worked on UI things (check out the ToDo-Sections and Pins), while we were waiting for the [synapse fix on reading the timeline from the beginning](https://github.com/matrix-org/synapse/pull/14149), which is now released in 1.73. Happy to get back to implementing the state machines soon.
+> 
+> You want updates more frequently and close to when they actually happen? Join our [#news:effektio.org](https://matrix.to/#/#news:effektio.org) or hang out with the devs in our [#tech:effektio.org](https://matrix.to/#/#tech:effektio.org) matrix room.
+
+## Dept of SDKs and Frameworks 🧰
+
+### libolm
+
+[uhoreg](https://matrix.to/#/@hubert:uhoreg.ca) reports
+
+> libolm 3.2.14 has been released. This is maintenance release. The main change was improvements in the TypeScript types. There were also some improvements in the Python packaging, which should mean that the pre-built Python package for Linux is compatible with more distributions. Unfortunately, there are some issues with the i686 and aarch64 Linux builds, meaning that those packages are not currently available for the current version. However, if the previous version works for you, there is no reason to upgrade. We are investigating the issue, and may provide new packages later.
+
+### elm-matrix-webhooks
+
+[Bram](https://matrix.to/#/@bram:noordstar.me) says
+
+> If you write code in Elm, you can now send messages in a Matrix room using a webhook.
+> 
+> I built [noordstar/elm-matrix-webhooks](https://package.elm-lang.org/packages/noordstar/elm-matrix-webhooks/latest/), a small wrapper around the Webhook API of [nim65s/matrix-webhook](https://github.com/nim65s/matrix-webhook).
+> 
+> I am building an Matrix SDK in Elm but I've never created or published a library before. This is a practice library to see what I can expect. You can install the library using
+> 
+> ```sh
+> elm install noordstar/elm-matrix-webhooks
+> ```
+> 
+> And you can send a webhook message using a function like this:
+> 
+> ```elm
+> import Matrix.Webhooks as Hook
+> 
+> send : String -> Cmd msg
+> send = Hook.sendMessage toMsg webhook
+> 
+> -- send "Hi TWIM!"
+> -- send "I support **Markdown!**"
+> -- send "That's cool, isn't it?"
+> ```
+> 
+> There is currently no room for this library. Just contact me @bram:noordstar.me for the library or visit [#matrix-webhook:tetaneutral.net](https://matrix.to/#/#matrix-webhook:tetaneutral.net) for questions about the Webhook API.
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) reports
+
+> After porting the remaining fixes over from the [demo branch for element-x as PRs to `main`](https://github.com/matrix-org/matrix-rust-sdk/pull/1255), we've spent a significant time debugging the two biggest know pain points: double echos for sending messages, [for which we've merged a fix](https://github.com/matrix-org/matrix-rust-sdk/pull/1260), and unable to decrypt, which appears to be caused by a broken to-device message exchange (with an incomplete `sender_key`), which we are still investigating. Furthermore we've exposed the ability to [send reactions over FFI](https://github.com/matrix-org/matrix-rust-sdk/pull/1257), [`LoginBuilder` and `SsoLoginBuilder` can now be used with `.await`](https://github.com/matrix-org/matrix-rust-sdk/pull/1261) and merged [some smaller sled crypto store improvements](https://github.com/matrix-org/matrix-rust-sdk/pull/1259).
+> 
+> The latter came up when investigating, whether we could use [sanakirja](https://docs.rs/sanakirja/latest/sanakirja/), the [pijul](https://pijul.org/) database backend, as a multi-process crypto store backend for mobile. This investigation is still on-going.
+> 
+> Further than an investigation is the [uniffi async support](https://github.com/mozilla/uniffi-rs/pull/1409). After completing the Python backend, Swift is also passing all tests now. Additional Docs should clarify most questions. We are as excited about this as the [Mozillians](https://github.com/mozilla/uniffi-rs/pull/1409#issuecomment-1331959797) seem to be. Next up: Kotlin backend.
+> 
+> 
+>  👉 Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+## Dept of Bots 🤖
+
+### ChatGPT for Matrix
+
+[Jake C](https://matrix.to/#/@jake:jakecopp.chat) announces
+
+> I built a ChatGPT bot for Matrix! It does exactly what you think it does: you send a message, and ChatGPT will respond. It's very cool being able to talk to ChatGPT while on a mobile device.
+> 
+> It sends read receipts when messages are received by the bot, and the bot sends a typing indicator as ChatGPT is "thinking" 😀
+> 
+> It currently only works in unencrypted chats. I haven't managed to get encryption using `matrix-bot-sdk` working reliably yet. If it's meant to be working, tips or PRs are very welcome! I've really enjoyed tinkering with`matrix-bot-sdk` on a few projects so far.
+> 
+> Keep in mind any text you send it will go to the closed source servers of OpenAI, and it is unlikely to stay free forever.
+> 
+> PRs very welcome!
+> 
+> https://github.com/jakecoppinger/matrix-chatgpt-bot
+> 
+> ![](/blog/img/WiMdUdgZysfvtOtmUgtVRRlO.png)
+
+## Dept of Events and Talks 🗣️
+
+[Thib](https://matrix.to/#/@thib:ergaster.org) reports
+
+> The Matrix.org Foundation has a stand at FOSDEM! Come in Brussels on February 4 and 5 to meet us in person, see the fun stuff we're doing, show us the nice things _you_ are doing and grab cool merch.
+> 
+> We have also received proposals for a little more than a full day of devroom! We only have half a day of in-person devroom. We will (try to?) broadcast the in-person devroom in the Matrix room _of course_, and then the conference bot will schedule the talks we couldn't fit in the in-person slots.
+
+[Yan](https://matrix.to/#/@yan:datanauten.de) says
+
+> Matrix Community Summit Berlin 2022 Podcast (German)
+> Another week, another episode, another community member interviewed.
+> Meet Robert, who spoke with Christian, about creating a CMS system on top of matrix.
+> 
+> episode link: https://spotifyanchor-web.app.link/e/p8aiO8ABCvb
+> rss feed: https://anchor.fm/s/cdb34188/podcast/rss
+> I hope you enjoy this week's interview and learn what other people in the community are up to.
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|nognu.de|594|
+|2|keks.club|596.5|
+|3|cezeri.tech|840|
+|4|trygve.me|912|
+|5|kittenface.studio|916|
+|6|babel1.eu|1026.5|
+|7|willian.wang|1084|
+|8|btln.de|1878|
+|9|mailstation.de|2662|
+|10|poldrack.dev|2762|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|kumma.juttu.asia|284|
+|2|dendrite.s3cr3t.me|343|
+|3|willian.wang|481.5|
+|4|frai.se|646|
+|5|matrix.shutdown.network|986|
+|6|rustybever.be|3051|
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/12/2022-12-16-this-week-in-matrix-2022-12-16.md
+++ b/content/blog/2022/12/2022-12-16-this-week-in-matrix-2022-12-16.md
@@ -1,0 +1,329 @@
++++
+title = "This Week in Matrix 2022-12-16"
+date = "2022-12-16T19:51:14Z"
+path = "/blog/2022/12/16/this-week-in-matrix-2022-12-16"
+
+[taxonomies]
+author = ["uhoreg"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+<iframe src="https://www.youtube.com/embed/LvLEufkXK94" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
+## Dept of *Status of Matrix* 🌡️
+
+[Matthew](https://matrix.to/#/@matthew:matrix.org) announces
+
+> BwMessenger (the German Armed Forces' branded version of Element) is expanding to cover the whole of Germany, as BundesMessenger: https://element.io/blog/bundesmessenger-is-a-milestone-in-germanys-ground-breaking-vision.  Super exciting to see Matrix spreading throughout the German public sector (as well as Sweden! https://element.io/blog/dsam-och-esam-forordar-matrix-for-saker-och-federerad-kommunikation-inom-sveriges-offentliga-sektor/)
+
+[Kim Brose](https://matrix.to/#/@kim.brose.nordeck:matrix.org) adds
+
+> homepage: https://messenger.bwi.de/bundesmessenger, sourcecode: https://gitlab.opencode.de/bwi/bundesmessenger/
+
+## Dept of Spec 📜
+
+[TravisR](https://matrix.to/#/@travis:t2l.io) announces
+
+> # The Spec
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> 
+> ## MSC Status
+> 
+> **New MSCs:**
+> * [MSC3949: Power Level Tags](https://github.com/matrix-org/matrix-spec-proposals/pull/3949)
+> * [MSC3948: Repository room for Thirdroom](https://github.com/matrix-org/matrix-spec-proposals/pull/3948)
+> * [MSC3947: Allow Clients to Request Searching the User Directory Constrained to Only Homeserver-Local Users](https://github.com/matrix-org/matrix-spec-proposals/pull/3947)
+> 
+> **MSCs in Final Comment Period:**
+> * [MSC3706: Extensions to `/_matrix/federation/v2/send_join/{roomId}/{eventId}` for partial state](https://github.com/matrix-org/matrix-spec-proposals/pull/3706) (merge)
+> 
+> **Accepted MSCs:**
+> * *No MSCs were accepted this week.*
+> 
+> **Closed MSCs:**
+> * [MSC3265: Login and SSSS with a Single Password](https://github.com/matrix-org/matrix-spec-proposals/pull/3265)
+> 
+> ## Spec Updates
+> 
+> 
+> With the year wrapping up, the Spec Core Team has been looking at getting some of the outstanding MSCs landed and ready for spec writing, as well as writing more spec itself. There's also plenty of work behind the scenes on Extensible Events: a mission to redefine how events work within the Matrix ecosystem. Check out [MSC1767](https://github.com/matrix-org/matrix-spec-proposals/pull/1767) and friends for an overview of what this actually entails.
+> 
+> 
+> ## SCT Holiday
+> 
+> We're coming up to some holiday time for the SCT: the spec progress might naturally slow as we all close our laptops, but we'll be back in our full capacity in the new year, working out the next version of Matrix in time for FOSDEM (hopefully) :)
+> 
+> ![](/blog/img/a01611e112862790d5a6243849df060e04a2bb2a.png)
+
+## Dept of Servers 🏢
+
+
+
+### Telodendria ([website](https://telodendria.io))
+
+An open source Matrix homeserver implementation written from scratch in ANSI C and designed to be lightweight and simple, yet functional
+
+[Jordan Bancino](https://matrix.to/#/@jordan:bancino.net) reports
+
+> # [Telodendria](https://telodendria.io)
+> 
+> **Telodendria** `v0.1.0` was released earlier this week. This is the very first tagged release, and it is a mostly symbolic release intended to signal that most of the elementary components necessary to construct a Matrix homeserver are now in place, and I'm ready to actually start implementing Matrix API endpoints. In fact, I've already started on the user-interactive authentication API and the registration endpoints, and am making good progress on them.
+> 
+> As always, I could use your help. If you like what's happening, then feel free to spread awareness about the project, come say hi in the [Matrix rooms](https://telodendria.io/man/man7/telodendria.7.html), or [send a donation](https://telodendria.io/#donate). Again, [#telodendria-newsletter:bancino.net](https://matrix.to/#/#telodendria-newsletter:bancino.net) has the latest, and now that I'm actually versioning the project, you might be interested in [#telodendria-releases:bancino.net](https://matrix.to/#/#telodendria-releases:bancino.net), which is a low-traffic room that simply notifies of new releases.
+
+### Synapse ([website](https://github.com/matrix-org/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the matrix.org core team
+
+[Shay](https://matrix.to/#/@shayshay:matrix.org) says
+
+> # Synapse
+> 
+> How is it Friday already (and the end of the year)?? While the holidays are almost upon us, the
+> team behind Synapse has been hard at work and has released v1.74.0rc1 for your consideration.
+> Some notable features and bugfixes include:
+> 
+> * Improved user search for international display names
+> * The addition of a new `push.enabled` config option to allow opting out of push notification calculation
+> * Fixes for a long-standing bug where a device list update might not be sent to clients in certain circumstances
+> * The addition of Single-Sign On setup instructions for Mastodon-based instances
+> 
+> and much, much more! You can take a look here: https://github.com/matrix-org/synapse/releases. 
+> A note about the end of the year: With the holiday season coming up we plan to release Synapse v1.74.0 as normal next Tuesday, December 20th, 2022 and then skip releases for the next two weeks, before resuming with v1.75.0rc1 on Tuesday, January 10th, 2023.
+
+## Dept of Bridges 🌉
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) reports
+
+> # Valheim Matrix Bridge
+> 
+> The bridge now avoids double bridging even with multiple users running the bridge client side. It also prevents historical messages from showing up in Valheim, so that starting the game is less confusing. Last but not least, red_sky (nheko.im) ported the user color algorithm from Nheko, so the colors should now look more familiar instead of being a generic blue.
+> ![](/blog/img/vAjNeYupaMZuYacGpGbXSHDj.png)
+
+## Dept of Clients 📱
+
+
+
+### Nheko ([website](https://nheko-reborn.github.io))
+
+Desktop client for Matrix using Qt and C++17.
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) reports
+
+> # Nheko
+> 
+> Nheko now prompts you to join the upgraded room, deletes image files you haven't accessed in a month (which freed over 1GB of data on my system) and tries to focus the chat, when you start typing.
+> 
+> LorenDB also added support for confetti messages, although those seem to work only on systems, that are not mine! You can of course turn them off in the settings. :D
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[andybalaam](https://matrix.to/#/@andybalaam:matrix.org) announces
+
+> ## Element Web/Desktop
+> 
+> We have been working really hard on the 20th December release (with threads on by default!  🎉 🧵 🎉) this week:
+> 
+> * We did lots of work on threads, and we're ready to turn it on by default!
+> * All our code is now automatically formatted with prettier.
+> * We made small fixes and improvements to voice broadcasts and device manager.
+> * We are making progress on automating the Element Desktop release process.
+> * We are investigating performance improvements in matrix-js-sdk.
+> 
+> And if you love to live on the edge, in labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> 
+> * The rich text editor can now create inline code.
+> * Soon, we will have a Favourite Messages screen!
+> 
+> We will skip one release cycle while team members are on holiday, so after 20th December, the next release will be 17th January 2023.
+> ![](/blog/img/oRLPwZHxYkQDsAAkxGTXoVZr.png)
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Ștefan](https://matrix.to/#/@stefan.ceriu:matrix.org) says
+
+> Element iOS
+> * What’s this then? The last release of Element in 2022, that’s what! And to round out the year, we’re enabling Threads for everyone in the release planned for the 20th of December!
+>   * Threads: Enabled by default for everyone. Please let us know if you discover any issues as we get ready to make them permanently enabled.
+>   * Notifications: The Spaces button now shows a badge to indicate the number of unread conversations in other spaces so you won’t miss those important messages or invites anymore.
+> * Things are quickly moving along on the ElementX side too
+>   * the new split iPad and macOS layout has been merged
+>   * the timeline has been refactored and scrolling is now smoother than ever
+>   * we have brought our code coverage to 45% and actively working on making it even better
+>   * and we’re also working on improved room list loading, a new room details screen and improving the developer experience and reliability
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[benoit](https://matrix.to/#/@benoit.marty:matrix.org) announces
+
+> # Element Android
+> * Element Android 1.5.12 is currently being released on the stores. It includes threads support, enabled by default.
+> * We are currently working on finalising the session management screens, and we are fixing issues in polls. The composer is also getting some improvements, like support for links, code blocks, quotes, etc.
+> * On ElementX, we are working to setup the project: dependency injection, continuous integration, and other similar tasks.
+
+## Dept of Non Chat Clients 🎛️
+
+[imbev](https://matrix.to/#/@imbev:matrix.org) says
+
+> ## matrix-social
+> 
+> matrix-social is a new Matrix "Social Media" client made using the Matrix Rust SDK and Yew. With a design inspired by Reddit, matrix-social's purpose is to be a social media client that integrates well with the rest of the Matrix ecosystem. At the moment, it is very early in development, and lacks crucial features such as sending messages, comments, reactions, and categories.
+> 
+> The source code is licensed AGPL and hosted at https://codeberg.org/imbev/matrix-social
+> 
+> If you have experience with Rust, WASM, or are otherwise interested, join us in https://matrix.to/#/#matrix-social:matrix.org
+
+### Matrix Wrench ([website](https://gitlab.com/jaller94/matrix-wrench/))
+
+Matrix Wrench is a web client to tweak Matrix rooms.
+
+[jaller94](https://matrix.to/#/@jaller94:matrix.org) says
+
+> ## Matrix Wrench v0.9.0 🔧
+> 
+> Source: https://gitlab.com/jaller94/matrix-wrench/
+> 
+> * Added: Password login
+> * Added: Create and mutate users using the Synapse API.
+> * And, together with the team of the [#matrix-berlin:matrix.org](https://matrix.to/#/#matrix-berlin:matrix.org), I've added (hidden URLs so far) pages for people to analyse their Matrix usage (How many of my DM contacts are in a given room? How many homeservers are joined to a given room? Which of my DM contacts do I share the most rooms with?). For a preview or to bring in your ideas, please join us in [#matrix-dashboard:matrix.org](https://matrix.to/#/#matrix-dashboard:matrix.org).
+
+## Dept of Widgets 🧩
+
+[Oliver Sand](https://matrix.to/#/@oliver.sand:matrix.org) announces
+
+> Going towards Christmas we from Nordeck can announce that we made another of our widgets Open Source: [matrix-barcamp](https://github.com/nordeck/matrix-barcamp).
+> 
+> The matrix-barcamp widget allows to perform agile Barcamps in Matrix spaces. You can create a space, add the widget to a Lobby room and use it to collaboratively create your Barcamp agenda.
+> Once you set up your sessions, the widget can take care of creating the individual discussion rooms inside the space.
+> The widget was created in collaboration with the ZIT SH from the German public sector.
+> Like the [matrix-poll](https://github.com/nordeck/matrix-poll) widget, this widget is built using TypeScript, React, our [matrix-widget-toolkit](https://github.com/nordeck/matrix-widget-toolkit), and the matrix-widget-api.
+> Our remaining widgets will follow soon, we keep you updated here.
+> 
+> If you have any questions, reach out to us at [#nordeck:matrix.org](https://matrix.to/#/#nordeck:matrix.org).
+> ![](/blog/img/TlhZEgglOhXJIksEeahSuHVG.png)
+
+## Dept of SDKs and Frameworks 🧰
+
+
+
+### matrix-rust-sdk ([website](https://github.com/matrix-org/matrix-rust-sdk))
+
+Next-gen crypto-included SDK for developing Clients, Bots and Appservices; written in Rust with bindings for Node, Swift and WASM
+
+[ben](https://matrix.to/#/@gnunicorn:matrix.org) announces
+
+> ## [Matrix Rust SDK](https://github.com/matrix-org/matrix-rust-sdk)
+> 
+> With [the last fixes ported over from the demo branch](https://github.com/matrix-org/matrix-rust-sdk/pull/1255) and [the growing-full-sync-window support](https://github.com/matrix-org/matrix-rust-sdk/pull/1270) added, we turned our head back to debugging a few remaining [deserialization](https://github.com/ruma/ruma/pull/1405) and decryption bugs in Sliding Sync when we were hit by a new tokio-thread-panic on Element-X at the end of the week. A quick debugging revealed that it was caused by out of bound indizes supplied by the server. We are still looking into making our code more defensive for these circumstances, too.
+> 
+> Async Uniffi is progressing nicely meanwhile, with now both Swift and Kotlin being able to run and execute a Rust created future. We now have [fallible function support implemented on the proc-frontend](https://github.com/matrix-org/matrix-rust-sdk/pull/1228) and further work is coming up to support `&str` and `&[u8]`.
+> 
+> This week also saw the first experimentation in replacing the default Sled database backend. A first PoC attempt was made with sanakirja (pijul is based on), but after learning that its API is unsound and can lead to UB, the team agreed that this requires quit a bit more work (especially in terms of safety guards) than we have time for in the short term. Thus, offering a sqlite-backend for mobile in the short term at least for the crypto store has been agreed upon.
+> 
+> 
+> 👉️ Wanna hack on matrix rust? Go check out our [`help wanted` tagged issues](https://github.com/matrix-org/matrix-rust-sdk/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) and join our matrix channel at Matrix Rust SDK.
+
+## Dept of Events and Talks 🗣️
+
+[ChristianP](https://matrix.to/#/@christianp:vector.modular.im) reports
+
+> ## Matrix Community Summit Berlin 2022 Podcast (German)
+> 
+> Meet ben, Rust developer and Co-Founder at EFFEKTIO. He and I spoke about Social Organising and how his app tries to enable people to participate more directly in their community, political party or neighbourhood.
+> 
+> Same [website](https://anchor.fm/matrix-podcast0) and [RSS feed](https://anchor.fm/s/cdb34188/podcast/rss) as last week.
+> 
+> Mastodon toot: https://mastodontech.de/@jaller94/109523913828753926
+> 
+> I hope you enjoy this week's interview and learn what other people in the community are up to.
+> Stay tuned for a second English episode in two weeks!
+
+[Thib](https://matrix.to/#/@thib:ergaster.org) announces
+
+> Very good news for FOSDEM: _we managed to make some room for all of the proposals we got!_ We thank everyone participating in our CfP for submitting such high quality proposals. Our in-person devroom is going to be on Sunday 5 morning, between 09:00 and 13:00 CET. It was difficult to make a choice, but we had to put some talks in the virtual devroom only in the afternoon. We will follow-up with speakers individually.
+> 
+> We will also have a stand at FOSDEM, and will be happy to see you there, talk about what we're doing, what's next and just generally have a nice chat together.
+
+[Nik | Klampfradler 🎸🚴🏻](https://matrix.to/#/@nik:matrix.teckids.org) announces
+
+> # Professional Matrix courses at Linuxhotel
+> 
+> From June 19th to 23rd 2023, the, in Germany, well-known Open Source training center [Linuxhotel](https://www.linuxhotel.de/) will be offering two courses on Matrix (in German):
+> 
+> 1. [Matrix: Server operation, usage and federation](https://www.linuxhotel.de/course/matrix-de/)
+> 2. [Matrix: Development and IoT](https://www.linuxhotel.de/course/matrix-dev-de/)
+> 
+> If you want to learn hands-on how to establish Matrix and Element for your company or team, how to operate it, or how to make small IoT components operatable via Matrix – or know someone who wants to know – **and** speak German, don't forget to get seats while they're available 🤓!
+
+## Dept of Interesting Projects 🛰️
+
+[Florian Heese](https://matrix.to/#/@fheese:element.io) reports
+
+> https://forgejo.org/2022-12-15-hello-forgejo/
+> 
+> > Forgejo’s code base is of course hosted on Codeberg, and by using Woodpecker CI instead of Drone and Matrix instead of Discord, we exclusively rely on Free Software tools.
+
+## Dept of Guides 🧭
+
+[Bram](https://matrix.to/#/@bram:noordstar.me) says
+
+> # Introducing the Matrix Events Directory
+> 
+> Are you a client developer working with custom event types in the Matrix ecosystem? It can be tough to keep track of all the different events that are being used, and even harder to interoperate with other developers' clients and bots. That's why I've built the Matrix Events Directory, a website where you can look up and register custom event types. 
+> 
+> Here are just a few ways the Matrix Events Directory can help you:
+> 
+> 1. If you come across an event type that you're not familiar with, you can use the directory to find out more about it and decide if you want to do anything with it.
+> 2. If you're working on implementing a new feature in your client, you can use the directory to see if anyone else has already done it and potentially interoperate with their work.
+> 
+> I hope that the Matrix Events Directory will improve interoperability and make it easier for the community to define and use their own custom events, while still being able to build on top of the Matrix spec. 
+> 
+> Please check out the [repository](https://github.com/BramvdnHeuvel/Matrix-Events-Directory) and the website at https://matrix.directory. Contributions are welcome!
+
+## Dept of Ping
+
+Here we reveal, rank, and applaud the homeservers with the lowest ping, as measured by [pingbot](https://github.com/maubot/echo), a [maubot](https://github.com/maubot/maubot) that you can host on your own server.
+
+### [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net)
+Join [#ping:maunium.net](https://matrix.to/#/#ping:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|keks.club|541.5|
+|2|catvibers.me|662|
+|3|nognu.de|714|
+|4|alemann.dev|741|
+|5|matrix.nicfab.it|788.5|
+|6|willian.wang|851|
+|7|kittenface.studio|894|
+|8|anontier.nl|1175.5|
+|9|grmml.de|1444|
+|10|mailstation.de|2786.5|
+
+### [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net)
+Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium.net) to experience the fun live, and to find out how to add YOUR server to the game.
+
+|Rank|Hostname|Median MS|
+|:---:|:---:|:---:|
+|1|matrix.sum7.eu|192|
+|2|frai.se|272|
+|3|dendrite.neilalexander.dev|307|
+|4|cringe.chat|320|
+|5|willian.wang|567|
+|6|forlorn.day|661|
+|7|grin.hu|4507.5|
+
+
+## That's all I know
+
+See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/12/2022-12-23-this-week-in-matrix-2022-12-23.md
+++ b/content/blog/2022/12/2022-12-23-this-week-in-matrix-2022-12-23.md
@@ -1,0 +1,237 @@
++++
+title = "This Week in Matrix 2022-12-23"
+date = "2022-12-23T19:38:10Z"
+path = "/blog/2022/12/23/this-week-in-matrix-2022-12-23"
+
+[taxonomies]
+author = ["uhoreg"]
+category = ["This Week in Matrix"]
++++
+
+## Matrix Live
+
+Matrix Live will be back in the new year.
+
+## Dept of Spec 📜
+
+[uhoreg](https://matrix.to/#/@hubert:uhoreg.ca) says
+
+> # Spec
+> 
+> Here's your weekly spec update! The heart of Matrix is the specification - and this is modified by Matrix Spec Change (MSC) proposals. Learn more about how the process works at https://matrix.org/docs/spec/proposals.
+> 
+> 
+> ## MSC Status
+> 
+> **Merged MSCs:**
+> * [MSC3706: Extensions to `/_matrix/federation/v2/send_join/{roomId}/{eventId}` for partial state](https://github.com/matrix-org/matrix-spec-proposals/pull/3706)
+> 
+> **MSCs in Final Comment Period:**
+> * [MSC3938: Remove keyId from `/keys` endpoints](https://github.com/matrix-org/matrix-spec-proposals/pull/3938) (merge)
+> 
+> **New MSCs:**
+> * *There were no new MSCs this week.*
+> 
+> **Closed MSCs:**
+> * [MSC3945: Private device names](https://github.com/matrix-org/matrix-spec-proposals/pull/3945)
+> 
+> ## Spec Core Team
+> Some of the spec core team have been on holidays this week, but we still finished FCP on one MSC, and merged another to the spec.  As mentioned in last week's update, progress will be slower over the holiday season, but we'll be back in the new year, working to make Matrix better.
+> 
+> ## Random MSC of the Week
+> 
+> The random MSC of the week is... [MSC2783: Homeserver Migration Data Format](https://github.com/matrix-org/matrix-spec-proposals/pull/2783)!  If you're running a homeserver using one implementation, it's currently impossible to switch to a different implementation without losing data.  This MSC proposes a file format for exporting data from one implementation and importing it into another.
+>
+> ![](/blog/img/UnnlISqrbrrjXcHkhUnFVJIW.png)
+
+## Dept of Servers 🏢
+
+
+
+### Conduit ([website](https://conduit.rs))
+
+Conduit is a simple, fast and reliable chat server powered by Matrix
+
+[Timo on Conduit ⚡️](https://matrix.to/#/@timo:conduit.rs) says
+
+> # Conduit
+> 
+> If all you wanted for Christmas is a new Conduit release, then I have great news for you:
+> 
+> Conduit v0.5.0 just released and it contains almost everything you wanted:
+> 
+> * Feature: Restricted room joining [!398](https://gitlab.com/famedly/conduit/-/merge_requests/398)
+> * Feature: Call sd-notify after init and before exit [!426](https://gitlab.com/famedly/conduit/-/merge_requests/426)
+> * Improvement: V9 as default room version [!400](https://gitlab.com/famedly/conduit/-/merge_requests/400)
+> * Improvement: More efficient E2EE key claiming [!389](https://gitlab.com/famedly/conduit/-/merge_requests/389)
+> * Fix: All E2EE problems [!393](https://gitlab.com/famedly/conduit/-/merge_requests/393)
+> * Fix: Infinite room loading [!388](https://gitlab.com/famedly/conduit/-/merge_requests/388)
+> * Fix: Wrong notification rules [!405](https://gitlab.com/famedly/conduit/-/merge_requests/405)
+> * Fix: Wrong notification counts [!408](https://gitlab.com/famedly/conduit/-/merge_requests/408)
+> * Fix: Can't rejoin rooms [!399](https://gitlab.com/famedly/conduit/-/merge_requests/399)
+> * Fix: Fluffychat login works again [!391](https://gitlab.com/famedly/conduit/-/merge_requests/391)
+> * Fix: Starting DMs with Synapse users [!390](https://gitlab.com/famedly/conduit/-/merge_requests/390)
+> * Fix: is_guest for appservices [!401](https://gitlab.com/famedly/conduit/-/merge_requests/401)
+> * Fix: Invites from Dendrite [!416](https://gitlab.com/famedly/conduit/-/merge_requests/416)
+> * Fix: Send unrecognized error for unknown endpoints [!397](https://gitlab.com/famedly/conduit/-/merge_requests/397)
+> * Refactor: Service layer [!365](https://gitlab.com/famedly/conduit/-/merge_requests/365)
+> 
+> Conduit is getting a lot more usable with this release, the main missing feature is backfill over federation (loading room messages from before your server joined a room).
+> To update conduit, simply stop it, replace the binary and start it again.
+> Also feel free to join [#conduit:fachschaften.org](https://matrix.to/#/#conduit:fachschaften.org) and ask questions there
+
+## Dept of Clients 📱
+
+
+
+### Nheko ([website](https://nheko-reborn.github.io))
+
+Desktop client for Matrix using Qt and C++17.
+
+[Nico](https://matrix.to/#/@deepbluev7:neko.dev) announces
+
+> # Nheko
+> 
+> This week we sped up search in rooms with a lot of history. We now also don't block the UI during the search of local messages anymore.
+
+### Neochat ([website](https://invent.kde.org/network/neochat))
+
+A client for matrix, the decentralized communication protocol
+
+[Tobias Fella](https://matrix.to/#/@tobiasfella:kde.org) reports
+
+> Ho ho ho Matrix fans!
+> 
+> It's that time of year again, and we have a special gift for all of you just in time for the holidays: Neochat now supports end-to-end encryption! This is made possible thanks to the release of libQuotient 0.7.
+> 
+> While this feature is still somewhat experimental, it's a big step forward in ensuring the privacy and security of your conversations. Just keep in mind that if your only logged-in client is Neochat and something goes wrong, you might lose your messages.
+> 
+> If you're feeling adventurous and want to try out the new end-to-end encryption feature, you can already get it from Flathub and some distros. We're also working on supporting it in our Windows, Android, and macOS builds, so stay tuned for updates.
+> 
+> And in the spirit of the season, here's a Christmas joke: Why was the JavaScript developer's house cold? Because he left his closure open!
+> 
+> Merry Christmas and happy chatting, everyone!
+
+### Element Web/Desktop ([website](https://github.com/vector-im/element-web))
+
+Secure and independent communication, connected via Matrix. Come talk with us in [#element-web:matrix.org](https://matrix.to/#/#element-web:matrix.org)!
+
+[Danielle](https://matrix.to/#/@daniellekirkwood:one.ems.host) reports
+
+> ## Element Web/Desktop
+> 
+> Happy Holidays from us at Element! This is our last update for 2022, and it’s a good ‘un.
+> 
+> * We’re still working on Notifications, reviewing how they work across platforms for new users, and planning the improvements we’re looking to make in the new year. While we look at this user experience holistically, we’re making some subtle changes to the product including removing the bold dot and ordering rooms by activity by default for new users.
+> * We’re also continuing to improve the password reset flow so that user’s who can’t remember their passwords have a smoother experience regaining access to their account.
+> * And, thanks to a contribution we now have the ability to multi-select members when changing users’ permissions in a room! Head to Room Settings > Roles & Permissions.
+> 
+> In labs (you can enable labs features in settings on develop.element.io or on Nightly):
+> 
+> * Rich text editor improvements are still coming so be sure to check them out, including updates to emoji handling and  inline code formatting.
+> * Threads! Threads notifications and performance improvements are landing thick and fast. We’re nearly ready to enable the feature by default and we’ll be excited to do that in the new year.
+>     - Be sure to check that you’re still in the threads beta for this release as in fixing some bugs your setting may have been changed.
+
+### Element iOS ([website](https://github.com/vector-im/element-ios))
+
+Secure and independent communication for iOS, connected via Matrix. Come talk with us in [#element-ios:matrix.org](https://matrix.to/#/#element-ios:matrix.org)!
+
+[Danielle](https://matrix.to/#/@daniellekirkwood:one.ems.host) says
+
+> ## Element iOS
+> 
+> For our last iOS update of 2022…
+> 
+> * Element 1.9.14 has been released to the App Store. It enables threads by default for all users and adds a notifications badge to your spaces button.
+> 
+>     - As always, there’s some bug squashing in this release too.
+> * ElementX has also seen a lot of improvements this week:
+> 
+>     - We now have support for timeline day separators and read markers
+>     - There’s an improved and simpler UI for playing videos
+>     - Connectivity indicators have been added, to show up when the network is offline
+>     - Along with many others…
+> 
+> In labs:
+> 
+> * Voice broadcast and the rich text editor are seeing some improvements, be sure to test them out and keep us posted on your feedback.
+
+### Element Android ([website](https://github.com/vector-im/element-android))
+
+Secure and independent communication for Android, connected via Matrix. Come talk with us in [#element-android:matrix.org](https://matrix.to/#/#element-android:matrix.org)!
+
+[Danielle](https://matrix.to/#/@daniellekirkwood:one.ems.host) announces
+
+> ## Element Android
+> 
+> Happy Holidays! Here’s what’s happened this week:
+> 
+> * There’s been some bugs and crashes keeping us hard at work this week. Along with some exciting improvements to both Element and Element X. On Element:
+>     - There are updates to voice broadcast features and users can sign out of other sessions.
+>     - The colours for pills have been updated and work better in both light and dark mode.
+>     - Threads improvements have been made and we’re looking forward to enabling this feature by default for all users in the new year.
+> * On ElementX we’re moving ahead fast and this week focused our efforts on the Settings pages and the bug reporting functionality (including rageshake detection and screenshot management)
+
+## Dept of SDKs and Frameworks 🧰
+
+
+
+### libQuotient ([website](https://github.com/quotient-im/libQuotient))
+
+A Qt5 library to write cross-platform clients for Matrix
+
+[kitsune](https://matrix.to/#/@kitsune:matrix.org) reports
+
+> # libQuotient 0.7
+> It took us (yes, us - there's more than one person actively working on the project!) a very long time but libQuotient 0.7.0 is out, with a [huge wall of release notes](https://github.com/quotient-im/libQuotient/releases/tag/0.7.0). Big, big, BIG thanks to Carl Schwan and Tobias Fella for their contributions and early adoption of this release in NeoChat (NeoChat maintained compatibility with libQuotient's development branch, along with the stable branch, for quite some time by now). A short summary of most significant things:
+> 
+> * Requirements: C++20, Qt 5.15 or 6.x
+> * E2EE code is now in beta quality, features:
+>   - sending/receiving new messages
+>   - getting historical messages where Megolm keys are already loaded
+>   - encrypting/decrypting attachments
+>   - device verification (to-device flow only, no in-room verification yet)
+> * Individual APIs for `m.fully_read` and `m.read` markers
+> * Client-Server API backend uses Matrix 1.5 API definitions
+> * A complete rewrite of the event types framework to make it truly extensible; you can now add both base classes and specific event types on the client side without touching the library code (the library still provides standard ones)
+> * Account registry for multi-account usage; account access tokens and pickling keys are stored with Qt Keychain
+> * Sticker events support
+> * Pinned messages support
+> * First-class support in Network Access Manager for `mxc:` URLs, to enable showing inline images in messages
+> * A lot of code tightening, bug fixing, performance improvements
+> 
+> Merry Christmas and Happy New Year to those who observe those - and hopefully I'll get to my senses and release 0.8 sooner than in another year 🙂
+
+## Dept of Bots 🤖
+
+[MTRNord](https://matrix.to/#/@mtrnord:midnightthoughts.space) reports
+
+> # Matrix Spam ML
+> 
+> As part of the efforts for working on detecting spam using ML I started to write a moderation bot.
+> 
+> This bot is written from scratch with some design decisions that hopefully will improve usability for both newcomers and seasoned admins.
+> 
+> These decisions are:
+> 
+> * If an action can be done using a reaction, then it will be done using a reaction.
+> * There is a private admin room and a public room for warnings, where admins issue actions. This is meant to serve as a human-readable ban list if admins want to provide this to their users.
+> * The bot will at a later point be able to issue reports to server admins via email and matrix easily by allowing admins to just react after doing a ban. The bot will initially ask how to contact a server if it didn't issue a report to the server before. The bot will remember the setting supplied last time for a server and allows updating the settings if they change. These reports will contain a warning that it was issued from the bot and that replies are necessary for it to be properly relayed back to the admins for further questions. These replies will end up as threads in the admin room. Also, as part of the report, the event JSON for the report will be sent with the report to allow server admins to review the case themselves. (This is still WIP)
+> 
+> The warnings also contain a "false positive" action. This is meant to be used to feed back into the used model for further training and improving it.
+> 
+> All in all, I hope to simplify the process of moderation based on what I experienced as an admin. Feel free to chime in at [#matrix-spam-ml:midnightthoughts.space](https://matrix.to/#/#matrix-spam-ml:midnightthoughts.space) to suggest ideas for the bot. At the time of writing, it is still very much a prototype/demo.
+> 
+> The code can be found at https://github.com/MTRNord/matrix-spam-ml/tree/main/bot
+> 
+> Documentation can be found at: https://mtrnord.github.io/matrix-spam-ml/bot
+> 
+> ![](/blog/img/393699a66c230ed33237716efbb28df4db5c319e.png)
+
+## Dept of Ping
+
+Dept of Ping will be back next week.
+
+## That's all I know
+
+There will be no TWIM next week, but we'll be back in the new year. Be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!

--- a/content/blog/2022/12/2022-12-25-the-matrix-holiday-update-2022.md
+++ b/content/blog/2022/12/2022-12-25-the-matrix-holiday-update-2022.md
@@ -1,0 +1,195 @@
++++
+title = "The Matrix Holiday Update 2022"
+path = "/blog/2022/12/25/the-matrix-holiday-update-2022"
+
+[taxonomies]
+author = ["Matthew Hodgson"]
+category = ["General"]
+
+[extra]
+image = "https://matrix.org/blog/img/matrix-logo.png"
++++
+
+Hi all,
+
+2022 has been a rollercoaster of a year for Matrix.
+
+On one hand, the network has doubled in size (44.1M to 80.3M visible matrix IDs). The wider world is having a grand awakening to the importance of decentralisation thanks to the situation at Twitter. We’ve seen an amazing number of major new players entering the Matrix ecosystem: [Reddit appears to be building out new Chat](https://macaw.social/@wongmjane/109529583352532543) functionality using Matrix; [TeamSpeak announced](https://twitter.com/teamspeak/status/1589621116032585728) Matrix-based chat in TS5; [Discourse](https://meta.discourse.org/t/matrix-protocol-for-chat/210780) is working on adding Matrix support; [Thunderbird](https://www.theregister.com/2022/06/30/thunderbird_102) launched Matrix support; Governments from [Luxembourg](https://gouvernement.lu/en/actualites/toutes_actualites/communiques/2022/11-novembre/16-hansen-lancement.html) to [Ukraine](https://delta.mil.gov.ua/wiki/info/) have launched their own Matrix-powered chat infrastructure; and hundreds of other organisations ranging from startups to massive private & public sector entities are betting on the protocol. The European Parliament has used Matrix as a proof-point for the viability for communication interoperability between gatekeepers in the [Digital Markets Act](https://matrix.org/blog/2022/03/29/how-do-you-implement-interoperability-in-a-dma-world). [FOSDEM 2022](https://matrix.org/blog/2022/02/07/hosting-fosdem-2022-on-matrix) ran smoothly via Matrix with over 23,000 attendees, making it the world's largest open source conference (with 70% of attendees using their own servers!). [Sweden](https://element.io/blog/dsam-och-esam-forordar-matrix-for-saker-och-federerad-kommunikation-inom-sveriges-offentliga-sektor/) has published case studies on the benefits of Matrix for messaging interoperability. Meanwhile existing players like Germany’s BWI have expanded their scope to providing Matrix messaging to the [whole German State](https://element.io/blog/bundesmessenger-is-a-milestone-in-germanys-ground-breaking-vision/); Automattic is busy building [Matrix plugins](https://github.com/Automattic/chatrix) for Wordpress; Rocket.Chat launched [federation via Matrix](https://rocket.chat/press-releases/rocket-chat-leverages-matrix-protocol-for-decentralized-and-interoperable-communications), Gematik has been busy progressing their [TI Messenger](https://www.gematik.de/anwendungen/ti-messenger) initiative for interoperable messaging within Germany’s healthcare industry, and [Tchap](https://element.io/case-studies/tchap) in France is continuing to expand.
+
+On the other hand, only a handful of these initiatives have resulted in funding reaching the core Matrix team. **This is directly putting core Matrix development at risk.** We are witnessing a classic tragedy of the commons. We’ve released all the foundational code of Matrix as permissively-licensed open source and got it to the point that anyone can successfully run it at scale themselves. The network is expanding exponentially. But in return, it transpires that the vast majority of these commercial deployments fail to contribute financially to the Matrix Foundation - whether by donating directly or supporting indirectly by working with [Element](https://element.io), who fund the vast majority of core Matrix development today.
+
+In short: folks love the amazing decentralised encrypted comms utopia of Matrix.  But organisations also love that they can use it without having to pay anyone to develop or maintain it. **This is completely unsustainable**, and Element is now *literally* unable to fund the entirety of the Matrix Foundation on behalf of everyone else - and has had to lay off some of the folks working on the core team as a result.
+
+The only viable solution to this is for organisations building on Matrix to contribute to sharing the costs of maintaining Matrix’s core projects.  We made [a proposal](https://matrix.org/blog/2022/12/01/funding-matrix-via-the-matrix-org-foundation) to address this a few weeks ago, which we’ll iterate on further in the new year to find an approach which both empowers the community and encourages organisations to participate.  In the interim, if you are an organisation who’s building on Matrix and you want the project to continue to flourish, **please** mail [funding@matrix.org](mailto:funding@matrix.org) to discuss how you can support the foundations that you are depending on.
+
+As a reminder, the work the [Foundation](https://matrix.org/foundation) does today for the benefit of the Matrix includes:
+
+* Publishing the[ Matrix Specification](https://spec.matrix.org)
+* Organising the Matrix Spec Core Team, responsible for reviewing and evolving the protocol.
+* Writing roughly half the Matrix Spec Change [proposals](https://spec.matrix.org/proposals).
+* Developing [Synapse](https://github.com/matrix-org/synapse), the Python matrix homeserver implementation
+* Developing [Dendrite](https://github.com/matrix-org/dendrite), the Go homeserver implementation
+* Developing client SDKs for Web (matrix-js-sdk, matrix-react-sdk), iOS (matrix-ios-sdk), Android (matrix-android-sdk2), Python (matrix-nio)
+* Developing our next-generation client SDKs (matrix-rust-sdk)
+* Developing our end-to-end encryption implementations ([libolm](https://gitlab.matrix.org/matrix-org/olm) in C/C++ and [vodozemac](https://github.com/matrix-org/vodozemac) in Rust)
+* Developing next-generation end-to-end encryption implementations ([MLS](https://arewemlsyet.com))
+* Developing and evolving additional core functionality in Matrix, including:
+    * Account portability
+    * Faster room joins over federation
+    * Sliding Sync for instant client sync
+    * Threads
+    * Rich Text composer components
+    * Spaces
+* Developing [open source integrations](https://github.com/matrix-org/matrix-hookshot) to other products (GitLab, GitHub, JIRA... )
+* Developing open source bridges to other platforms (IRC, XMPP, Slack, Discord, Telegram, bifrost…)
+* Developing [peer-to-peer Matrix](https://arewep2pyet.com) implementations, avoiding the need for servers (and associated data/metadata accumulation) entirely
+* Developing [low-bandwidth Matrix](https://github.com/matrix-org/lb) transports
+* Developing and hosting static Matrix room archives for the wider network ([matrix-static](https://github.com/matrix-org/matrix-static) and [matrix-public-archive](https://github.com/matrix-org/matrix-public-archive))
+* Developing and hosting the [matrix.to](https://matrix.to) link redirect service
+* Developing open source authentication mechanisms and integrations for Matrix ([OIDC](https://areweoidcyet.com))
+* Developing decentralised Video/VoIP conferencing servers on Matrix ([waterfall](github.com/matrix-org/waterfall))
+* Developing decentralised Video/VoIP client components on Matrix ([matrixRTC](https://github.com/matrix-org/matrix-js-sdk/pull/2553))
+* Developing showcase "beyond chat" implementations of Matrix such as [Third Room](https://thirdroom.io) 
+* Developing moderation tooling and applying it to matrix.org ([mjolnir](https://github.com/matrix-org/mjolnir) and much more)
+* Publishing moderation reputation lists for the benefit of the wider community
+* Developing integration test suites for Matrix compatibility testing ([sytest](github.com/matrix-org/sytest), [complement](https://github.com/matrix-org/complement), [trafficlight](https://github.com/matrix-org/trafficlight))
+* Developing a reference push notification server ([sygnal](https://github.com/matrix-org/sygnal))
+* Developing a reference identity directory server ([sydent](https://github.com/matrix-org/sydent))
+* Procuring and publishing independent [public audits](https://matrix.org/blog/2022/05/16/independent-public-audit-of-vodozemac-a-native-rust-reference-implementation-of-matrix-end-to-end-encryption) of Matrix's encryption and wider stack
+* Publishing the matrix.org website and blog
+* Publishing the weekly "Matrix Live" video podcast
+* Publishing the weekly "This Week In Matrix" news letter
+* Organising regular meetups (e.g. "Open Tech Will Save Us")
+* Promoting Matrix at open source conferences
+* Running the matrix.org homeserver
+* Moderating the matrix.org project rooms
+* Running free public bridges to networks such as IRC networks and XMPP.
+
+This list is not remotely exhaustive (turns out there are over 240 projects in the matrix.org GitHub org!) but it serves to illustrate the sheer scale of work that the Foundation performs today.  Keeping the core team funded to work on Matrix as our day job is critical for Matrix’s long-term success, and so we **really** hope that organisations depending on Matrix (or passing philanthropists who appreciate Matrix’s value) will drop a line to [funding@matrix.org](mailto:funding@matrix.org) and help keep the show on the road.
+
+
+### Turbocharging Matrix
+
+Aside from the nightmares of funding open source software, 2022 has very much been a year of building - focusing on implementing a step change in Matrix’s performance and usability: ensuring that the protocol can punch its weight (and more!) against centralised proprietary alternatives. After all, Matrix clients need to be at least as good as the centralised alternatives in order to get widespread uptake.
+
+This work has ended up taking many forms: on the server-side, Synapse sprouted Rust support to accelerate its hot paths, starting with [push rule evaluation](https://github.com/matrix-org/synapse/pull/13838). It’s super exciting to see Synapse performance heading into a new era, building on the foundations of what’s become a very mature and stable homeserver implementation.
+
+Meanwhile work is in the final stages on “[Faster Joins](https://github.com/matrix-org/matrix-spec-proposals/blob/rav/proposal/faster_joins/proposals/3902-faster-remote-joins.md)”, finally letting servers rapidly join rooms over federation by synchronising only the minimal subset of state needed to join, rather than proactively synchronising the room’s full current state.  Faster joins became [available for testing](https://matrix.org/blog/2022/10/18/testing-faster-remote-room-joins) in Synapse in October, and since then the team has been [working through](https://github.com/matrix-org/synapse/milestone/10) making it support workers and addressing the various edge cases and bugs that have shown up during testing.  Current join performance is a roughly 25x speedup on large rooms, although we’re confident that we can improve this even more, and we’re aiming to land it in time for FOSDEM at the beginning of Feb.
+
+On the client-side, the work to transform Matrix client performance has centred around “[Sliding Sync](https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md)” - our entirely new API for synchronising the minimal data to a client needed for it to render its UI, thus making login, launch and sync instant.  Sliding sync (originally called “sync v3”) has been a long time in the making; the API has gone through countless iterations as we worked away throughout 2022 implementing it in real-life clients, and adding all the extensions ([MSC3884](https://github.com/matrix-org/matrix-spec-proposals/pull/3884), [MSC3885](https://github.com/matrix-org/matrix-spec-proposals/pull/3885)) needed to get to parity with sync v2.  The wait has been well worth it, though: [support](https://pr9256--matrix-react-sdk.netlify.app/) in Element Web is in the final stages of development - and moreover the next-generation Element X mobile clients will only speak Sliding Sync.
+
+Element X itself is shaping up to be a showcase of just how snappy and performant Matrix can be: built on matrix-rust-sdk, it uses native Swift UI on iOS/macOS and Jetpack Compose on Android to couple together the best possible platform-native user experience with the ultimate underlying native-code SDK implementation, backed by sliding sync. The goal is to be at least as snappy as Telegram, iMessage or WhatsApp (we’ve taken to counting the frames in screen recordings to compare things like time-to-launch and time-to-load scrollback).  Element X is currently in late alpha on iOS, and the hope is to enter public beta in time for FOSDEM.  You can see a sneak peek here of the iPad-style layout (running under macOS) though!
+
+![Element X](/blog/img/2022-12-25-elementx.png)
+
+Finally, in terms of usability, there have been leaps and bounds forwards across Matrix - particularly with Element’s mobile UI being [entirely refreshed](https://element.io/blog/an-unrecognisable-improvement-elements-new-design-is-here/) by the design team in September as a stepping stone to the forthcoming final Element X design.  Any remaining UX quirks should be flushed out with Element X, but the visuals are already a clear step forwards towards an excellent alternative to the centralised encumbents.
+
+<iframe src="https://www.youtube.com/embed/kjZCD14qMK0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+### Encryption
+
+We had great plans for E2EE in Matrix this year; starting off in a huge rush to get [vodozemac](https://github.com/matrix-org/vodozemac) finished and [audited](https://matrix.org/blog/2022/05/16/independent-public-audit-of-vodozemac-a-native-rust-reference-implementation-of-matrix-end-to-end-encryption) as our shiny new native-Rust implementation of Olm/Megolm. The plan was then to integrate vodozemac into matrix-rust-sdk’s crypto crate, and then replace the various old fragmented E2EE implementations across matrix-js-sdk, matrix-ios-sdk, matrix-android-sdk2 and matrix-rust-sdk itself with One True audited implementation - with audits booked with Least Authority to get further assurance around matrix-rust-sdk-crypto, matrix-rust-sdk itself and finally the full stack (Element X + Synapse).
+
+Unfortunately, things went sideways when security researchers from Royal Holloway University London & elsewhere got in touch to explain that they had found some [nasty implementation vulnerabilities](https://nebuchadnezzar-megolm.github.io/) in the venerable matrix-js-sdk implementation.  So, we had no choice but to pause “Element R” - the project to converge matrix-{js,ios,android}-sdk on matrix-rust-sdk-crypto, and instead start analysing and addressing the issues across all current shipping Matrix clients in order to resolve them as rapidly as possible.  Ironically, it turned out in the end that only matrix-{js,ios,android}-sdk were affected - all other independent implementations, including matrix-rust-sdk, were okay.  As such, the Element R work would have protected us from these vulnerabilities had it been ready, and failing that it would have let us solve them in a single place.  Instead, Element R ended up getting pushed back for months while we worked through the various issues in triplicate across the legacy SDKs, while also checking all the other client implementations we could find, and dealing with additional issues which the RHUL researchers discovered as they dug deeper.  Eventually we finished the analysis and agreed a [coordinated disclosure](https://matrix.org/blog/2022/09/28/upgrade-now-to-address-encryption-vulns-in-matrix-sdks-and-clients) at the end of September.
+(EDIT: to be clear, we are very grateful to the security researchers for discovering and disclosing the vulns responsibly to us. The frustration here stems from the irony that if we'd finished the matrix-rust-sdk-crypto rewrite a few months earlier, we'd have mitigated the severe vulns - but instead, the rewrite got pushed back even further. It's obviously our fault though, not the researchers'.)
+
+Since then, work has been split three ways: firstly, Element R work has resumed - and in fact Element R on iOS is pretty much usable as of today, other than needing some work to support E2EE push notifications (which will also be required for Element X). Element R on Android is very close too, and meanwhile Element R on Web decrypted its first event on Dec 19th! We’re hoping to get Element R in production on all platforms by Feb.
+
+Secondly, we’ve been addressing other points raised by the RHUL researchers to ensure that malicious servers cannot add malicious devices or users to conversations, rather than warning as we do today.  This is not a trivial problem to solve, but we’re making progress via [MSC3917](https://github.com/matrix-org/matrix-spec-proposals/pull/3917) (Cryptographically Constrained Room Membership) and [MSC3834](https://github.com/matrix-org/matrix-spec-proposals/pull/3834) (Opportunistic user key pinning (TOFU)).  However, this work is effectively blocked on Element R landing first, as there’s no way we’re going to fix this in triplicate on the legacy SDKs.
+
+Thirdly, we’ve been pushing ahead on implementing Decentralised MLS as a next-generation encryption protocol for Matrix to potentially replace Olm and Megolm.  This work was badly disrupted by RHUL mitigations, but we’re making good progress again - you can follow all the details over at [https://arewemlsyet.com](https://arewemlsyet.com).  Matrix over DMLS is currently in alpha, but the aim is to start beta testing Decentralised MLS in 2023.
+
+Finally, we’ve been working hard on completely reworking the overall UX of how E2EE should work in Matrix clients - specifically, requiring users to cross-sign their devices in order to use E2EE, and so end up in a much higher trust world (alongside Trust On First Use). Can’t wait to finally simplify the E2EE UX!
+
+
+### All new features
+
+It’s not all been performance and stability work this year - there have been some large areas of feature work happening too.
+
+One of the most visible projects has been Threads, which [launched in beta](https://element.io/blog/introducing-threads-in-beta/) in April, and subsequently has undergone huge amounts of polish to improve performance, notification semantics, unread behaviour and thread-aware read receipts.  The end result is feeling great now, and threads [exited beta](https://twitter.com/element_hq/status/1605861000296640512) in Element Mobile on Dec 20th. Web narrowly missed the window due to a final ‘stuck notification’ bug which is still being tracked down, but will follow shortly afterwards and then threads will be finally out of beta!
+
+Another big project in 2022 has been to create a general purpose Rich Text Editor to provide WYSIWYG (What You See Is What You Get) message composition for Matrix clients.  This has ended up being a very ambitious project to define all the core editing semantics in a shared rust library, with platform-specific bindings to link it into the editing UI available on Web, iOS & Android.  The end result lives at [https://github.com/matrix-org/matrix-rich-text-editor](https://github.com/matrix-org/matrix-rich-text-editor) - and you can play with it by enabling it in labs on Element Web/iOS/Android or experiment with the [live demo](https://matrix-org.github.io/matrix-rich-text-editor). The core behaviour is feeling excellent, although predictably some of the fine detail is very fiddly to get right. It’s almost there, though, and thanks to its built-in rust test harness generator(!) we are confident we’ll catch and control all the edge cases, and this should form an incredibly strong platform for all future rich text editing requirements in Matrix (and beyond!).  This work was very kindly sponsored by one of Element’s public sector customers in order to get Element to parity with Teams - thank you!
+
+Location Sharing was another feature which landed in 2022 - powered by [MSC3488](https://github.com/matrix-org/matrix-spec-proposals/pull/3488) and [MSC3489](https://github.com/matrix-org/matrix-spec-proposals/pull/3489), and implemented in matrix-{js,ios,android}-sdk in Element Web/iOS/Android, letting users share static and live locations and view them on an OpenStreetMap compatible map tileserver of their server’s choice. The Live Location Sharing is controversial in that it stores location data in the room history (and as such is hidden behind a labs flag on Element), but should eventually be replaced by [MSC3672](https://github.com/matrix-org/matrix-spec-proposals/pull/3672) to share locations are custom ephemeral events instead (once custom EDUs land) in the spec.  Around the same time, Polls also went live thanks to [MSC3381](https://github.com/matrix-org/matrix-spec-proposals/pull/3381) - it’s worth noting that both Location Sharing and Polls are excellent examples of “extensible events” in the wild: ensuring that clients which understand the custom event type will render them appropriately, but letting other clients fall back to showing them as simple timeline events.
+
+
+### Open ID Connect
+
+The transition to using Open ID Connect for Matrix authentication has been progressing steadily throughout 2022 - with Third Room being the first OIDC-native Matrix client, closely followed by Element X. [matrix-authentication-service](https://github.com/matrix-org/matrix-authentication-service) now exists as a basic OIDC identity provider suitable for being linked into Synapse, and meanwhile Third Room demonstrates how you can integrate Keycloak as a third party IDP (complete with reCAPTCHA and guest access!).  The team also went on a very exciting detour to figure out how to perform login-and-E2EE-setup in a single operation by scanning a QR code ([MSC3906](https://github.com/matrix-org/matrix-spec-proposals/pull/3906)), and how it might integrate into OIDC in future.
+
+Element X looks set to be the showcase for native OIDC in a typical Matrix client going forwards, so watch this space to see how it feels!
+
+You can keep track of the inexorable transition to OIDC over at [https://areweoidcyet.com](https://areweoidcyet.com).
+
+
+### VoIP
+
+2022 was the year that Matrix finally got native multiparty VoIP.  After launching [Element Call Beta 1](https://element.io/blog/introducing-native-matrix-voip-with-element-call/) in March followed by [Beta 2](https://element.io/blog/element-call-beta-2-encryption-spatial-audio-walkie-talkie-mode-and-more/) in June, we’ve been busy embedding Element Call as a “matryoshka” widget into Element Web, using it to replace Jitsi in powering video rooms and video calls.  You can read all about this in detail in the [summer blog post](https://matrix.org/blog/2022/08/15/the-matrix-summer-special-2022#native-voip-conferencing).
+
+Meanwhile, lots of progress is underway on [Waterfall](https://github.com/matrix-org/waterfall) - the name we picked for the Pion-based decentralised Selective Forwarding Unit (i.e. conferencing focus) contributed by Sean DuBois earlier in the year, including adding simulcast support to support large scale conferences.
+
+There’s only one catch, which is that Element Call is still in (very very late) beta, thanks to a handful of bugs which have been hard to track down, which has in turn kept all the other dependencies (embedded Element Call; video rooms etc) in beta too.  However, we think we’re pretty much there now - which is perfect timing given how Waterfall is coming together, meaning that both stable *and* scalable native Matrix conferences are on the horizon!
+
+Even better, the plan is for Element X to rely entirely on embedding Element Call for VoIP - so we should be able to jump forwards pretty rapidly to having excellent native multiparty VoIP and video rooms on mobile as well as on Web.  So, once Element Call exits beta, everything should follow.  Just for a change, we’re aiming to get this done by the end of January - but there are a lot of unknown unknowns still flying around, so watch this space…
+
+
+### IETF & MIMI
+
+Another massive new initiative this year has been the process of proposing Matrix to the IETF as a candidate for use in interoperable instant messaging standardisation.  The [MIMI (More Instant Messaging Interoperability) working group](https://datatracker.ietf.org/group/mimi/about/) emerged earlier in the year within IETF as an initiative to define how MLS could be used to interoperate between different instant messaging silos - as shortly to be required by the [Digital Markets Act](https://matrix.org/blog/2022/03/29/how-do-you-implement-interoperability-in-a-dma-world).
+
+One of the things that MIMI aims to do is to define a common application layer protocol to exchange messages. At first [CPIM was proposed](https://datatracker.ietf.org/doc/draft-mahy-mimi-content/01/) (an ancient message format that looks a lot like email) - and then an [entirely new JSON message format](https://datatracker.ietf.org/doc/draft-rosenberg-mimi-msg-format/) proposal emerged which looks somewhat Matrix (but isn’t). At this point it became obvious that we should throw our hat into the ring and encourage MIMI to use Matrix rather than reinvent it, and so we set about proposing Matrix as at least the [message format](https://datatracker.ietf.org/doc/draft-ralston-mimi-matrix-message-format/) and [message transport layer](https://datatracker.ietf.org/doc/draft-ralston-mimi-matrix-transport/) of the stack. It’s quite surreal to see Matrix starting to fly around as IETF Drafts!
+
+The next step here is to re-express the relevant bits of the current Matrix spec as self-contained IETF Drafts (rather than backreferencing the current spec from the drafts).  The idea is that the normal Matrix spec will continue to evolve much as it always has, but we’ll effectively donate a Long Term Supported dialect of it to IETF which can then evolve according to IETF process and be immortalise as RFCs for use in MIMI.  We’ll then backport those changes into spec.matrix.org in order to avoid fragmentation, while retaining the same ability we have to rapidly iterate and extend Matrix with MSCs.  This work is well under way (taking opportunity to use [Extensible Events](https://github.com/matrix-org/matrix-spec-proposals/blob/matthew/msc1767/proposals/1767-extensible-events.md) from the outset!), and we should see explosions of further IETF Drafts emanating from Travis as 2023 progresses.
+
+
+### Trust & Safety
+
+2022 saw a real uptick in spam and abuse across Matrix, and there have been some valiant attempts to improve our moderation tooling over the course of the year.  Unfortunately it hasn’t come together as rapidly as we might have hoped, however, and we’ve seen several large communities give up on Matrix and move back to Discord thanks in part to needing better anti-abuse mechanisms.
+
+In 2023 we’re resetting our trust & safety work, with Mjolnir dev returning to its original development team, and we’ll be working as tactically as possible to ensure that all communities on Matrix can easily block abuse using whatever mechanisms they need.
+
+
+### P2P & Dendrite
+
+Meanwhile, Dendrite (our second generation homeserver implementation) development has continued at pace throughout the year. According to sytest we are now at 93% client-server API compliance with 577 out of 620 tests passing, and the server-server API compliance is at 97% with 111 out of 114 tests passing! None of the missing tests are showstoppers, so it’s fair to say that Dendrite is very nearly ready for primetime.
+
+The interesting plot twist is that Dendrite development has ended up increasingly focusing on embedded matrix server use cases - particularly to power Peer-to-Peer Matrix, where clients require a server to be embedded within them.  So while Synapse has ended up increasingly focusing on large-scale deployments, Dendrite has ended up pursuing smaller instances (which is ironic, given originally it was meant to be the other way round!).
+
+P2P Matrix work has been progressing well too - you can follow the blow-by-blow updates over at [https://arewep2pyet.com](https://arewep2pyet.com). After a lot of back and forth evaluating hard-state routing versus soft-state routing in Pinecone, we’ve ended up converging on soft-state routing (which is chattier, but easier to reason about in terms of mitigating attacks). However, the chattiness means that it doesn’t scale as well as one might hope - so we’re now working on a “tiered” approach where separate Pinecone networks can be tiered together into one inter-network, giving us scalability at the expense of being slightly less decentralised. It’s fair to say that the journey here has been pretty frustrating in its twists and turns, and sadly Neil Alexander chose to move on a few months ago. However, Devon has stepped up to fill his shoes as primary Pinecone and P2P wrangler, and is making amazing progress on the remaining work - firstly implementing [Store and Forward relaying](https://github.com/matrix-org/dendrite/pull/2917) in Dendrite so that today’s Pinecone networks can exchange messages even if the recipient node is offline.  Next up will be bridging P2P Matrix with today’s Matrix network - and then working on tiering to provide the scalability we need.  The expectation is that today’s serverside Dendrite instances will effectively turn into static pinecone peers, store and forwarding messages on behalf of P2P nodes, and providing tiering between respective pinecone subnets.
+
+
+### Hydrogen & Chatterbox
+
+Development on Hydrogen as a super-lightweight progressive-web-app Matrix client has also been progressing throughout the year (with a few detours to help out with end-to-end testing via [trafficlight](https://github.com/matrix-org/trafficlight) both for the benefit of Hydrogen and other clients).
+
+The biggest change has been Hydrogen sprouting a separate SDK layer, letting the engine be embedded into other webapps in order to add noninvasive Matrix messaging with as minimal a footprint as possible.  This was showcased in Element’s [chatterbox](https://element.io/blog/element-launches-chatterbox/) offering in July - providing an open source chatbox which can be trivially embedded into existing sites, and also powers the [Chatrix](https://github.com/Automattic/chatrix) wordpress plugin that Automattic is working on.
+
+Hydrogen also added independent support for [MSC3401](https://github.com/matrix-org/matrix-spec-proposals/pull/3401) multiparty voice/video calling (albeit on a [branch](https://github.com/vector-im/hydrogen-web/pull/705)), letting us showcase heterogeneous Element Call &lt;-> Hydrogen group calling and prove MSC3401 as fit for purpose as a true open interoperable call signalling - and in turn Hydrogen SDK, complete with the multiparty voice/video calling, powers the Matrix engine within Third Room - our metaverse-on-Matrix platform.
+
+We’re looking forwards to Hydrogen continuing to reach full feature parity with Element over the next year, and popping up in increasingly unexpected places as everyone’s favourite embedded Matrix client!
+
+
+### Third Room
+
+Finally, it’s hard to believe that [Third Room](https://thirdroom.io), our Matrix-based open platform for decentralised realtime spatial collaboration, barely existed at the beginning of the year.  Third Room serves to demonstrate that Matrix is *way* more than just chat and VoIP, but can power the spatial communication layer of the open web. This has ended up driving forwards a tonne of new capabilities for Matrix - showcasing native OIDC auth; scalable multiparty VoIP in Hydrogen SDK, efficient binary-diffed file storage, and more recently has been defining how to store extensible behaviour for Matrix rooms as WASM objects stored in the Matrix room itself.
+
+Third Room itself is a Hydrogen-based Matrix client, which lets you view Matrix rooms as interactive multiparty 3D environments (using [MSC3815](https://github.com/matrix-org/matrix-spec-proposals/pull/3815)) - with the world defined as glTF blobs stored in the Matrix room, and the ability to script and customise any aspect of that world using WASM blobs stored in Matrix rooms, which execute on the participating clients, exposing a new scenegraph API called WebSceneGraph in order to manipulate the glTF that makes up the world.  We also expect to see a variant of Matrix’s normal widget API to be exposed to these WASM blobs, introducing the concept of sandboxed clientside widgets, bots or other integrations - letting users customise and extend Matrix without ever having to run serverside bots again.
+
+The intention is to provide a platform which can be used to build *any* kind of interactive realtime spatial multiparty app in an open standardised, decentralised, end-to-end encrypted way - whether that’s for gaming, social, or professional activity such as building “digital twins” for manufacturing, agriculture, smart cities, search & rescue, etc.  You can read more about the vision at [thirdroom.io/preview](https://thirdroom.io/preview), or via press coverage at [TheNewStack](https://thenewstack.io/third-room-teases-user-generated-content-for-the-metaverse/) or [Golem](https://www.golem.de/news/third-room-das-open-source-metaverse-von-matrix-2212-170638.html).  We were also incredibly flattered to be invited to present Third Room at [SIGGRAPH Asia](https://sa2022.siggraph.org/en/presentation/?id=realcur_102&sess=sess143) a few weeks ago.  The official recording has yet to emerge, but you can find a [cheeky bootleg here](https://twitter.com/o_ob/status/1601442998696677376).
+
+We launched [Tech Preview 1 of Third Room](https://matrix.org/blog/2022/09/27/announcing-third-room-tech-preview-1) at the end of September, and since then all of the work has been around building out WebSceneGraph and the WASM scripting environment - letting users build their own functionality in JS via QuickJS or C (and in future Rust or Zig too).  We’ve also been working on making the networking (via Matrix WebRTC-negotiated data channels) more robust, switching to an ‘authoritative’ simulation model rather than having each client run its own physics simulation, in order to kick the hard problem of decentralised physics simulations down the road a bit further. We’re also adding in a much-needed ‘discover’ page to help users find new rooms and explore everything that’s possible in the platform.  And finally, we’re adding WebXR support so that folks can use ThirdRoom with VR and AR hardware if they so desire. All this should culminate in Tech Preview 2, due in the coming weeks.
+
+If you want a quick sneak preview of the scripting capabilities on the horizon with a [very basic script](https://matrix.thirdroom.io/_matrix/media/r0/download/thirdroom.io/qFfvHcXNQkjeDjTpdMfPCniY) stored in the media repository, head over to [https://thirdroom.io/world/#surprise:thirdroom.dev](https://thirdroom.io/world/#surprise:thirdroom.dev) and click on the television ;)
+
+
+### Conclusion
+
+So there you have it: it’s been a mixed year for Matrix, but at least the project itself is moving forwards faster than ever, for now. If you look back at the predictions from [last year’s holiday blog post](https://matrix.org/blog/2021/12/22/the-mega-matrix-holiday-special-2021#2022) you’ll see that most of them even came true. This year, we’ll keep the predictions simple: our plans for 2023 are to ensure that the Foundation is well funded, ship all of the step-change improvements in performance and usability which are currently in beta as rapidly as possible - and demonstrate for once and for all that Matrix can indeed punch its weight against the proprietary centralised alternatives.
+
+If you can afford it, please consider donating to the Matrix.org Foundation to support our work. The most efficient way to support us is to [donate via donorbox](https://donorbox.org/keep-matrix-exciting). Our Patreon is not going anywhere, so if you wish to keep supporting it there we're happy to count you in our supporters.
+
+[![](/images/donorbox.png)](https://donorbox.org/keep-matrix-exciting)
+
+Thanks for flying Matrix;
+
+Matthew, Amandine & the whole core team.

--- a/content/blog/2023/01/2023-01-06-this-week-in-matrix-2023-01-06.md
+++ b/content/blog/2023/01/2023-01-06-this-week-in-matrix-2023-01-06.md
@@ -13,7 +13,7 @@ image = "https://matrix.org/blog/img/cbIulIJDvrpoIxneRNUgGLmd.png"
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/tfC5SAdTnUM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/tfC5SAdTnUM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Dept of *Status of Matrix* 🌡️

--- a/content/blog/2023/01/2023-01-13-this-week-in-matrix-2023-01-13.md
+++ b/content/blog/2023/01/2023-01-13-this-week-in-matrix-2023-01-13.md
@@ -10,7 +10,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5j-lELpKjHs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/5j-lELpKjHs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Dept of *Status of Matrix* 🌡️

--- a/content/blog/2023/01/2023-01-27-this-week-in-matrix-2023-01-27.md
+++ b/content/blog/2023/01/2023-01-27-this-week-in-matrix-2023-01-27.md
@@ -11,7 +11,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/sbb3x41gGso" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/sbb3x41gGso" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of GSoC 🎓️
 

--- a/content/blog/2023/02/2023-02-09-finally-a-hybrid-conference-that-worked.md
+++ b/content/blog/2023/02/2023-02-09-finally-a-hybrid-conference-that-worked.md
@@ -40,7 +40,7 @@ end of the year](https://matrix.org/blog/2022/08/15/the-matrix-summer-special-20
 and had far too much giving the mother of all demos to a packed room of nearly
 1500 people.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/eUPJ9zFV5IE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/eUPJ9zFV5IE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## The first ever in-person Matrix devroom
 
@@ -57,19 +57,19 @@ the gap very quickly.
 
 The devroom started with a quick intro to Matrix from Matthew & Amandine.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/dPgYy-Y4f7w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/dPgYy-Y4f7w" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Florian followed with a talk about MatrixRTC to explore what Matrix can do
 beyond instant messaging
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/P--LwIB3deA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/P--LwIB3deA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 Then Matthew did an awesome demo of Third Room and “3D widgets” (user generated
 content) that can be embedded into its worlds. Of course with a nice “The Matrix
 in Matrix” scene.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/nG8qJ4on00Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/nG8qJ4on00Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Stunning 3D worlds are great, but the most popular use case for Matrix today is
 instant messaging. And we did a lot as the Matrix Foundation to significantly
@@ -79,17 +79,17 @@ respectively, while Mauro showed us how Element X, the first client to use it,
 doesn’t stop here and goes way beyond to provide a snappy, sturdy, polished
 client.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/5iIs1zWuVOU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/5iIs1zWuVOU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Kim and Oliver from Nordeck made an interesting presentation about how widgets
 can make Matrix a rich app creation environment.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/hhEUe414scU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/hhEUe414scU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 The Trixnity project then introduced their fast, multi-purpose, well-tested SDK.
 A talk you don’t want to miss, particularly if you’re into Kotlin.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/zDftIZm-DZ0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/zDftIZm-DZ0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Pierre from Technostructures introduced us to [Kazarma](https://technostructures.org/projects/kazarma/)
 a bridge between Matrix and ActivityPub. In Pierre’s own words: “we talked a lot
@@ -97,7 +97,7 @@ about interoperability, and we found it sad that we talked about
 interoperability for proprietary platforms, not with alternative decentralised
 networks, so we tried doing that”. And they did. Bravo Pierre and the team!
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/D3olH1aUCkQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/D3olH1aUCkQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Finally Yan concluded the in-person devroom with a speedrun of all the Matrix
 projects he could find around. The video is not out yet, so we’ll add it to the

--- a/content/blog/2023/02/2023-02-10-this-week-in-matrix-2023-02-10.md
+++ b/content/blog/2023/02/2023-02-10-this-week-in-matrix-2023-02-10.md
@@ -12,7 +12,7 @@ image = "https://matrix.org/blog/img/rAgBabTmwQhtxzRrtuIrOFvR.jpg"
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/eUPJ9zFV5IE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/eUPJ9zFV5IE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of Spec 📜
 

--- a/content/blog/2023/02/2023-02-24-this-week-in-matrix-2023-02-24.md
+++ b/content/blog/2023/02/2023-02-24-this-week-in-matrix-2023-02-24.md
@@ -9,7 +9,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/25wkV2ZCSsM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/25wkV2ZCSsM" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 Transcription (Community made): https://en.miki.community/wiki/Matrix_Tutorial_7
 

--- a/content/blog/2023/03/2023-03-03-this-week-in-matrix-2023-03-03.md
+++ b/content/blog/2023/03/2023-03-03-this-week-in-matrix-2023-03-03.md
@@ -9,7 +9,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/YB0vBc81DvI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/YB0vBc81DvI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of Spec 📜
 

--- a/content/blog/2023/03/2023-03-10-this-week-in-matrix-2023-03-10.md
+++ b/content/blog/2023/03/2023-03-10-this-week-in-matrix-2023-03-10.md
@@ -10,7 +10,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/HlsMMzTFZ_A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/HlsMMzTFZ_A" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Dept of Spec 📜

--- a/content/blog/2023/03/2023-03-15-the-dma-stakeholder-workshop-interoperability-between-messaging-services.md
+++ b/content/blog/2023/03/2023-03-15-the-dma-stakeholder-workshop-interoperability-between-messaging-services.md
@@ -31,7 +31,7 @@ All of the workshop proceeds were livestreamed and archived by European Commissi
 
 The first panel focused on setting up the scene and highlighting the challenges expected during the implementation phase, featuring [Simonetta Vezzoso](https://www.soi.unitn.it/staff/simonetta-vezzoso/) (Professor of Economics at The University of Trento), [Chiara Caccinelli](https://www.linkedin.com/in/chiaracaccinelli) (Co-chair - Digital Markets WG at [BEREC](https://www.berec.europa.eu/)), [Suzanne Blohm](https://www.vzbv.de/en/policy-work/experts) (Policy officer at [Verbraucherzentrale Bundesverbands (VZBV)](https://www.vzbv.de/)) and [Jan Penfrat](https://www.linkedin.com/in/jan-penfrat) (Senior Policy Advisor at [EDRi](https://edri.org/)). There was a lot of emphasis around the risks of gatekeepers dragging their feet, or choosing the solution which makes it harder for SMEs or self-hosters to interoperate, as well as the challenge of introducing the new paradigm of interoperability for messaging without losing the usability aspect - see below for the full scope:
 
-<iframe width="1280" height="720" src="https://www.youtube.com/embed/yoKjXN3G8a8" title="DMA &amp; messaging services interoperability - Legal framework of article 7, tradeoff &amp; challenges" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/yoKjXN3G8a8" title="DMA &amp; messaging services interoperability - Legal framework of article 7, tradeoff &amp; challenges" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <br/>
 
@@ -80,7 +80,7 @@ When DMA first became headline news last year, there was a lot of [very vocal co
 
 You can see the whole panel split into the various sections below:
 
-<iframe width="1280" height="720" src="https://www.youtube.com/embed/FDnUJXzVn3s" title="DMA &amp; messaging services interoperability - End to end Encryption and Security" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe  src="https://www.youtube.com/embed/FDnUJXzVn3s" title="DMA &amp; messaging services interoperability - End to end Encryption and Security" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <br/>
 
@@ -137,7 +137,7 @@ You can see the whole panel split into the various sections below:
 
 Finally, we launched into the third and final session of the day - a second technical panel to dig into questions of identity, usability, data privacy, consent and anti-abuse in a DMA world.  Relative to the second panel, there were more questions than answers here, as the panellists discussed whether users would need to consent or opt-in/opt-out of interoperability, and debated the various data privacy implications of DMA.  The panel starred Stephen Hurley from Meta again, [Lucas Verney](https://www.linkedin.com/in/lucas-verney) from [PEReN](https://www.peren.gouv.fr), Markus Klein from [Bundesnetzagentur](https://www.bundesnetzagentur.de/) and [Rohan Mahy](https://rohan.com/) from [Wire](https://wire.com) introducing the [MIMI working group](https://datatracker.ietf.org/group/mimi) at IETF.
 
-<iframe width="1280" height="720" src="https://www.youtube.com/embed/ZtRmAaHUxWw" title="DMA &amp; messaging services interoperability - Metadata, cross-certification of users, and UI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/ZtRmAaHUxWw" title="DMA &amp; messaging services interoperability - Metadata, cross-certification of users, and UI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 <br/>
 

--- a/content/blog/2023/03/2023-03-17-this-week-in-matrix-2023-03-17.md
+++ b/content/blog/2023/03/2023-03-17-this-week-in-matrix-2023-03-17.md
@@ -13,7 +13,7 @@ image = "https://matrix.org/blog/img/matrix-logo.png"
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/EeCsB1EPwf4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/EeCsB1EPwf4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of Spec 📜
 

--- a/content/blog/2023/03/2023-03-24-this-week-in-matrix-2023-03-24.md
+++ b/content/blog/2023/03/2023-03-24-this-week-in-matrix-2023-03-24.md
@@ -14,7 +14,7 @@ image = "https://matrix.org/blog/img/matrix-logo.png"
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/1U57WNc4tkw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/1U57WNc4tkw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Dept of Spec 📜

--- a/content/blog/2023/03/2023-03-31-this-week-in-matrix-2023-03-31.md
+++ b/content/blog/2023/03/2023-03-31-this-week-in-matrix-2023-03-31.md
@@ -14,7 +14,7 @@ image = "https://matrix.org/blog/img/matrix-logo.png"
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/DCEgWsTTId4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/DCEgWsTTId4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Dept of *Status of Matrix* 🌡️

--- a/content/blog/2023/04/2023-04-10-this-week-in-matrix-2023-04-10.md
+++ b/content/blog/2023/04/2023-04-10-this-week-in-matrix-2023-04-10.md
@@ -10,7 +10,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/ZtMGKbyb4Cs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/ZtMGKbyb4Cs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Dept of Spec 📜
 

--- a/content/blog/2023/04/2023-04-21-this-week-in-matrix-2023-04-21.md
+++ b/content/blog/2023/04/2023-04-21-this-week-in-matrix-2023-04-21.md
@@ -10,7 +10,7 @@ category = ["This Week in Matrix"]
 
 ## Matrix Live
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/1VKBD_6PTvs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe src="https://www.youtube.com/embed/1VKBD_6PTvs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 
 ## Dept of Servers 🏢


### PR DESCRIPTION
Tries to somewhat normalize iframes (not fully as you see) to make them responsive by removing width and height.

Also imports a few posts which got lost on the migrator due to a bug with the frontmatter in the gatsby original.