### PR TITLE
Fix legacy redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -108,7 +108,7 @@
 /docs/spec/rooms/* https://spec.matrix.org/latest/rooms/:splat
 
 # Dynamic old landing page for the spec to the new spec docs
-/docs/spec/* https://spec.matrix.org/:splat
+/docs/spec/* https://spec.matrix.org/legacy/:splat
 
 # Dynamic GIT
 /git/* https://git.matrix.org/:splat


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix.org/issues/1879

```
$ curl -sIL https://7ab1dba5.matrix-website.pages.dev/docs/spec/push_gateway/r0.1.0.html|grep -E "location|HTTP"
HTTP/2 302 
location: https://spec.matrix.org/legacy/push_gateway/r0.1.0.html
HTTP/2 200 

$ curl -sIL https://7ab1dba5.matrix-website.pages.dev/docs/spec/server_server/r0.1.0.html|grep -E "location|HTTP"
HTTP/2 302 
location: https://spec.matrix.org/legacy/server_server/r0.1.0.html
HTTP/2 200 
```
