### PR TITLE
Adjust section submenu wrap top to match the menu height

### DIFF
--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -179,8 +179,7 @@
 
         .section-submenu-wrap {
             position: absolute;
-            top: 60px;
-            padding-top: 4px;
+            top: 47.5px;
         }
 
         .section-submenu {


### PR DESCRIPTION
The menu section is 47.5px tall, so the submenu wrap should have the same value in order to align it and not have the submenu disappear when transitioning from the menu to the submenu area.

Fixes #2278 and replaces #2267