### PR TITLE
Issue#1778

### DIFF
--- a/sass/_hosting.scss
+++ b/sass/_hosting.scss
@@ -33,8 +33,7 @@
                 max-width: 300px;
             }
 
-
-            border: 1px solid #D2D2D2;
+            border: 1px solid #d2d2d2;
             border-radius: 16px;
 
             .details {
@@ -57,16 +56,20 @@
 
                 .operating_since {
                     height: 1.5rem;
-                    font-size: .9rem;
+                    font-size: 0.9rem;
                 }
+            }
 
+            .details p,
+            ul {
+                text-align: left;
             }
 
             .call-to-action {
                 background-color: #000;
                 color: #fff;
                 border-radius: 1000px;
-                padding: .4rem 2rem;
+                padding: 0.4rem 2rem;
                 align-self: center;
             }
         }

--- a/templates/shortcodes/hosting_providers.html
+++ b/templates/shortcodes/hosting_providers.html
@@ -8,8 +8,9 @@
             </div>
             <h3>{{ provider.name }}</h3>
             <div class="operating_since">Operating since {{ provider.operating_since }}</div>
+            <p>{{ provider.description | markdown | safe }}</p>
         </div>
-        <p>{{ provider.description | markdown | safe }}</p>
+      
         <a href="{{ provider.website }}" class="call-to-action">Try them</a>
     </div>
     {% endfor %}

--- a/templates/shortcodes/hosting_providers.html
+++ b/templates/shortcodes/hosting_providers.html
@@ -10,7 +10,6 @@
             <div class="operating_since">Operating since {{ provider.operating_since }}</div>
             <p>{{ provider.description | markdown | safe }}</p>
         </div>
-      
         <a href="{{ provider.website }}" class="call-to-action">Try them</a>
     </div>
     {% endfor %}


### PR DESCRIPTION
Fixed Bullet points misaligned in providers cards #1778. I have moved provider card description i.e

{{ provider.description | markdown | safe }}

inside details class div so that space-around property shouldn't affect the description element. And the elements p and ul inside details class div i gave text align left.