### PR TITLE
Fix: Unify author names which were unusual or duplicated

### DIFF
--- a/content/blog/2017/05/2017-05-18-synapse-0-21-0-is-released.md
+++ b/content/blog/2017/05/2017-05-18-synapse-0-21-0-is-released.md
@@ -3,7 +3,7 @@ title = "Synapse 0.21.0 is released!"
 path = "/blog/2017/05/18/synapse-0-21-0-is-released"
 
 [taxonomies]
-author = ["Tom Lant"]
+author = ["Thomas Lant"]
 category = ["Tech"]
 +++
 

--- a/content/blog/2017/07/2017-07-06-synapse-0-22-0-released.md
+++ b/content/blog/2017/07/2017-07-06-synapse-0-22-0-released.md
@@ -3,7 +3,7 @@ title = "Synapse 0.22.0 released!"
 path = "/blog/2017/07/06/synapse-0-22-0-released"
 
 [taxonomies]
-author = ["Tom Lant"]
+author = ["Thomas Lant"]
 category = ["Tech"]
 +++
 

--- a/content/blog/2017/08/2017-08-30-pr.md
+++ b/content/blog/2017/08/2017-08-30-pr.md
@@ -3,7 +3,7 @@ title = "PR"
 path = "/blog/2017/08/30/pr"
 
 [taxonomies]
-author = ["Tom Lant"]
+author = ["Thomas Lant"]
 category = ["General"]
 +++
 

--- a/content/blog/2018/05/2018-05-25-gdpr-on-matrix-org.md
+++ b/content/blog/2018/05/2018-05-25-gdpr-on-matrix-org.md
@@ -3,7 +3,7 @@ title = "GDPR on matrix.org"
 path = "/blog/2018/05/25/gdpr-on-matrix-org"
 
 [taxonomies]
-author = ["Tom Lant"]
+author = ["Thomas Lant"]
 category = ["Privacy"]
 +++
 

--- a/content/blog/2018/05/2018-05-29-matrix-org-homeserver-privacy-policy-and-terms-of-use-being-enforced-today.md
+++ b/content/blog/2018/05/2018-05-29-matrix-org-homeserver-privacy-policy-and-terms-of-use-being-enforced-today.md
@@ -3,7 +3,7 @@ title = "Matrix.org homeserver privacy policy and terms of use being enforced to
 path = "/blog/2018/05/29/matrix-org-homeserver-privacy-policy-and-terms-of-use-being-enforced-today"
 
 [taxonomies]
-author = ["Tom Lant"]
+author = ["Thomas Lant"]
 category = ["Privacy"]
 +++
 

--- a/content/blog/2019/04/2019-04-26-this-week-in-matrix-2019-04-26.md
+++ b/content/blog/2019/04/2019-04-26-this-week-in-matrix-2019-04-26.md
@@ -3,7 +3,7 @@ title = "This Week in Matrix 2019-04-26"
 path = "/blog/2019/04/26/this-week-in-matrix-2019-04-26"
 
 [taxonomies]
