### PR TITLE
Update NeoChat client description

### DIFF
--- a/content/ecosystem/clients/neochat.md
+++ b/content/ecosystem/clients/neochat.md
@@ -5,7 +5,7 @@ thumbnail = "neochat.svg"
 maintainer = "Carl Schwan, Tobias Fella"
 licence = "GPL-3.0-only"
 language = "C++"
-last_release = "2023-04-12"
+last_release = "2023-11-09"
 maturity = "Beta"
 repo = "https://invent.kde.org/network/neochat"
 website = "https://apps.kde.org/neochat"
@@ -13,7 +13,7 @@ matrix_room = "#neochat:kde.org"
 featured = false
 [extra.features]
 e2ee = true
-spaces = false
+spaces = true
 voip_1to1 = false
 voip_jitsi = false
 widgets = false


### PR DESCRIPTION
The client has gained support for spaces. It is unknown to me when did that happen, as it is not mentioned in the changelog.
I have also updated the date of last release according to [the app's website](https://apps.kde.org/neochat/).