### PR TITLE
fix postmoogle docs link

### DIFF
--- a/content/ecosystem/bridges/email/bridges.toml
+++ b/content/ecosystem/bridges/email/bridges.toml
@@ -8,7 +8,7 @@ Postmoogle is an actual SMTP server that allows you to send and receive emails o
 maturity = "Stable"
 language = "Go"
 license = "GPL-3.0"
-docs = "https://etke.cc/help/bridges/postmoogle"
+docs = "https://gitlab.com/etke.cc/postmoogle/-/blob/main/README.md"
 repo = "https://gitlab.com/etke.cc/postmoogle"
 room = "#postmoogle:etke.cc"
 featured = false


### PR DESCRIPTION
https://etke.cc/help/bridges/postmoogle is a quick start guide for etke.cc customers, using configuration patterns specific to etke.cc. The actual bridge documentation is in the README.md file and docs/ dir within the bridge repo