### PR TITLE
Fix feeds generation config for zola 0.18

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@ build_search_index = false
 
 default_language = "en"
 
-generate_feeds = true
+generate_feed = true
 
 taxonomies = [
     { name = "author", feed = false, paginate_by = 10 },


### PR DESCRIPTION
# this PR is assuming that zola 0.18 is still being used

resolves #2422

there is also a transitional period of the config field with zola 0.19.1 https://github.com/getzola/zola/blob/master/CHANGELOG.md