### PR TITLE
Fix minor grammatical error

### DIFF
--- a/templates/try-matrix.html
+++ b/templates/try-matrix.html
@@ -13,7 +13,7 @@
             <div class="instructions">
                 <h3>Choose a client</h3>
                 <p>
-                    We recommend Element as a safe default, but there is a variety of clients available.
+                    We recommend Element as a safe default, but there are a variety of clients available.
                 </p>
                 <div class="cta-wrapper">
                     <a href="/ecosystem/clients/element/" class="call-to-action">Install Element</a>


### PR DESCRIPTION
On https://matrix.org/try-matrix/:

> We recommend Element as a safe default, but there is a variety of clients available.

`clients` is plural, so the verb `is` should be `are` instead.