### PR TITLE
Reduce index size

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ base_url = "https://matrix.turbo.fish"
 compile_sass = true
 
 # Whether to build a search index to be used later on by a JavaScript library
-build_search_index = true
+build_search_index = false
 
 default_language = "en"
 
@@ -32,8 +32,3 @@ skip_anchor_prefixes = [
     # Spec page does not have anchors in the html it seems. (Probably loading using js.) This causes a false positive
     "https://spec.matrix.org/v1.3/changelog/",
 ]
-
-[search]
-# At which character to truncate the content to. Useful if you have a lot of pages and the index would
-# become too big to load on the site. Defaults to not being set.
-truncate_content_length = 256

--- a/config.toml
+++ b/config.toml
@@ -32,3 +32,8 @@ skip_anchor_prefixes = [
     # Spec page does not have anchors in the html it seems. (Probably loading using js.) This causes a false positive
     "https://spec.matrix.org/v1.3/changelog/",
 ]
+
+[search]
+# At which character to truncate the content to. Useful if you have a lot of pages and the index would
+# become too big to load on the site. Defaults to not being set.
+truncate_content_length = 256


### PR DESCRIPTION
Reduce the `search_index.en.js` file, it is 36.8 MB in size and takes >8s to build. This is too big to deploy on cloudflare pages.

This change reduces it to 2.7M (arguably still too big) and builds in <2s

We should look at the [search](https://www.getzola.org/documentation/getting-started/configuration/#:~:text=paths_keep_dates%20%3D%20false-,%5Bsearch%5D,-%23%20Whether%20to%20include) configuration in greater detail. Using a value of `100` and/or excluding the content would be ideal