### PR TITLE
[Clients / NeoChat] Fix flathub.app_id

### DIFF
--- a/content/ecosystem/clients/neochat.md
+++ b/content/ecosystem/clients/neochat.md
@@ -24,7 +24,7 @@ multi_language = true
 windows_installer = "https://www.microsoft.com/store/apps/9PNXWVNRC29H"
 macos_installer = "https://binary-factory.kde.org/search/?q=neochat"
 #f_droid.app_id = "" https://community.kde.org/Android/FDroid
-flathub.app_id = "org.kde.NeoChat"
+flathub.app_id = "org.kde.neochat"
 +++
 
 A Matrix client for desktop and mobile


### PR DESCRIPTION
The Flathub-Link on the Client-Page for NeoChat is currently broken because the app id is wrong.
This change fixes this, so that the Link on the Client-Page does not result in a 404.

Currently: [org.kde.NeoChat](https://flathub.org/apps/org.kde.NeoChat)
Fixed: [org.kde.neochat](https://flathub.org/apps/org.kde.neochat)