### PR TITLE
Add matrix_dotnet to the list of SDKs

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -647,3 +647,16 @@ featured_in = []
 description = """
 Matrix client SDK in Swift
 """
+
+[[sdks]]
+name = "matrix_dotnet"
+maintainer = "Greenscreener"
+maturity = "Beta"
+language = "C#"
+licence = "GPL-3.0-or-later"
+repository = "https://gitlab.com/Greenscreener/matrix-dotnet"
+purpose = ["client", "bot"]
+featured_in = []
+description = """
+Matrix client SDK in C#
+"""


### PR DESCRIPTION
Hello,

I wrote a C# library for working with matrix as a semester project for uni and I'd like to publish it to the list of SDKs.

Signed-off-by: Greenscreener <gs@grsc.cz>