### PR TITLE
Expand feed link to all pages.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,6 @@
 {% block head_extra %}
 <meta name="description"
     content="The homepage of the matrix.org website. Chat securely with your family, friends, community, or build great apps with Matrix!">
-<link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
 {% endblock head_extra %}
 {% block content %}
 {% set sponsors_data = load_data(path="content/sponsors.toml") %}

--- a/templates/skel.html
+++ b/templates/skel.html
@@ -45,6 +45,7 @@
     <link rel="shortcut icon" href="/assets/favicon.ico" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/style.css" />
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
 
     {% block head_extra %}{% endblock head_extra -%}
 </head>


### PR DESCRIPTION
Previously the link was only present on the index, but this meant that it was easy to miss that the feed existed when viewing other pages, notably the blog pages.