### PR TITLE
security-disclosure-policy: Remove typical triage confirmation time

### DIFF
--- a/content/security-disclosure-policy.md
+++ b/content/security-disclosure-policy.md
@@ -32,7 +32,7 @@ with us first.
 On receipt, the security team will:
 
 - Review the report, verify the vulnerability and respond with confirmation
-  and/or further information requests; we typically reply within 24 hours.
+  and/or further information requests.
 - Once the reported security bug has been addressed we will notify the
   Researcher, who is then welcome to optionally disclose publicly.
 


### PR DESCRIPTION
In my experience, it does not seem to be correct:

* NVT#1532845: 7 days
* NVT#1533594: five minutes
* NVT#1534420: 3 months
* NVT#1534963: 2 months
* NVT#1536926: submitted on 2022-08-15, no reply yet
* NVT#1537459 and NVT#1537460: 3 days
* NVT#1539520: 17 hours
* NVT#1545463: 3 days
* NVT#1546367: 26 hours
* NVT#1550329: submitted on 2023-07-12, no reply yet