### PR TITLE
Zola base url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "matrix.org"
+base_url = "https://matrix.org"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "matrix-website.pages.dev"
+base_url = "matrix.org"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://matrix.turbo.fish"
+base_url = "matrix-website.pages.dev"
 
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true


### PR DESCRIPTION
Update the `base_url` as this redirects parts of the site to elsewhere which makes testing tricky.

For now, the `CF_PAGES_URL` is used to override this, and before deployment we'll set that only for non `main` deployments; those will use this setting (matrix.org)