### PR TITLE
fix: update maturity level of gomatrix SDK to "Obsolete"

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -66,7 +66,7 @@ A set of Rust crates for interacting with the Matrix chat network.
 [[sdks]]
 name = "gomatrix"
 maintainer = "Matrix.org"
-maturity = "Stable"
+maturity = "Obsolete"
 language = "Go"
 licence = "Apache-2.0"
 repository = "https://github.com/matrix-org/gomatrix"


### PR DESCRIPTION
Fixes https://fosstodon.org/@lil5/111940191501771658