### PR TITLE
minor fixes + transparency in staff arrangements

### DIFF
--- a/content/about/guardians.toml
+++ b/content/about/guardians.toml
@@ -9,14 +9,14 @@ Jon Crowcroft is the Marconi Professor of Communications Systems in the Computer
 name = "Matthew Hodgson"
 picture = "matthew.jpg"
 bio = """
-Matthew is technical co-founder of Matrix, and CEO/CTO of New Vector - the company formed in 2017 to let the core Matrix dev team work on Matrix full-time as their day job. He came up with the idea of Matrix with Amandine in 2013 while they were running Amdocs’ Unified Communication unit. He has a degree in Physics & Computer Science from the University of Cambridge.
+Matthew is technical co-founder of Matrix, and CEO/CTO of Element - the company formed in 2017 to let the core Matrix dev team work on Matrix full-time as their day job. He came up with the idea of Matrix with Amandine in 2013 while they were running Amdocs’ Unified Communication unit. He has a degree in Physics & Computer Science from the University of Cambridge.
 """
 
 [[guardians]]
 name = "Amandine Le Pape"
 picture = "amandine.jpg"
 bio = """
-Amandine is co-founder of Matrix, and COO of New Vector. She previously ran the business side of Amdocs’ UC unit with Matthew. She has an engineering degree in Telecoms, Electronics and Computer Science and uses it most to translate the technicalities of Matrix to humans and businesses, and make sure we keep the users at heart when making decisions!
+Amandine is co-founder of Matrix, and COO of Element. She previously ran the business side of Amdocs’ UC unit with Matthew. She has an engineering degree in Telecoms, Electronics and Computer Science and uses it most to translate the technicalities of Matrix to humans and businesses, and make sure we keep the users at heart when making decisions!
 """
 
 [[guardians]]

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -144,7 +144,12 @@ of the project and the definition of the Spec Core Team, which are [reproduced h
 
 ## Who We Are
 
-The ecosystem around Matrix is full of people who are enthusiastic about the mission to bring secure, interoperable, decentralised communication to the world. The Matrix.org Foundation, as the nonprofit that serves this ecosystem, is itself made up of many hard working people across several key groups that you can learn about on this page: [the staff of the Foundation](#the-staff-of-the-foundation), [the Spec Core Team](#the-spec-core-team), and [the Guardians](#the-guardians).
+The ecosystem around Matrix is full of people who are enthusiastic about the
+mission to bring secure, interoperable, decentralised communication to the world.
+The Matrix.org Foundation, as the nonprofit that serves this ecosystem, is itself
+made up of many hard working people across several key groups that you can learn
+about on this page: [the staff of the Foundation](#the-staff-of-the-foundation),
+[the Spec Core Team](#the-spec-core-team), and [the Guardians](#the-guardians).
 
 ### The Staff of the Foundation
 {{ staff() }}

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -152,6 +152,18 @@ about on this page: [the staff of the Foundation](#the-staff-of-the-foundation),
 [the Spec Core Team](#the-spec-core-team), and [the Guardians](#the-guardians).
 
 ### The Staff of the Foundation
+
+We have a small but mighty team of staffers who are responsible for the day-to-day
+operations of the Foundation. Because the organization doesn't yet have the capacity
+to take on employees directly, all of us are working under contract. We look forward
+to building the Foundation such that it can take on employees directly, in addition
+to being self-sustaining and more fully independent.
+
+In the interest of transparency, we think it's important for people to know that
+most of our staffers are employees of Element, working under a contract with, and
+funded by, the Foundation. The exception is our Managing Director who contracts
+directly with the Foundation.
+
 {{ staff() }}
 
 ### The Spec Core Team


### PR DESCRIPTION
Adding context to make sure we're being forthright and transparent about staff working arrangements (eg, most are seconded through Element).