### PR TITLE
Update servers.toml

### DIFF
--- a/content/ecosystem/servers/servers.toml
+++ b/content/ecosystem/servers/servers.toml
@@ -4,7 +4,7 @@ description = "Matrix.org homeserver"
 author = "Matrix.org team"
 maturity = "Stable"
 language = "Python"
-licence = "Apache-2.0"
+licence = "AGPL-3.0-or-later"
 repository = "https://github.com/element-hq/synapse"
 room = "#synapse:matrix.org"
 

--- a/content/ecosystem/servers/servers.toml
+++ b/content/ecosystem/servers/servers.toml
@@ -5,7 +5,7 @@ author = "Matrix.org team"
 maturity = "Stable"
 language = "Python"
 licence = "Apache-2.0"
-repository = "https://github.com/matrix-org/synapse/"
+repository = "https://github.com/element-hq/synapse"
 room = "#synapse:matrix.org"
 
 [[servers]]


### PR DESCRIPTION
This PR updates the Synapse repository link on the Servers page (<https://matrix.org/ecosystem/servers>) to reflect the project's move from matrix-org to element-hq.