### PR TITLE
Nheko: mark as featured client

### DIFF
--- a/content/ecosystem/clients/nheko.md
+++ b/content/ecosystem/clients/nheko.md
@@ -10,7 +10,7 @@ maturity = "Beta"
 repo = "https://github.com/Nheko-Reborn/nheko"
 website = "https://nheko-reborn.github.io/"
 matrix_room = "#nheko-reborn:matrix.org"
-featured = false
+featured = true
 [extra.features]
 e2ee = true
 spaces = true


### PR DESCRIPTION
It's a shame that Cinny, which doesn't support a lot of stuff is listed in "featured" while much more advanced and feature-complete Nheko is somewhere below. Moreover, Nheko is Qt/C++ based client, which makes it faster as a native application and more suitable for older hardware (and there are lot of people with less beefy hardware out there). Since Nheko just recently made a release, I propose moving it to a "Featured" section.

https://github.com/Nheko-Reborn/nheko/releases/tag/v0.12.0

For example, Cinny doesn't support VoIP, Threads, and multi-language, while Nheko does.

Closes https://github.com/matrix-org/matrix.org/issues/2394
