### PR TITLE
Update response time and clarify HoF crediting

### DIFF
--- a/content/security-disclosure-policy.md
+++ b/content/security-disclosure-policy.md
@@ -14,8 +14,10 @@ On our side, this means:
   to accept the risk, after which we will disclose the vulnerability.
 - We will always transparently let the community know about any incident that
   affects them.
+- After disclosing the vulnerability, we will credit you for the report in our
+  [Security Hall of Fame](/security-hall-of-fame/), if you wish.
 
-In general, we will aim for a fix within 90 days of processing your report, but
+In general, we will aim for a fix within 90 days of receiving your report, but
 we may propose a longer time frame (usually 120 days) for especially complex
 vulnerabilities. In some cases, when a vulnerability is particularly disruptive
 and/or easy to exploit, we may delay publishing technical details for an
@@ -31,7 +33,7 @@ with us first.
 On receipt, the security team will:
 
 - Review the report, verify the vulnerability and respond with confirmation
-  and/or further information requests; we typically reply within 24 hours.
+  and/or further information requests; we reply within 5 business days.
 - Once the reported security bug has been addressed we will notify the
   Researcher, who is then welcome to optionally disclose publicly.
 


### PR DESCRIPTION
Make the time to reply a clear commitment and spell out the hall of fame crediting in the process.