### PR TITLE
Add anchor links

### DIFF
--- a/content/blog/2014/09/_index.md
+++ b/content/blog/2014/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2014/10/_index.md
+++ b/content/blog/2014/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2014/11/_index.md
+++ b/content/blog/2014/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2014/12/_index.md
+++ b/content/blog/2014/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2014/_index.md
+++ b/content/blog/2014/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/01/_index.md
+++ b/content/blog/2015/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/02/_index.md
+++ b/content/blog/2015/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/03/_index.md
+++ b/content/blog/2015/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/04/_index.md
+++ b/content/blog/2015/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/05/_index.md
+++ b/content/blog/2015/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/06/_index.md
+++ b/content/blog/2015/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/07/_index.md
+++ b/content/blog/2015/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/08/_index.md
+++ b/content/blog/2015/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/09/_index.md
+++ b/content/blog/2015/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/10/_index.md
+++ b/content/blog/2015/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/11/_index.md
+++ b/content/blog/2015/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/12/_index.md
+++ b/content/blog/2015/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2015/_index.md
+++ b/content/blog/2015/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/01/_index.md
+++ b/content/blog/2016/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/02/_index.md
+++ b/content/blog/2016/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/03/_index.md
+++ b/content/blog/2016/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/04/_index.md
+++ b/content/blog/2016/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/05/_index.md
+++ b/content/blog/2016/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/07/_index.md
+++ b/content/blog/2016/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/08/_index.md
+++ b/content/blog/2016/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/09/_index.md
+++ b/content/blog/2016/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/10/_index.md
+++ b/content/blog/2016/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/11/_index.md
+++ b/content/blog/2016/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/12/_index.md
+++ b/content/blog/2016/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2016/_index.md
+++ b/content/blog/2016/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/01/_index.md
+++ b/content/blog/2017/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/02/_index.md
+++ b/content/blog/2017/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/03/_index.md
+++ b/content/blog/2017/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/04/_index.md
+++ b/content/blog/2017/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/05/_index.md
+++ b/content/blog/2017/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/06/_index.md
+++ b/content/blog/2017/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/07/_index.md
+++ b/content/blog/2017/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/08/_index.md
+++ b/content/blog/2017/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/09/_index.md
+++ b/content/blog/2017/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/10/_index.md
+++ b/content/blog/2017/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/11/_index.md
+++ b/content/blog/2017/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/12/_index.md
+++ b/content/blog/2017/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2017/_index.md
+++ b/content/blog/2017/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/01/_index.md
+++ b/content/blog/2018/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/02/_index.md
+++ b/content/blog/2018/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/03/_index.md
+++ b/content/blog/2018/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/04/_index.md
+++ b/content/blog/2018/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/05/_index.md
+++ b/content/blog/2018/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/06/_index.md
+++ b/content/blog/2018/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/07/_index.md
+++ b/content/blog/2018/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/08/_index.md
+++ b/content/blog/2018/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/09/_index.md
+++ b/content/blog/2018/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/10/_index.md
+++ b/content/blog/2018/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/11/_index.md
+++ b/content/blog/2018/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/12/_index.md
+++ b/content/blog/2018/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2018/_index.md
+++ b/content/blog/2018/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/01/_index.md
+++ b/content/blog/2019/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/02/_index.md
+++ b/content/blog/2019/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/03/_index.md
+++ b/content/blog/2019/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/04/_index.md
+++ b/content/blog/2019/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/05/_index.md
+++ b/content/blog/2019/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/06/_index.md
+++ b/content/blog/2019/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/07/_index.md
+++ b/content/blog/2019/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/08/_index.md
+++ b/content/blog/2019/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/09/_index.md
+++ b/content/blog/2019/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/10/_index.md
+++ b/content/blog/2019/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/11/_index.md
+++ b/content/blog/2019/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/12/_index.md
+++ b/content/blog/2019/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2019/_index.md
+++ b/content/blog/2019/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/01/_index.md
+++ b/content/blog/2020/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/02/_index.md
+++ b/content/blog/2020/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/03/_index.md
+++ b/content/blog/2020/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/04/_index.md
+++ b/content/blog/2020/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/05/_index.md
+++ b/content/blog/2020/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/06/_index.md
+++ b/content/blog/2020/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/07/_index.md
+++ b/content/blog/2020/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/08/_index.md
+++ b/content/blog/2020/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/09/_index.md
+++ b/content/blog/2020/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/10/_index.md
+++ b/content/blog/2020/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/11/_index.md
+++ b/content/blog/2020/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/12/_index.md
+++ b/content/blog/2020/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2020/_index.md
+++ b/content/blog/2020/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/01/_index.md
+++ b/content/blog/2021/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/02/_index.md
+++ b/content/blog/2021/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/03/_index.md
+++ b/content/blog/2021/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/04/_index.md
+++ b/content/blog/2021/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/05/_index.md
+++ b/content/blog/2021/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/06/_index.md
+++ b/content/blog/2021/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/07/_index.md
+++ b/content/blog/2021/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/08/_index.md
+++ b/content/blog/2021/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/09/_index.md
+++ b/content/blog/2021/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/10/_index.md
+++ b/content/blog/2021/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/11/_index.md
+++ b/content/blog/2021/11/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/12/_index.md
+++ b/content/blog/2021/12/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2021/_index.md
+++ b/content/blog/2021/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/01/_index.md
+++ b/content/blog/2022/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/02/_index.md
+++ b/content/blog/2022/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/03/_index.md
+++ b/content/blog/2022/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/04/_index.md
+++ b/content/blog/2022/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/05/_index.md
+++ b/content/blog/2022/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/06/_index.md
+++ b/content/blog/2022/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/07/_index.md
+++ b/content/blog/2022/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/08/_index.md
+++ b/content/blog/2022/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/09/_index.md
+++ b/content/blog/2022/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/10/_index.md
+++ b/content/blog/2022/10/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2022/_index.md
+++ b/content/blog/2022/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/01/_index.md
+++ b/content/blog/2023/01/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/02/_index.md
+++ b/content/blog/2023/02/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/03/_index.md
+++ b/content/blog/2023/03/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/04/_index.md
+++ b/content/blog/2023/04/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/05/_index.md
+++ b/content/blog/2023/05/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/06/_index.md
+++ b/content/blog/2023/06/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/07/_index.md
+++ b/content/blog/2023/07/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/08/_index.md
+++ b/content/blog/2023/08/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/09/_index.md
+++ b/content/blog/2023/09/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/2023/_index.md
+++ b/content/blog/2023/_index.md
@@ -1,4 +1,5 @@
 +++
 transparent = true
 render = false
