### PR TITLE
Fix Author in Feed

### DIFF
--- a/templates/atom.xml
+++ b/templates/atom.xml
@@ -26,8 +26,8 @@
         <updated>{{ page.updated | default(value=page.date) | date(format="%+") }}</updated>
         <author>
           <name>
-            {%- if page.authors -%}
-              {{ page.authors[0] }}
+            {%- if page.taxonomies.authors -%}
+              {{ page.taxonomies.authors[0] }}
             {%- elif config.author -%}
               {{ config.author }}
             {%- else -%}


### PR DESCRIPTION
The authors array is in the taxonomies, not on the page itself.