### PR TITLE
Ensure we add images to the NewArticle metadata

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -15,6 +15,19 @@
     {% if page.updated %}
     "dateModified": "{{ page.updated | date(format="%Y-%m-%dT%H:%M+00:00") }}",
     {% endif %}
+    {% if page.extra.image %}
+    "image": [
+        "{{ page.extra.image }}"
+    ],
+    {% elif section.extra.image %}
+    "image": [
+        "{{ section.extra.image }}"
+    ],
+    {% else %}
+    "image": [
+        "https://matrix.org/blog/img/matrix-logo.png"
+    ],
+    {% endif %}
     "author": [
     {% for author in page.taxonomies.author %}
     {


### PR DESCRIPTION
This removes a small warning which google has in their validator. And since we now do images on posts this is a simple fix.