+insert_anchor_links = "left"
 +++

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -9,4 +9,5 @@ The Matrix.org Foundation blog is where the Matrix Foundation and Community
 post updates on their activity. Every Friday evening they publish This Week In
 Matrix, a digest of the past week activity.
 """
+insert_anchor_links = "left"
 +++

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,4 +2,5 @@
 title = "Documentation"
 render = false
 extra.updated = "2022-10-18T16:00:00Z"
+insert_anchor_links = "left"
 +++

--- a/content/docs/chat_basics/_index.md
+++ b/content/docs/chat_basics/_index.md
@@ -7,4 +7,5 @@ render = false
 emoji = "🧑"
 tile = "Learn the basics on how to chat on Matrix, for individuals"
 updated = "2022-10-18T16:00:00Z"
+insert_anchor_links = "left"
 +++

--- a/content/docs/chat_basics/matrix-for-im/_index.md
+++ b/content/docs/chat_basics/matrix-for-im/_index.md
@@ -9,6 +9,7 @@ meta_description = """
 Matrix is an open protocol many apps can use for secure, decentralised
 communications. Your first steps with Matrix start here.
 """
+insert_anchor_links = "left"
 +++
 
 ## What is it?

--- a/content/docs/chat_basics/private-group-chat/_index.md
+++ b/content/docs/chat_basics/private-group-chat/_index.md
@@ -11,6 +11,7 @@ Matrix can be used to create small private group chats. It can be used to send
 messages, invite others, but it also has moderation features to keep the group
 safe.
 """
+insert_anchor_links = "left"
 +++
 
 The simplest way to get started is to create a private group chat so you can

--- a/content/docs/chat_basics/public-rooms/_index.md
+++ b/content/docs/chat_basics/public-rooms/_index.md
@@ -11,6 +11,7 @@ Matrix is often use for public online discussions. Being an interoperable
 protocol, it allows people using different providers to talk together online,
 safely.
 """
+insert_anchor_links = "left"
 +++
 
 When you want to join larger public conversations, you have three major options

--- a/content/docs/communities/_index.md
+++ b/content/docs/communities/_index.md
@@ -7,4 +7,5 @@ render = false
 emoji = "👪"
 tile = "Create a cozy place on Matrix for your community or organisation"
 updated = "2022-11-18T09:50:00Z"
+insert_anchor_links = "left"
 +++

--- a/content/docs/communities/bridging/_index.md
+++ b/content/docs/communities/bridging/_index.md
@@ -6,6 +6,7 @@ weight = 400
 emoji = "🌉"
 tile = "I want to bridge my community from another platform with Matrix"
 updated = "2022-11-18T09:50:00Z"
+insert_anchor_links = "left"
 +++
 
 The easiest way to bridge your Matrix community with you Discord one is to rely

--- a/content/docs/communities/getting-started/_index.md
+++ b/content/docs/communities/getting-started/_index.md
@@ -11,6 +11,7 @@ meta_description = """
 Everyone can start their community on Matrix by creating a Matrix Space.
 Community Managers can then tweak the Space to their needs.
 """
+insert_anchor_links = "left"
 +++
 
 We strongly recommend getting familiar with Matrix as an individual. It's easy

--- a/content/docs/communities/moderation/_index.md
+++ b/content/docs/communities/moderation/_index.md
@@ -11,6 +11,7 @@ Matrix allows communities to stay safe thanks to moderation tools. Mjolnir is
 the recommended solution for community managers who want to fight abuse on
 Matrix.
 """
