### PR TITLE
Fix Fractal's room address

### DIFF
--- a/content/ecosystem/clients/fractal.md
+++ b/content/ecosystem/clients/fractal.md
@@ -8,7 +8,7 @@ language = "Rust"
 last_release = "2023-03-09"
 maturity = "Beta"
 repo = "https://gitlab.gnome.org/GNOME/fractal"
-matrix_room = "#fractal:matrix.org"
+matrix_room = "#fractal:gnome.org"
 featured = false
 [extra.features]
 e2ee = true


### PR DESCRIPTION
This address doesn't exist and it's not the canonical alias of the room anyway :slightly_smiling_face:.