### PR TITLE
Add Elm SDK to SDK ecosystem

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -595,3 +595,16 @@ featured_in = ["client", "bot", "bridge"]
 description = """
 A .NET 8 library for interacting with Matrix.
 """
+
+[[sdks]]
+name = "Elm SDK"
+maintainer = "Bram Noordstar"
+maturity = "Beta"
+language = "Elm"
+licence = "EUPL-1.2"
+repository = "https://github.com/noordstar/elm-matrix-sdk-beta"
+purpose = ["client"]
+featured_in = ["client"]
+description = """
+A more consistent alternative to the matrix-js-sdk written in Elm.
+"""


### PR DESCRIPTION
Add Elm SDK as a beta SDK to the configuration listing all ecosystem SDKs.