### PR TITLE
Set @matrix-org/security as CODEOWNERS for security blog posts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 gatsby/content/blog/**/*synapse*.mdx @matrix-org/synapse-core
+gatsby/content/blog/**/*security*.mdx @matrix-org/security


### PR DESCRIPTION
After seeing it work with synapse-core, it seems like a nice addition, especially given the upcoming RACI matrix for the security process.

Alternatively we could also have it include `*vulnerabilit*` and/or `*advisor*`, but checking historical blog posts, most of the security-related ones have `security` in their title.

<!-- Replace -->
Preview: https://pr1809--matrix-org-previews.netlify.app
<!-- Replace -->
