### PR TITLE
Add MSC1929 support contacts

### DIFF
--- a/static/.well-known/matrix/support
+++ b/static/.well-known/matrix/support
@@ -1,0 +1,7 @@
+{
+  "support_page": "https://matrix.org/contact/",
+  "contacts": [
+    { "role": "m.role.admin", "email_address": "abuse@matrix.org" },
+    { "role": "m.role.security", "email_address": "security@matrix.org" }
+  ]
+}


### PR DESCRIPTION
The "admin" contact is largely meant to be used for reporting users and such, so we supply our abuse contact there.