### PR TITLE
Fix vertical centering of the matrix logo on matrix.org

### DIFF
--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -19,7 +19,7 @@
         overflow: hidden;
 
         .hero_content {
-            height: 100%;
+            height: 88%;
             display: flex;
             flex-direction: column;
             justify-content: center;


### PR DESCRIPTION
In classical graphical design you almost never center something to literally 50% of the height of the screen; instead you aim for the golden ratio of 0.618:1 rather than 1:1.  I've tweaked this a bit more to account for the visual density of the logo & accompanying text.  Closes https://github.com/matrix-org/matrix.org/issues/1836