### PR TITLE
fix broken links in kazv report

### DIFF
--- a/content/blog/2024/03/2024-03-01-twim.md
+++ b/content/blog/2024/03/2024-03-01-twim.md
@@ -94,57 +94,57 @@ Synapse is a Matrix homeserver implementation developed by the matrix.org core t
 > ### Added
 > 
 > * Use fluent for translations. <https://lily.kazv.moe/kazv/kazv/-/tree/tusooa/3-fluent>
-> * Support read and save client state. <https://lily.kazv.moe/kazv/kazv/-/merge\_requests/2>
-> * Support common event types. <https://lily.kazv.moe/kazv/kazv/-/merge\_requests/3>
-> * Add send message shortcut. <https://lily.kazv.moe/kazv/kazv/-/merge\_requests/7>
-> * Support auto-discovery and provide better login error messages. <https://lily.kazv.moe/kazv/kazv/-/merge\_requests/9>
-> * Add translations for Hindi(hi) <https://lily-is.land/kazv/kazv/-/merge\_requests/11>
-> * Use room heroes when there is no explicit room name. <https://lily-is.land/kazv/kazv/-/merge\_requests/15>
-> * Add media file menu for download. <https://lily-is.land/kazv/kazv/-/merge\_requests/14>
-> * Add a shortcut editor. <https://lily-is.land/kazv/kazv/-/merge\_requests/17>
-> * Add UI for sending media files, controlling pause and cancel, and display the progress in real time. <https://lily-is.land/kazv/kazv/-/merge\_requests/18>
-> * Use QtNetwork for job handling instead of libkazvjob. <https://lily-is.land/kazv/kazv/-/merge\_requests/21>
-> * Implement creating and joining rooms. <https://lily-is.land/kazv/kazv/-/merge\_requests/19>
-> * Add the ability to see users' devices and manage trust level. <https://lily-is.land/kazv/kazv/-/merge\_requests/23>
-> * Support local echo. <https://lily-is.land/kazv/kazv/-/merge\_requests/25>
-> * Support redaction. <https://lily-is.land/kazv/kazv/-/merge\_requests/28>
-> * Implement profile settings. <https://lily-is.land/kazv/kazv/-/merge\_requests/30>
-> * Support viewing event source. <https://lily-is.land/kazv/kazv/-/merge\_requests/32>
-> * Display hero avatar if it is a two-person room. <https://lily-is.land/kazv/kazv/-/merge\_requests/34>
-> * Support typing status. <https://lily-is.land/kazv/kazv/-/merge\_requests/33>
-> * Support room tagging. <https://lily-is.land/kazv/kazv/-/merge\_requests/35>
-> * Allow paginate back in the timeline. <https://lily-is.land/kazv/kazv/-/merge\_requests/38>
-> * Handle incoming invites. <https://lily-is.land/kazv/kazv/-/merge\_requests/39>
-> * Support displaying notifications for incoming messages. <https://lily-is.land/kazv/kazv/-/merge\_requests/40>
-> * Support leaving room. <https://lily-is.land/kazv/kazv/-/merge\_requests/41>
-> * Support sending and receiving encrypted media files. <https://lily-is.land/kazv/kazv/-/merge\_requests/20>
-> * Allow selecting message content. <https://lily-is.land/kazv/kazv/-/merge\_requests/44>
-> * Implement room member list view. <https://lily-is.land/kazv/kazv/-/merge\_requests/45>
-> * Handle message replies. <https://lily-is.land/kazv/kazv/-/merge\_requests/48>
-> * Implement reactions. <https://lily-is.land/kazv/kazv/-/merge\_requests/50>
-> * Use libkazv push rules to determine whether to notify for an event. <https://lily-is.land/kazv/kazv/-/merge\_requests/51>
-> * Implement displaying and changing users' power levels. <https://lily-is.land/kazv/kazv/-/merge\_requests/52>
-> * Add the ability to ban and unban user. <https://lily-is.land/kazv/kazv/-/merge\_requests/54>
-> * Sort rooms by descending order of latest event timestamp. <https://lily-is.land/kazv/kazv/-/merge\_requests/57>
-> * Implement kicking user. <https://lily-is.land/kazv/kazv/-/merge\_requests/58>
-> * Improve event view layout. <https://lily-is.land/kazv/kazv/-/merge\_requests/62>
-> * Install kazv logo to icon directory. <https://lily-is.land/kazv/kazv/-/merge\_requests/63>
-> * Implement inviting user. <https://lily-is.land/kazv/kazv/-/merge\_requests/65>
-> * Support inviting users when creating a room. <https://lily-is.land/kazv/kazv/-/merge\_requests/66>
+> * Support read and save client state. <https://lily.kazv.moe/kazv/kazv/-/merge_requests/2>
+> * Support common event types. <https://lily.kazv.moe/kazv/kazv/-/merge_requests/3>
+> * Add send message shortcut. <https://lily.kazv.moe/kazv/kazv/-/merge_requests/7>
+> * Support auto-discovery and provide better login error messages. <https://lily.kazv.moe/kazv/kazv/-/merge_requests/9>
+> * Add translations for Hindi(hi) <https://lily-is.land/kazv/kazv/-/merge_requests/11>
+> * Use room heroes when there is no explicit room name. <https://lily-is.land/kazv/kazv/-/merge_requests/15>
+> * Add media file menu for download. <https://lily-is.land/kazv/kazv/-/merge_requests/14>
+> * Add a shortcut editor. <https://lily-is.land/kazv/kazv/-/merge_requests/17>
+> * Add UI for sending media files, controlling pause and cancel, and display the progress in real time. <https://lily-is.land/kazv/kazv/-/merge_requests/18>
+> * Use QtNetwork for job handling instead of libkazvjob. <https://lily-is.land/kazv/kazv/-/merge_requests/21>
+> * Implement creating and joining rooms. <https://lily-is.land/kazv/kazv/-/merge_requests/19>
+> * Add the ability to see users' devices and manage trust level. <https://lily-is.land/kazv/kazv/-/merge_requests/23>
+> * Support local echo. <https://lily-is.land/kazv/kazv/-/merge_requests/25>
+> * Support redaction. <https://lily-is.land/kazv/kazv/-/merge_requests/28>
+> * Implement profile settings. <https://lily-is.land/kazv/kazv/-/merge_requests/30>
+> * Support viewing event source. <https://lily-is.land/kazv/kazv/-/merge_requests/32>
+> * Display hero avatar if it is a two-person room. <https://lily-is.land/kazv/kazv/-/merge_requests/34>
+> * Support typing status. <https://lily-is.land/kazv/kazv/-/merge_requests/33>
+> * Support room tagging. <https://lily-is.land/kazv/kazv/-/merge_requests/35>
+> * Allow paginate back in the timeline. <https://lily-is.land/kazv/kazv/-/merge_requests/38>
+> * Handle incoming invites. <https://lily-is.land/kazv/kazv/-/merge_requests/39>
+> * Support displaying notifications for incoming messages. <https://lily-is.land/kazv/kazv/-/merge_requests/40>
+> * Support leaving room. <https://lily-is.land/kazv/kazv/-/merge_requests/41>
+> * Support sending and receiving encrypted media files. <https://lily-is.land/kazv/kazv/-/merge_requests/20>
+> * Allow selecting message content. <https://lily-is.land/kazv/kazv/-/merge_requests/44>
+> * Implement room member list view. <https://lily-is.land/kazv/kazv/-/merge_requests/45>
+> * Handle message replies. <https://lily-is.land/kazv/kazv/-/merge_requests/48>
+> * Implement reactions. <https://lily-is.land/kazv/kazv/-/merge_requests/50>
+> * Use libkazv push rules to determine whether to notify for an event. <https://lily-is.land/kazv/kazv/-/merge_requests/51>
+> * Implement displaying and changing users' power levels. <https://lily-is.land/kazv/kazv/-/merge_requests/52>
+> * Add the ability to ban and unban user. <https://lily-is.land/kazv/kazv/-/merge_requests/54>
+> * Sort rooms by descending order of latest event timestamp. <https://lily-is.land/kazv/kazv/-/merge_requests/57>
+> * Implement kicking user. <https://lily-is.land/kazv/kazv/-/merge_requests/58>
+> * Improve event view layout. <https://lily-is.land/kazv/kazv/-/merge_requests/62>
+> * Install kazv logo to icon directory. <https://lily-is.land/kazv/kazv/-/merge_requests/63>
+> * Implement inviting user. <https://lily-is.land/kazv/kazv/-/merge_requests/65>
+> * Support inviting users when creating a room. <https://lily-is.land/kazv/kazv/-/merge_requests/66>
 > 
 > ### Fixed
 > 