-author = ["Neil J"]
+author = ["Neil Johnson"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2021/09/2021-09-10-pre-disclosure-upcoming-critical-fix-for-several-popular-matrix-clients.md
+++ b/content/blog/2021/09/2021-09-10-pre-disclosure-upcoming-critical-fix-for-several-popular-matrix-clients.md
@@ -4,7 +4,7 @@ date = "2021-09-10T16:43:49Z"
 path = "/blog/2021/09/10/pre-disclosure-upcoming-critical-fix-for-several-popular-matrix-clients"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2021/09/2021-09-13-vulnerability-disclosure-key-sharing.md
+++ b/content/blog/2021/09/2021-09-13-vulnerability-disclosure-key-sharing.md
@@ -4,7 +4,7 @@ date = "2021-09-13T17:29:59Z"
 path = "/blog/2021/09/13/vulnerability-disclosure-key-sharing"
 
 [taxonomies]
-author = ["Denis Kasak, Dan Callahan, and Matthew Hodgson"]
+author = ["Denis Kasak", "Dan Callahan", "Matthew Hodgson"]
 category = ["Security"]
 
 [extra]

--- a/content/blog/2021/11/2021-11-18-pre-disclosure-upcoming-security-release-of-synapse-1-47-1.md
+++ b/content/blog/2021/11/2021-11-18-pre-disclosure-upcoming-security-release-of-synapse-1-47-1.md
@@ -3,7 +3,7 @@ title = "Pre-disclosure: upcoming security release of Synapse 1.47.1"
 path = "/blog/2021/11/18/pre-disclosure-upcoming-security-release-of-synapse-1-47-1"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2021/12/2021-12-03-pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk.md
+++ b/content/blog/2021/12/2021-12-03-pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk.md
@@ -3,7 +3,7 @@ title = "Pre-disclosure: upcoming security release of libolm and matrix-js-sdk"
 path = "/blog/2021/12/03/pre-disclosure-upcoming-security-release-of-libolm-and-matrix-js-sdk"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2021/12/2021-12-13-disclosure-buffer-overflow-in-libolm-and-matrix-js-sdk.md
+++ b/content/blog/2021/12/2021-12-13-disclosure-buffer-overflow-in-libolm-and-matrix-js-sdk.md
@@ -5,7 +5,7 @@ updated = "2021-12-13T16:11:07Z"
 path = "/blog/2021/12/13/disclosure-buffer-overflow-in-libolm-and-matrix-js-sdk"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2021/12/2021-12-15-on-matrix-and-the-log4j-vulnerabilities.md
+++ b/content/blog/2021/12/2021-12-15-on-matrix-and-the-log4j-vulnerabilities.md
@@ -4,7 +4,7 @@ date = "2021-12-15T12:58:02Z"
 path = "/blog/2021/12/15/on-matrix-and-the-log4j-vulnerabilities"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2022/01/2022-01-31-high-severity-vulnerability-in-element-desktop-1-9-6-and-earlier.md
+++ b/content/blog/2022/01/2022-01-31-high-severity-vulnerability-in-element-desktop-1-9-6-and-earlier.md
@@ -4,7 +4,7 @@ date = "2022-01-31T14:01:24Z"
 path = "/blog/2022/01/31/high-severity-vulnerability-in-element-desktop-1-9-6-and-earlier"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2022/08/2022-08-05-this-week-in-matrix-2022-08-05.md
+++ b/content/blog/2022/08/2022-08-05-this-week-in-matrix-2022-08-05.md
@@ -4,7 +4,7 @@ date = "2022-08-05T19:46:28Z"
 path = "/blog/2022/08/05/this-week-in-matrix-2022-08-05"
 
 [taxonomies]
-author = ["Andrew Morgan (anoa)"]
+author = ["Andrew Morgan"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2022/08/2022-08-12-this-week-in-matrix-2022-08-12.md
+++ b/content/blog/2022/08/2022-08-12-this-week-in-matrix-2022-08-12.md
@@ -3,7 +3,7 @@ title = "This Week in Matrix 2022-08-12"
 path = "/blog/2022/08/12/this-week-in-matrix-2022-08-12"
 
 [taxonomies]
-author = ["Andrew Morgan (anoa)"]
+author = ["Andrew Morgan"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2022/08/2022-08-31-security-releases-matrix-js-sdk-19-4-0-and-matrix-react-sdk-3-53-0.md
+++ b/content/blog/2022/08/2022-08-31-security-releases-matrix-js-sdk-19-4-0-and-matrix-react-sdk-3-53-0.md
@@ -4,7 +4,7 @@ date = "2022-08-31T18:13:45Z"
 path = "/blog/2022/08/31/security-releases-matrix-js-sdk-19-4-0-and-matrix-react-sdk-3-53-0"
 
 [taxonomies]
-author = ["Denis Kasak (dkasak)"]
+author = ["Denis Kasak"]
 category = ["Releases", "Security"]
 +++
 

--- a/content/blog/2022/09/2022-09-13-security-release-of-matrix-appservice-irc-0-35-0-high-severity.md
+++ b/content/blog/2022/09/2022-09-13-security-release-of-matrix-appservice-irc-0-35-0-high-severity.md
@@ -4,7 +4,7 @@ date = "2022-09-13T16:56:43Z"
 path = "/blog/2022/09/13/security-release-of-matrix-appservice-irc-0-35-0-high-severity"
 
 [taxonomies]
-author = ["Denis Kasak (dkasak)"]
+author = ["Denis Kasak"]
 category = ["Releases", "Security"]
 +++
 

--- a/content/blog/2022/09/2022-09-23-pre-disclosure-upcoming-critical-security-release-of-matrix-sd-ks-and-clients.md
+++ b/content/blog/2022/09/2022-09-23-pre-disclosure-upcoming-critical-security-release-of-matrix-sd-ks-and-clients.md
@@ -4,7 +4,7 @@ date = "2022-09-23T14:53:12Z"
 path = "/blog/2022/09/23/pre-disclosure-upcoming-critical-security-release-of-matrix-sd-ks-and-clients"
 
 [taxonomies]
-author = ["Matrix Security"]
+author = ["Matrix Security Team"]
 category = ["Security"]
 +++
 

--- a/content/blog/2022/12/2022-12-16-this-week-in-matrix-2022-12-16.md
+++ b/content/blog/2022/12/2022-12-16-this-week-in-matrix-2022-12-16.md
@@ -4,7 +4,7 @@ date = "2022-12-16T19:51:14Z"
 path = "/blog/2022/12/16/this-week-in-matrix-2022-12-16"
 
 [taxonomies]
-author = ["uhoreg"]
+author = ["Hubert Chathi"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2022/12/2022-12-23-this-week-in-matrix-2022-12-23.md
+++ b/content/blog/2022/12/2022-12-23-this-week-in-matrix-2022-12-23.md
@@ -4,7 +4,7 @@ date = "2022-12-23T19:38:10Z"
 path = "/blog/2022/12/23/this-week-in-matrix-2022-12-23"
 
 [taxonomies]
-author = ["uhoreg"]
+author = ["Hubert Chathi"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2023/02/2023-02-03-this-week-in-matrix-2023-02-03.md
+++ b/content/blog/2023/02/2023-02-03-this-week-in-matrix-2023-02-03.md
@@ -4,7 +4,7 @@ date = "2023-02-04T00:31:01Z"
 path = "/blog/2023/02/03/this-week-in-matrix-2023-02-03"
 
 [taxonomies]
-author = ["uhoreg"]
+author = ["Hubert Chathi"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2023/03/2023-03-28-security-releases-matrix-js-sdk-24-0-0-and-matrix-react-sdk-3-69-0.md
+++ b/content/blog/2023/03/2023-03-28-security-releases-matrix-js-sdk-24-0-0-and-matrix-react-sdk-3-69-0.md
@@ -3,7 +3,7 @@ title = "Security releases: matrix-js-sdk 24.0.0 and matrix-react-sdk 3.69.0"
 path = "/blog/2023/03/28/security-releases-matrix-js-sdk-24-0-0-and-matrix-react-sdk-3-69-0"
 
 [taxonomies]
-author = ["Denis Kasak (dkasak)"]
+author = ["Denis Kasak"]
 category = ["Releases", "Security"]
 +++
 

--- a/content/blog/2023/05/2023-05-19-this-week-in-matrix-2023-05-19.md
+++ b/content/blog/2023/05/2023-05-19-this-week-in-matrix-2023-05-19.md
@@ -3,7 +3,7 @@ title = "This Week in Matrix 2023-05-19"
 path = "/blog/2023/05/19/this-week-in-matrix-2023-05-19"
 
 [taxonomies]
-author = ["Andrew Morgan (anoa)"]
+author = ["Andrew Morgan"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2023/05/2023-05-24-disclosing-synapse-security-advisories.md
+++ b/content/blog/2023/05/2023-05-24-disclosing-synapse-security-advisories.md
@@ -5,7 +5,7 @@ updated = "2023-05-24T13:36:50Z"
 path = "/blog/2023/05/24/disclosing-synapse-security-advisories"
 
 [taxonomies]
-author = ["Denis Kasak (dkasak)"]
+author = ["Denis Kasak"]
 category = ["Security"]
 +++
 

--- a/content/blog/2023/05/2023-05-26-this-week-in-matrix-2023-05-26.md
+++ b/content/blog/2023/05/2023-05-26-this-week-in-matrix-2023-05-26.md
@@ -5,7 +5,7 @@ updated = "2023-05-26T20:24:34Z"
 path = "/blog/2023/05/26/this-week-in-matrix-2023-05-26"
 
 [taxonomies]
-author = ["uhoreg"]
+author = ["Hubert Chathi"]
 category = ["This Week in Matrix"]
 +++
 

--- a/content/blog/2023/06/2023-06-20-membership-program.md
+++ b/content/blog/2023/06/2023-06-20-membership-program.md
@@ -3,7 +3,7 @@ title = "Announcing the Matrix.org Foundation Membership program!"
 date = "2023-06-20T13:00:00Z"
 
 [taxonomies]
-author = ["Amandine"]
+author = ["Amandine Le Pape"]
 category = ["Foundation"]
 
 [extra]

--- a/content/blog/2023/07/2023-07-04-what-happened-with-the-archive.md
+++ b/content/blog/2023/07/2023-07-04-what-happened-with-the-archive.md
@@ -3,7 +3,7 @@ date = "2023-07-04T14:24:00Z"
 title = "What happened with archive.matrix.org"
 
 [taxonomies]
-author = ["Matthew", "Thib"]
+author = ["Matthew Hodgson", "Thib"]
 category = ["General"]
 +++
 

--- a/content/blog/2023/07/2023-07-14-twim.md
+++ b/content/blog/2023/07/2023-07-14-twim.md
@@ -3,7 +3,7 @@ date = "2023-07-14"
 title = "This Week in Matrix 2023-07-14"
 
 [taxonomies]
-author = ["uhoreg"]
+author = ["Hubert Chathi"]
 category = ["This Week in Matrix"]
 
 [extra]

--- a/content/blog/2023/07/2023-07-18-a-giant-leap-with-mls.md
+++ b/content/blog/2023/07/2023-07-18-a-giant-leap-with-mls.md
@@ -4,7 +4,7 @@ title = "A giant leap forwards for encryption with MLS"
 path = "/blog/2023/07/a-giant-leap-with-mls"
 
 [taxonomies]
-author = ["Matthew", "Hubert"]
+author = ["Matthew Hodgson", "Hubert Chathi"]
 category = ["Encryption"]
 
 [extra]


### PR DESCRIPTION
There were some author names duplicated or merged into a single string. This commit fixes that.

![image](https://github.com/matrix-org/matrix.org/assets/1374914/7b4d1088-f879-4a97-afc8-60a042d68e95)

Based on the overview at https://matrix.org/author/