### PR TITLE
Fix the contrast of links and ensure we underline those links

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -62,6 +62,10 @@ a {
     text-decoration: underline;
 }
 
+nav a {
+    text-decoration: none;
+}
+
 ul,
 ol {
     margin-top: 0px;

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -11,7 +11,7 @@
         --color-text-light: #595959;
     }
 
-    --color-link: #0098d4;
+    --color-link: #00719d;
 
     --page-header-height: 15rem;
 
@@ -59,7 +59,7 @@ main {
 
 a {
     color: var(--color-link);
-    text-decoration: none;
+    text-decoration: underline;
 }
 
 ul,

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -121,7 +121,6 @@ ol:last-child {
 
     a {
         color: #999;
-        text-decoration: none;
         margin-inline: .8rem;
     }
 
@@ -355,6 +354,8 @@ a>code {
     font-weight: 600;
     border-radius: 1000px;
     padding: .6em 2em;
+
+    text-decoration: none;
 
     &.inverted {
         border: 2px solid #fff;

--- a/sass/_bridges.scss
+++ b/sass/_bridges.scss
@@ -18,6 +18,7 @@
         padding-inline: .5rem 1rem;
         max-width: fit-content;
         cursor: pointer;
+        text-decoration: none;
 
         color: var(--color-text);
 
@@ -101,6 +102,7 @@
         gap: .5rem;
         margin-block: .5rem;
         margin-bottom: 1rem;
+        text-decoration: none;
     }
 
     .privileges>div,

--- a/sass/_projects.scss
+++ b/sass/_projects.scss
@@ -28,6 +28,7 @@
 
     border: 1px solid #D2D2D2;
     border-radius: 16px;
+    text-decoration: none;
 
     img {
         margin: 0;
@@ -68,6 +69,7 @@
         border-radius: 9999px;
         padding-inline: .5rem;
         color: var(--color-text);
+        text-decoration: none;
     }
 }
 
@@ -253,6 +255,7 @@
         display: flex;
         align-items: center;
         gap: .2rem;
+        text-decoration: none;
 
         border: 1px solid var(--color-text);
         color: var(--color-text);


### PR DESCRIPTION
This fixes some errors from my testing branch. I thought it might be a good idea to get these on a dedicated branch.

Explicitly it fixes https://dequeuniversity.com/rules/axe/4.9/color-contrast and `Ensure links are distinguished from surrounding text in a way that does not rely on color` which is part of WCAG 2.1 (A), WCAG 2.0 (A), WCAG 2.2 (A), Trusted Tester and EN 301 549

# Before and after images
![image](https://github.com/matrix-org/matrix.org/assets/1374914/1a4cfdee-4bad-481a-a26c-f01fc0ddb5e1)
![image](https://github.com/matrix-org/matrix.org/assets/1374914/7b337e15-da64-4607-a3ce-fc01645ad2cd)

This gives us _at least_ a 5.40:1 contrast ratio on all backgrounds. Which is enough for the AA requirements.