-> * Fix scroll-to-top when receiving new events. <https://lily-is.land/kazv/kazv/-/merge\_requests/26>
-> * Fix timeline efficiency. <https://lily-is.land/kazv/kazv/-/merge\_requests/37>
-> * Use proper style and l10n for event fallback. <https://lily-is.land/kazv/kazv/-/merge\_requests/55>
-> * Use debounce when setting local draft. <https://lily-is.land/kazv/kazv/-/merge\_requests/56>
-> * Fix AppImage build due to missing KNotification qml modules. <https://lily-is.land/kazv/kazv/-/merge\_requests/59>
-> * Put primary event loop back to separate thread. <https://lily-is.land/kazv/kazv/-/merge\_requests/60>
-> * Fix crash when timeline of a room is empty. <https://lily-is.land/kazv/kazv/-/merge\_requests/61>
+> * Fix scroll-to-top when receiving new events. <https://lily-is.land/kazv/kazv/-/merge_requests/26>
+> * Fix timeline efficiency. <https://lily-is.land/kazv/kazv/-/merge_requests/37>
+> * Use proper style and l10n for event fallback. <https://lily-is.land/kazv/kazv/-/merge_requests/55>
+> * Use debounce when setting local draft. <https://lily-is.land/kazv/kazv/-/merge_requests/56>
+> * Fix AppImage build due to missing KNotification qml modules. <https://lily-is.land/kazv/kazv/-/merge_requests/59>
+> * Put primary event loop back to separate thread. <https://lily-is.land/kazv/kazv/-/merge_requests/60>
+> * Fix crash when timeline of a room is empty. <https://lily-is.land/kazv/kazv/-/merge_requests/61>
 > 
 > ### Removed
 > 
-> * Remove useless use of tabs on main page. <https://lily-is.land/kazv/kazv/-/merge\_requests/34>
+> * Remove useless use of tabs on main page. <https://lily-is.land/kazv/kazv/-/merge_requests/34>
 
 ### Neochat ([website](https://invent.kde.org/network/neochat))
 


### PR DESCRIPTION
removing unnecessary escape characters that broke links