### PR TITLE
Add z-index = 2 for call-to-action class for priority to links

### DIFF
--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -9,6 +9,7 @@
         font-weight: 600;
         border-radius: 1000px;
         padding: .4em 2em;
+        z-index: 2;
     }
 
     #hero {


### PR DESCRIPTION
Fixed issue #1850 
- Giving a z-index of 2 to the "call-to-action" class gives them priority to links among others like images and other background elements