### PR TITLE
Improve the padding around the member images

### DIFF
--- a/sass/_support.scss
+++ b/sass/_support.scss
@@ -108,11 +108,12 @@
                     --supporters-card-border-width: 1px;
                     border: var(--supporters-card-border-width) solid var(--borders-color);
                     border-radius: 16px;
-                    padding-top: 4px;
-                    padding-bottom: 4px;
                     --supporters-card-hpadding: 8px;
-                    padding-left: var(--supporters-card-hpadding);
-                    padding-right: var(--supporters-card-hpadding);
+                    padding: var(--supporters-card-hpadding);
+                    // The whitespace of the text at the bottom visually adds to the padding so we account for this on the top a little.
+                    padding-top: calc(1.5 * var(--supporters-card-hpadding));
+                    // This adds some space between the text and the image
+                    gap: var(--supporters-card-hpadding);
 
                     img {
                         aspect-ratio: 1/1;


### PR DESCRIPTION
## Before

![image](https://github.com/matrix-org/matrix.org/assets/1374914/705257e0-ed2d-44af-812a-a1d62865e623)

## After

![image](https://github.com/matrix-org/matrix.org/assets/1374914/fb4dfbb9-7b2a-4cc6-b5af-250b60e422a4)