+insert_anchor_links = "left"
 +++
 
 ## Power levels

--- a/content/docs/communities/switching-providers/_index.md
+++ b/content/docs/communities/switching-providers/_index.md
@@ -11,6 +11,7 @@ Even after creating a community on a provider, it's possible to switch to
 another one. This allows communities to get more sovereignty on their
 conversations, and to connect them to their own systems.
 """
+insert_anchor_links = "left"
 +++
 
 ## Why switching providers?

--- a/content/docs/legacy/_index.md
+++ b/content/docs/legacy/_index.md
@@ -11,6 +11,7 @@ meta_description = """
 This section contains all the documentation previously published that is no
 longer relevant or maintained. It is kept online for archive purposes.
 """
+insert_anchor_links = "left"
 +++
 
 This section contains all the outdated documentation from the former matrix.org

--- a/content/docs/matrix-concepts/_index.md
+++ b/content/docs/matrix-concepts/_index.md
@@ -6,4 +6,5 @@ render = false
 emoji = "⚒️"
 tile = "Learn more about the inner working of Matrix"
 updated = "2023-02-08T08:00:00Z"
+insert_anchor_links = "left"
 +++

--- a/content/docs/matrix-concepts/elements-of-matrix/_index.md
+++ b/content/docs/matrix-concepts/elements-of-matrix/_index.md
@@ -10,6 +10,7 @@ Matrix relies on homeservers to connect clients together. Appservices are
 pieces of software that can bridge Matrix and third-party platforms together.
 The Matrix Specification defines the interactions between all those.
 """
+insert_anchor_links = "left"
 +++
 
 {{ howitworks() }}

