### PR TITLE
Build script for zola

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+# !/bin/bash
+
+if [ "$CF_PAGES_BRANCH" == "main" ]; then
+  # build production using base_url from the site config.toml
+  #zola build
+  zola build --base-url $CF_PAGES_URL
+elif [ "$CF_PAGES_BRANCH" == "staging" ]; then
+  # build staging using CF_STAGING_URL env
+  zola build --base-url $CF_STAGING_URL
+else
+  # build using the default cf pages env url
+  zola build --base-url $CF_PAGES_URL
+fi


### PR DESCRIPTION
Add a build script because

1. We want to use the zola config for production builds
2. We want to deploy a staging instance to test on
3. All other builds should work on cf pages without broken links