### PR TITLE
Make sure the footer sticks to the bottom

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -23,6 +23,8 @@ html {
 body {
     margin: 0;
     min-height: 100svh;
+    display: flex;
+    flex-direction: column;
     background-color: #fff;
     color: var(--color-text);
 
@@ -44,6 +46,7 @@ body {
 }
 
 main {
+    flex: 1;
     padding-top: var(--navbar-height);
 }
 


### PR DESCRIPTION
If the content doesn't otherwise fill the viewport, make it expand so the footer is at the very bottom of the viewport.

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-05-09 at 12-37-13 Matrix org - Podcasts](https://github.com/matrix-org/matrix.org/assets/951129/35e94357-90fb-445e-886c-5f1d9fb36798) | ![Screenshot 2023-05-09 at 12-38-14 🛠️ Matrix org - Podcasts](https://github.com/matrix-org/matrix.org/assets/951129/b27c6cf9-0b02-45a3-bfee-91c83eb32007) |