### PR TITLE
[zola] Make sure that the iframes are in the 16/9 aspect ratio. 

### DIFF
--- a/sass/_blog.scss
+++ b/sass/_blog.scss
@@ -60,6 +60,7 @@ article.post {
     }
 
     iframe {
+        aspect-ratio: 16/9;
         width: 100%;
     }
 


### PR DESCRIPTION
Otherwise, they won't scale correctly.

This is a regression. We seem to have lost this CSS line somewhere in the past.

Fixes #1748 