### PR TITLE
reorder display of Governing Board composition

### DIFF
--- a/templates/membership.html
+++ b/templates/membership.html
@@ -135,14 +135,6 @@
     </div>
     <div class="row">
         <div class="representatives">
-            <h3>Foundation representatives</h3>
-            <ul>
-                <li>Managing Director</li>
-                <li>2 Spec Core Team Members</li>
-                <li>3 Guardians</li>
-            </ul>
-        </div>
-        <div class="representatives">
             <h3>Community representatives</h3>
             <ul>
                 <li>4 Individual Members</li>
@@ -156,6 +148,14 @@
                 <li>4 Platinum Members</li>
                 <li>3 Gold Members</li>
                 <li>2 Silver Members</li>
+            </ul>
+        </div>
+        <div class="representatives">
+            <h3>Foundation representatives</h3>
+            <ul>
+                <li>3 Guardians</li>
+                <li>2 Spec Core Team Members</li>
+                <li>Managing Director</li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
putting community first, and foundation last, and aligning the sorting of foundation rep listing with the rest of the listings