### PR TITLE
Stop advertising lack of widget support

### DIFF
--- a/content/ecosystem/clients/cinny.md
+++ b/content/ecosystem/clients/cinny.md
@@ -16,7 +16,6 @@ e2ee = true
 spaces = true
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = true
 multi_account = false

--- a/content/ecosystem/clients/commet.md
+++ b/content/ecosystem/clients/commet.md
@@ -16,7 +16,6 @@ e2ee = true
 spaces = true
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = false
 multi_account = true

--- a/content/ecosystem/clients/element-x.md
+++ b/content/ecosystem/clients/element-x.md
@@ -15,7 +15,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = true
 threads = false
 sso = false
 multi_account = false

--- a/content/ecosystem/clients/element.md
+++ b/content/ecosystem/clients/element.md
@@ -15,7 +15,6 @@ e2ee = true
 spaces = true
 voip_1to1 = true
 voip_jitsi = true
-widgets = true
 threads = true
 sso = true
 multi_account = false

--- a/content/ecosystem/clients/fluffychat.md
+++ b/content/ecosystem/clients/fluffychat.md
@@ -17,7 +17,6 @@ e2ee = true
 spaces = true
 voip_1to1 = true
 voip_jitsi = true
-widgets = false
 threads = false
 sso = true
 multi_account = true

--- a/content/ecosystem/clients/fractal.md
+++ b/content/ecosystem/clients/fractal.md
@@ -15,7 +15,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = true
 multi_account = true

--- a/content/ecosystem/clients/gomuks.md
+++ b/content/ecosystem/clients/gomuks.md
@@ -14,7 +14,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = true
 multi_account = false

--- a/content/ecosystem/clients/gotktrix.md
+++ b/content/ecosystem/clients/gotktrix.md
@@ -13,7 +13,6 @@ e2ee = false
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = true
 multi_account = true

--- a/content/ecosystem/clients/hydrogen.md
+++ b/content/ecosystem/clients/hydrogen.md
@@ -14,7 +14,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = true
 multi_account = true

--- a/content/ecosystem/clients/iamb.md
+++ b/content/ecosystem/clients/iamb.md
@@ -15,7 +15,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 threads = false
 sso = false
 multi_account = true

--- a/content/ecosystem/clients/kazv.md
+++ b/content/ecosystem/clients/kazv.md
@@ -15,7 +15,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = false
 multi_account = false
 multi_language = false

--- a/content/ecosystem/clients/matrix-commander.md
+++ b/content/ecosystem/clients/matrix-commander.md
@@ -14,7 +14,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = true
 multi_account = false
 multi_language = false

--- a/content/ecosystem/clients/mnotify.md
+++ b/content/ecosystem/clients/mnotify.md
@@ -14,7 +14,6 @@ e2ee = false
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = false
 multi_account = false
 multi_language = false

--- a/content/ecosystem/clients/neochat.md
+++ b/content/ecosystem/clients/neochat.md
@@ -16,7 +16,6 @@ e2ee = true
 spaces = true
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = true
 multi_account = true
 multi_language = true

--- a/content/ecosystem/clients/nheko.md
+++ b/content/ecosystem/clients/nheko.md
@@ -16,7 +16,6 @@ e2ee = true
 spaces = true
 voip_1to1 = true
 voip_jitsi = false
-widgets = false
 threads = true
 sso = true
 multi_account = false

--- a/content/ecosystem/clients/quadrix.md
+++ b/content/ecosystem/clients/quadrix.md
@@ -16,7 +16,6 @@ e2ee = false
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = false
 multi_account = false
 multi_language = false

--- a/content/ecosystem/clients/quaternion.md
+++ b/content/ecosystem/clients/quaternion.md
@@ -15,7 +15,6 @@ e2ee = false
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = true
 multi_account = true
 multi_language = false

--- a/content/ecosystem/clients/schildichat.md
+++ b/content/ecosystem/clients/schildichat.md
@@ -15,7 +15,6 @@ e2ee = true
 spaces = true
 voip_1to1 = true
 voip_jitsi = true
-widgets = true
 sso = true
 multi_account = false
 multi_language = true

--- a/content/ecosystem/clients/syphon.md
+++ b/content/ecosystem/clients/syphon.md
@@ -16,7 +16,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = true
 multi_account = true
 multi_language = true

--- a/content/ecosystem/clients/thunderbird.md
+++ b/content/ecosystem/clients/thunderbird.md
@@ -16,7 +16,6 @@ e2ee = true
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = true
 multi_account = true
 multi_language = true

--- a/content/ecosystem/clients/watch-the-matrix.md
+++ b/content/ecosystem/clients/watch-the-matrix.md
@@ -15,7 +15,6 @@ e2ee = false
 spaces = false
 voip_1to1 = false
 voip_jitsi = false
-widgets = false
 sso = false
 multi_account = false
 multi_language = true


### PR DESCRIPTION
Considering this feature is not even in the spec and only 3 out of 21 listed clients implement it, I don’t think it’s fair to have it in the list. We could do with one less unticked box on the page.

I only touched “my” client so far, but I can amend the PR to remove it from all the non-supporting ones if deemed appropriate. What do you reckon?

Of course, considering the page dynamically picks up whatever feature is listed in the Markdown file, clients that do implement widgets can keep the feature listed!