### PR TITLE
Fix Signal bridge documentation link

### DIFF
--- a/content/ecosystem/bridges/signal/bridges.toml
+++ b/content/ecosystem/bridges/signal/bridges.toml
@@ -8,7 +8,7 @@ Communicates with Signal using [signald](https://gitlab.com/signald/signald).
 maturity = "Beta"
 language = "Python"
 license = "AGPL-3.0-or-later"
-docs = "https://docs.mau.fi/bridges/python/setup.html?bridge=telegram"
+docs = "https://docs.mau.fi/bridges/python/setup.html?bridge=signal"
 repo = "https://github.com/mautrix/signal"
 room = "#signal:maunium.net"
 featured = true


### PR DESCRIPTION
Noticed this while browsing the documentation today on https://matrix.org/ecosystem/bridges/signal/. The documentation link should go to https://docs.mau.fi/bridges/python/setup.html?bridge=signal but goes to https://docs.mau.fi/bridges/python/setup.html?bridge=telegram (the telegram bridge docs) instead.