### PR TITLE
Add Synapse update to TWIM 2024-04-26

### DIFF
--- a/content/blog/2024/04/2024-04-26-twim.md
+++ b/content/blog/2024/04/2024-04-26-twim.md
@@ -121,6 +121,16 @@ Conduit is a simple, fast and reliable chat server powered by Matrix
 > 
 > Chat with us in [#conduwuit:puppygock.gay](https://matrix.to/#/#conduwuit:puppygock.gay)
 
+### Synapse ([website](https://github.com/element-hq/synapse/))
+
+Synapse is a Matrix homeserver implementation developed by the Element
+
+[anoa](https://matrix.to/#/@andrewm:element.io) says
+
+> This week Element released [Synapse v1.105.1](https://github.com/element-hq/synapse/releases/tag/v1.105.1), which is a **security release** that fixes a denial of service attack. If you haven't upgraded already, please do!
+
+> Otherwise, a new release candidate went out yesterday! [Synapse v1.106.0rc1](https://github.com/element-hq/synapse/releases/tag/v1.106.0rc1) contains new features that are available for testing ahead of next week's full release. This release candidate contains the security fix from v1.105.1. Please test this release candidate and [file bugs](https://github.com/element-hq/synapse/issues/) if you're able to. Thanks!
+
 ## Dept of Clients 📱
 
 ### Element X Android ([website](https://github.com/vector-im/element-x-android))


### PR DESCRIPTION
Oops, I forgot to TWIM this week. I am a bad person.

This announces the latest Synapse security release, so should probably go in.