### PR TITLE
Track blog posts CTA

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -80,7 +80,7 @@
                         bridges for free. It fights for our collective rights to
                         digital privacy and dignity.
                     </p>
-                    <a class="call-to-action" href="/support">Support us</a>
+                    <a class="call-to-action plausible-event-name=BlogPostCtaSupportUs" href="/support">Support us</a>
                 </div>
             </div>
         </div>

--- a/templates/skel.html
+++ b/templates/skel.html
@@ -46,7 +46,7 @@
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/style.css" />
     <script async src="/js/components.js"></script>
-    <script defer data-domain="matrix.org" src="https://plausible.io/js/script.js"></script>
+    <script defer data-domain="matrix.org" src="https://plausible.io/js/script.tagged-events.js"></script>
 
 
     {% block head_extra %}{% endblock head_extra -%}


### PR DESCRIPTION
Changes the snippet to track custom events, needed according to https://plausible.io/docs/custom-event-goals#1-change-the-plausible-snippet-on-your-site

Adds the class name to track the CTA on the blog posts specifically, using the format specified in https://plausible.io/docs/custom-event-goals#you-can-also-add-class-names-directly-in-html
