### PR TITLE
add contact info for Josh

### DIFF
--- a/content/about/staff.toml
+++ b/content/about/staff.toml
@@ -2,6 +2,7 @@
 name = "Josh Simmons"
 title = "Managing Director"
 picture = "josh.jpg"
+email = "josh@foundation.matrix.org"
 website = "https://joshsimmons.com/"
 linkedin = "https://www.linkedin.com/in/joshsimmons/"
 fediverse = "https://josh.tel/@josh"

--- a/content/contact.md
+++ b/content/contact.md
@@ -13,3 +13,5 @@ However, if you prefer email, or have a need to be more direct:
   commercial queries
 - [security@matrix.org](mailto:security@matrix.org) to disclose security issues.
   Also see our [Security Disclosure Policy](/security-disclosure-policy/)
+
+You can find our staff members, and contact details for some of them, in the [About](/about/) section.

--- a/templates/shortcodes/staff.html
+++ b/templates/shortcodes/staff.html
@@ -6,6 +6,7 @@
             <h4 class="staff-name">{{ staff.name }}, {{ staff.title }}</h4>
             <p>{{ staff.bio }}</p>
             <ul class="socials">
+                {% if staff.email %}<li><a href="mailto:{{ staff.email }}">Email</a></li>{% endif %}
                 {% if staff.website %}<li><a href="{{ staff.website }}">Website</a></li>{% endif %}
                 {% if staff.linkedin %}<li><a href="{{staff.linkedin}}">LinkedIn</a></li>{% endif %}
                 {% if staff.fediverse %}<li><a href="{{ staff.fediverse }}">Fediverse</a></li>{% endif %}


### PR DESCRIPTION
added support for including staff email addresses, and added my own email address. also mentioning on the contact page that some more contact details are available in the about section.