### PR TITLE
Update Nheko information

### DIFF
--- a/content/ecosystem/clients/nheko.md
+++ b/content/ecosystem/clients/nheko.md
@@ -2,14 +2,14 @@
 title = "Nheko"
 [extra]
 thumbnail = "nheko.svg"
-maintainer = "mujx, red_sky, deepbluev7"
+maintainer = "red_sky, deepbluev7"
 licence = "GPL-3.0-or-later"
 language = "C++"
-latest_release = "2023-02-20"
+latest_release = "2024-06-12"
 maturity = "Beta"
 repo = "https://github.com/Nheko-Reborn/nheko"
 website = "https://nheko-reborn.github.io/"
-matrix_room = "#nheko-reborn:matrix.org"
+matrix_room = "#nheko:nheko.im"
 featured = true
 [extra.features]
 e2ee = true
@@ -23,7 +23,7 @@ multi_language = true
 [extra.packages]
 windows_installer = "https://github.com/Nheko-Reborn/nheko/releases"
 macos_installer = "https://github.com/Nheko-Reborn/nheko/releases"
-flathub.app_id = "io.github.NhekoReborn.Nheko"
+flathub.app_id = "im.nheko.Nheko"
 +++
 
 Desktop client for Matrix using Qt and C++20.


### PR DESCRIPTION
Using the old flathub id would be very confusing. And while it is sad, mujx hasn't been a maintainer for a while. They certainly started the project and did a humongous of work, but I think maintainers should probably reflect current contacts at this point?

The room change is mostly a visual thing. It points to the same room, but we usually use the nheko.im one and it is the canonical alias, so it probably is better to document that this way as well.