### PR TITLE
Add highlighting to social media icons #1779

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -131,6 +131,9 @@ ol:last-child {
             img {
                 margin-inline: .625rem;
             }
+            img:hover {
+                filter: brightness(0) invert(1);
+              }
         }
     }
 


### PR DESCRIPTION
Added highlight to social media icons.I have added the CSS code filter: brightness(0) invert(1); to the img:hover selector inside the a selector, which will invert the colors of the image, effectively making it white, when the image is hovered over.