### PR TITLE
Add Cosium/matrix-communication-client to the ecosystem page

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -569,3 +569,16 @@ featured_in = []
 description = """
 Matrix client library for MicroPython.
 """
+
+[[sdks]]
+name = "matrix-communication-client"
+maintainer = "Réda Housni Alaoui"
+maturity = "Stable"
+language = "Java"
+licence = "MIT"
+repository = "https://github.com/Cosium/matrix-communication-client"
+purpose = ["client", "bot"]
+featured_in = []
+description = """
+A java client for the Matrix protocol.
+"""


### PR DESCRIPTION
This change adds https://github.com/Cosium/matrix-communication-client to the ecosystem page.