### PR TITLE
Don't show obsolete clients as default

### DIFF
--- a/templates/ecosystem/clients.html
+++ b/templates/ecosystem/clients.html
@@ -118,7 +118,7 @@
                     <label for="maturity-alpha">Alpha</label>
                 </div>
                 <div class="filter-option">
-                    <input id="maturity-obsolete" type="checkbox" checked>
+                    <input id="maturity-obsolete" type="checkbox">
                     <label for="maturity-obsolete">Obsolete</label>
                 </div>
                 <div class="reset-links">Select <a>all</a> - <a>none</a></div>


### PR DESCRIPTION
Obsolete clients as default is not visible .I have removed checked attribute from obsolete filter option.