### PR TITLE
Display the full content of the article in the RSS feed

### DIFF
--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ lang }}">
+    <title>{{ config.title }}
+    {%- if term %} - {{ term.name }}
+    {%- elif section.title %} - {{ section.title }}
+    {%- endif -%}
+    </title>
+    {%- if config.description %}
+    <subtitle>{{ config.description }}</subtitle>
+    {%- endif %}
+    <link href="{{ feed_url | safe }}" rel="self" type="application/atom+xml"/>
+    <link href="
+      {%- if section -%}
+        {{ section.permalink | escape_xml | safe }}
+      {%- else -%}
+        {{ config.base_url | escape_xml | safe }}
+      {%- endif -%}
+    "/>
+    <generator uri="https://www.getzola.org/">Zola</generator>
+    <updated>{{ last_updated | date(format="%+") }}</updated>
+    <id>{{ feed_url | safe }}</id>
+    {%- for page in pages %}
+    <entry xml:lang="{{ page.lang }}">
+        <title>{{ page.title }}</title>
+        <published>{{ page.date | date(format="%+") }}</published>
+        <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
+        <author>
+          <name>
+            {%- if page.authors -%}
+              {{ page.authors[0] }}
+            {%- elif config.author -%}
+              {{ config.author }}
+            {%- else -%}
+              Unknown
+            {%- endif -%}
+          </name>
+        </author>
+        <link rel="alternate" href="{{ page.permalink | safe }}" type="text/html"/>
+        <id>{{ page.permalink | safe }}</id>
+        <content type="html">{{ page.content }}</content>
+    </entry>
+    {%- endfor %}
+</feed>

--- a/templates/rss.xml
+++ b/templates/rss.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+    <channel>
+      <title>{{ config.title }}
+        {%- if term %} - {{ term.name }}
+        {%- elif section.title %} - {{ section.title }}
+        {%- endif -%}
+      </title>
+      <link>
+        {%- if section -%}
+          {{ section.permalink | escape_xml | safe }}
+        {%- else -%}
+          {{ config.base_url | escape_xml | safe }}
+        {%- endif -%}
+      </link>
+      <description>{{ config.description }}</description>
+      <generator>Zola</generator>
+      <language>{{ lang }}</language>
+      <atom:link href="{{ feed_url | safe }}" rel="self" type="application/rss+xml"/>
+      <lastBuildDate>{{ last_updated | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+      {%- for page in pages %}
+      <item>
+          <title>{{ page.title }}</title>
+          <pubDate>{{ page.date | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+          <author>
+            {%- if page.authors -%}
+              {{ page.authors[0] }}
+            {%- elif config.author -%}
+              {{ config.author }}
+            {%- else -%}
+              Unknown
+            {%- endif -%}
+          </author>
+          <link>{{ page.permalink | escape_xml | safe }}</link>
+          <guid>{{ page.permalink | escape_xml | safe }}</guid>
+          <description>{{ page.content }}</description>
+      </item>
+      {%- endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
Fixes #1868 by overriding `atom.xml` and `rss.xml` default templates (default templates are in https://github.com/getzola/zola/tree/master/components/templates/src/builtins)