--- a/content/docs/matrix-concepts/rooms_and_events/_index.md
+++ b/content/docs/matrix-concepts/rooms_and_events/_index.md
@@ -9,6 +9,7 @@ Matrix relies on rooms to distribute events across servers and clients. Rooms
 have a hierarchy based on power levels. Each homeserver has its own copy of all
 the rooms all their users belong to.
 """
+insert_anchor_links = "left"
 +++
 
 Users on a server can send *events* into *rooms*. An event is a particular json

--- a/content/ecosystem/_index.md
+++ b/content/ecosystem/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "The Matrix Ecosystem"
 sort_by = "weight"
+insert_anchor_links = "left"
 +++
 
 *To be filled with content, maybe*

--- a/content/ecosystem/bridges/_index.md
+++ b/content/ecosystem/bridges/_index.md
@@ -6,6 +6,7 @@ extra.summary = """
 Bridges allow you to connect Matrix to a third-party platform, and interact
 seamlessly.
 """
+insert_anchor_links = "left"
 +++
 
 An important idea in Matrix is Interoperability. This means that Matrix is open

--- a/content/ecosystem/bridges/discord/_index.md
+++ b/content/ecosystem/bridges/discord/_index.md
@@ -2,4 +2,5 @@
 title = "Discord"
 weight = 100
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/email/_index.md
+++ b/content/ecosystem/bridges/email/_index.md
@@ -2,4 +2,5 @@
 title = "Email"
 weight = 1500
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/facebook_messenger/_index.md
+++ b/content/ecosystem/bridges/facebook_messenger/_index.md
@@ -2,4 +2,5 @@
 title = "Messenger"
 weight = 600
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/google_chat/_index.md
+++ b/content/ecosystem/bridges/google_chat/_index.md
@@ -2,4 +2,5 @@
 title = "Google Chat"
 weight = 900
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/groupme/_index.md
+++ b/content/ecosystem/bridges/groupme/_index.md
@@ -2,4 +2,5 @@
 title = "GroupMe"
 weight = 1900
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/imessage/_index.md
+++ b/content/ecosystem/bridges/imessage/_index.md
@@ -2,4 +2,5 @@
 title = "iMessage"
 weight = 700
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/instagram/_index.md
+++ b/content/ecosystem/bridges/instagram/_index.md
@@ -2,4 +2,5 @@
 title = "Instagram"
 weight = 1000
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/irc/_index.md
+++ b/content/ecosystem/bridges/irc/_index.md
@@ -2,4 +2,5 @@
 title = "IRC"
 weight = 1600
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/kakaotalk/_index.md
+++ b/content/ecosystem/bridges/kakaotalk/_index.md
@@ -2,4 +2,5 @@
 title = "KakaoTalk"
 weight = 1800
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/line/_index.md
+++ b/content/ecosystem/bridges/line/_index.md
@@ -2,4 +2,5 @@
 title = "LINE"
 weight = 2000
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/linkedin/_index.md
+++ b/content/ecosystem/bridges/linkedin/_index.md
@@ -2,4 +2,5 @@
 title = "LinkedIn"
 weight = 1100
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/mastodon/_index.md
+++ b/content/ecosystem/bridges/mastodon/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "Mastodon"
 weight = 1700
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/mattermost/_index.md
+++ b/content/ecosystem/bridges/mattermost/_index.md
@@ -2,4 +2,5 @@
 title = "Mattermost"
 weight = 800
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/mumble/_index.md
+++ b/content/ecosystem/bridges/mumble/_index.md
@@ -2,4 +2,5 @@
 title = "Mumble"
 weight = 999
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/signal/_index.md
+++ b/content/ecosystem/bridges/signal/_index.md
@@ -2,4 +2,5 @@
 title = "Signal"
 weight = 300
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/skype/_index.md
+++ b/content/ecosystem/bridges/skype/_index.md
@@ -2,4 +2,5 @@
 title = "Skype"
 weight = 1300
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/slack/_index.md
+++ b/content/ecosystem/bridges/slack/_index.md
@@ -2,4 +2,5 @@
 title = "Slack"
 weight = 200
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/sms/_index.md
+++ b/content/ecosystem/bridges/sms/_index.md
@@ -2,4 +2,5 @@
 title = "SMS"
 weight = 1400
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/telegram/_index.md
+++ b/content/ecosystem/bridges/telegram/_index.md
@@ -2,4 +2,5 @@
 title = "Telegram"
 weight = 400
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/tencent_qq/_index.md
+++ b/content/ecosystem/bridges/tencent_qq/_index.md
@@ -2,4 +2,5 @@
 title = "Tencent QQ"
 weight = 2200
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/tox/_index.md
+++ b/content/ecosystem/bridges/tox/_index.md
@@ -1,4 +1,5 @@
 +++
 title = "Tox"
 weight = 2300
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/twitter/_index.md
+++ b/content/ecosystem/bridges/twitter/_index.md
@@ -2,4 +2,5 @@
 title = "Twitter"
 weight = 1200
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/wechat/_index.md
+++ b/content/ecosystem/bridges/wechat/_index.md
@@ -2,4 +2,5 @@
 title = "WeChat"
 weight = 2100
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/whatsapp/_index.md
+++ b/content/ecosystem/bridges/whatsapp/_index.md
@@ -2,4 +2,5 @@
 title = "WhatsApp"
 weight = 500
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/bridges/xmpp/_index.md
+++ b/content/ecosystem/bridges/xmpp/_index.md
@@ -2,4 +2,5 @@
 title = "XMPP"
 weight = 2400
 template = "ecosystem/bridge_implementations.html"
+insert_anchor_links = "left"
 +++

--- a/content/ecosystem/clients/_index.md
+++ b/content/ecosystem/clients/_index.md
@@ -7,4 +7,5 @@ extra.summary = """
 The Matrix ecosystem is vibrant. Whatever platform you use, someone has probably
 already developed a client for it. 
 """
+insert_anchor_links = "left"
 +++

--- a/content/legal/_index.md
+++ b/content/legal/_index.md
@@ -2,4 +2,5 @@
 title = "Legal"
 template = "legal.html"
 sort_by = "title"
+insert_anchor_links = "left"
 +++


### PR DESCRIPTION
See https://www.getzola.org/documentation/content/section/#front-matter after the configs, it writes:

"Keep in mind that any configuration options apply only to the direct pages, not to the subsections' pages."

So it must be applied to all _index.md for it to be everywhere.

I have not applied the same thing for folders without a `_index.md` file, and anchor links doesn't seem to be applied to `<h1>` elements (maybe within `<header>`). It's possible I may have missed something.

fixes #1760