### PR TITLE
Update matrix-commander.mdx

### DIFF
--- a/gatsby/content/projects/clients/matrix-commander.mdx
+++ b/gatsby/content/projects/clients/matrix-commander.mdx
@@ -17,7 +17,7 @@ screenshot:
 featured: true
 platforms:
     - Linux
-    - Mac
+    - MacOS
     - Windows
 client_type: terminal
 features:


### PR DESCRIPTION
matrix-commander also supports MacOS and Windows, but on matrix.org webpage only Linux is listed. Why? How can I add MacOS and Windows to the platform list?