### PR TITLE
Use `system-ui` as default font

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -35,7 +35,8 @@ body {
     background-color: #fff;
     color: var(--color-text);
 
-    font-family: system-ui,
+    font-family: "Helvetica Neue",
+        system-ui,
         sans-serif,
         "Apple Color Emoji",
         /* Emojis*/

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -35,13 +35,7 @@ body {
     background-color: #fff;
     color: var(--color-text);
 
-    font-family: "Helvetica Neue",
-        "Helvetica",
-        Arial,
-        -apple-system,
-        BlinkMacSystemFont,
-        "Segoe UI",
-        Roboto,
+    font-family: system-ui,
         sans-serif,
         "Apple Color Emoji",
         /* Emojis*/


### PR DESCRIPTION
I'm on Ubuntu, and the font that's currently shown for me on matrix.org is Nimbus Sans. The font in the existing font list that is causing this is the font "Helvetica", which I do not have installed.

From my cursory understanding of font matching, when running `fc-match helvetica` in the terminal, I get `NimbusSans-Regular.otf: "Nimbus Sans" "Regular"`, which explains why I'm being shown Nimbus Sans.

As it appears from the existing font list, the desired result was to use the font of the system the user is on. By using `system-ui`, we can achieve this. In my case, I would be shown the Ubuntu Font, as that's my default on my system.