### PR TITLE
Add spacing below "Try Matrix" button in phone nav

### DIFF
--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -99,7 +99,7 @@
                 margin-inline: .5rem;
 
                 @media screen and (max-width: 767px) {
-                    margin-top: 1.2rem;
+                    margin-block: 1.2rem;
                     text-align: center;
                 }
 


### PR DESCRIPTION
Previously, the button would touch the bottom of the `nav` container, which looked a bit off IMO.

|Before|After
|---|---|
|![Screen Shot 2024-05-22 at 22 00 17](https://github.com/matrix-org/matrix.org/assets/6900601/83703fec-39d1-4604-80d0-4b42356aa821)|![Screen Shot 2024-05-22 at 21 59 20](https://github.com/matrix-org/matrix.org/assets/6900601/573f8082-32ec-467a-941d-a0ec99a063ed)|