### PR TITLE
Add missing <!-- more --> separators to latest two articles

### DIFF
--- a/content/blog/2023/10/2023-10-06-twim.md
+++ b/content/blog/2023/10/2023-10-06-twim.md
@@ -56,6 +56,8 @@ image = "https://matrix.org/blog/img/matrix-logo.png"
 >
 > Clients can activate this extension when making a request to the sliding sync endpoint. See the [Extensions](https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#extensions) section of MSC3575 for details.
 
+<!-- more -->
+
 ## Dept of Servers 🏢
 
 ### Synapse ([website](https://github.com/matrix-org/synapse/))

--- a/content/blog/2023/10/2023-10-13-twim.md
+++ b/content/blog/2023/10/2023-10-13-twim.md
@@ -51,6 +51,8 @@ image = "https://matrix.org/blog/img/matrix-logo.png"
 > 
 > I don't think Identity Servers get much love today, but this sounds like a no-brainer to add. Go forth and comment on if it sounds interesting to you!
 
+<!-- more -->
+
 ## Dept of Servers 🏢
 
 ### Synapse ([website](https://github.com/matrix-org/synapse/))


### PR DESCRIPTION
Some of these spec updates are real long, I'd prefer the separator to be after Matrix live (or maybe the first heading? a bit weird), but have put it after the spec updates for consistency.