### PR TITLE
Add a New Post Checklist to PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+<!-- Thanks for submitting a PR! Please ensure the following requirements are met when writing a new post -->
+
+## New Post Checklist
+
+-   [ ] Links are linkified
+  -   [ ] Bare links are surrounded by `<>` (required since Zola follows commonmark strictly)
+  -   [ ] Links with names are of the pattern `[Name](URL)`
+-   [ ] The frontmatter is valid
+  -   [ ] `date` frontmatter contains a time with timezone (This ensures that posts are properly ordered in Feed Readers)
+  -   [ ] A `category` and an `author` taxonomy are set


### PR DESCRIPTION
This adds a Pull request template to this repo for ensuring the posts don't have common issues that have been noticed over the last few TWIM editions. I am not trying to annoy editors here, but instead help them.

Zola uses CommonMark, while the old Blog used MDX. While both are markdown there is a small difference in some of the syntax especially around autolinking of links. This hopefully helps authors to double-check these things while they develop a muscle memory for the changed syntax.