### PR TITLE
Remove padding of rss icon

### DIFF
--- a/static/assets/rss.svg
+++ b/static/assets/rss.svg
@@ -1,12 +1,57 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
-<svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="#999999">
 
-<g id="SVGRepo_bgCarrier" stroke-width="0"/>
-
-<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
-
-<g id="SVGRepo_iconCarrier"> <path fill-rule="evenodd" clip-rule="evenodd" d="M4 5C4 4.44772 4.44772 4 5 4C13.2843 4 20 10.7157 20 19C20 19.5523 19.5523 20 19 20C18.4477 20 18 19.5523 18 19C18 11.8203 12.1797 6 5 6C4.44772 6 4 5.55228 4 5ZM4 10C4 9.44772 4.44772 9 5 9C10.5228 9 15 13.4772 15 19C15 19.5523 14.5523 20 14 20C13.4477 20 13 19.5523 13 19C13 14.5817 9.41828 11 5 11C4.44772 11 4 10.5523 4 10ZM6.5 20C7.88071 20 9 18.8807 9 17.5C9 16.1193 7.88071 15 6.5 15C5.11929 15 4 16.1193 4 17.5C4 18.8807 5.11929 20 6.5 20Z" fill="#999999"/> </g>
-
+<svg
+   width="17"
+   height="17"
+   viewBox="0 0 17 17"
+   fill="none"
+   stroke="#999999"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="rss.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="35.333333"
+     inkscape:cx="8.4764151"
+     inkscape:cy="8.490566"
+     inkscape:window-width="1920"
+     inkscape:window-height="1052"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     id="SVGRepo_bgCarrier"
+     stroke-width="0"
+     transform="translate(-3.5,-3.5)" />
+  <g
+     id="SVGRepo_tracerCarrier"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     transform="translate(-3.5,-3.5)" />
+  <g
+     id="SVGRepo_iconCarrier"
+     transform="translate(-3.5,-3.5)">
+    <path
+       fill-rule="evenodd"
+       clip-rule="evenodd"
+       d="M 4,5 C 4,4.44772 4.44772,4 5,4 c 8.2843,0 15,6.7157 15,15 0,0.5523 -0.4477,1 -1,1 -0.5523,0 -1,-0.4477 -1,-1 C 18,11.8203 12.1797,6 5,6 4.44772,6 4,5.55228 4,5 Z m 0,5 C 4,9.44772 4.44772,9 5,9 c 5.5228,0 10,4.4772 10,10 0,0.5523 -0.4477,1 -1,1 -0.5523,0 -1,-0.4477 -1,-1 C 13,14.5817 9.41828,11 5,11 4.44772,11 4,10.5523 4,10 Z M 6.5,20 C 7.88071,20 9,18.8807 9,17.5 9,16.1193 7.88071,15 6.5,15 5.11929,15 4,16.1193 4,17.5 4,18.8807 5.11929,20 6.5,20 Z"
+       fill="#999999"
+       id="path1" />
+  </g>
 </svg>


### PR DESCRIPTION
Fixes padding on the icon introduced in #2287

# Before

![image](https://github.com/matrix-org/matrix.org/assets/1374914/417c33d3-e20f-495a-8029-be36d4dea1ef)


# After

![image](https://github.com/matrix-org/matrix.org/assets/1374914/81069239-089a-40a1-bb08-f4dd61cf0f7a)
