### PR TITLE
Remove `overflow: hidden` on page headers

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -211,8 +211,6 @@ pre table {
 
     min-height: var(--page-header-height);
     background-color: #000000;
-    overflow: hidden;
-
     background-image: url(/assets/page-header-bg.svg);
     background-size: 90% 100%;
     background-position: bottom right;


### PR DESCRIPTION
It shouldn't be possible for the contents of page headers to overflow, considering the page header is bound by a variable sized bounding box (i.e., `min-height` instead of `height`).

I think it's dangerous to have `overflow: hidden` without reason, as if the design's implementation were to change, we would could be cutting off content without realising it.