### PR TITLE
Correct the MXID of the matrix.org mjolnir

### DIFF
--- a/content/legal/code-of-conduct.md
+++ b/content/legal/code-of-conduct.md
@@ -75,7 +75,7 @@ If the person who is harassing you is part of the response team, they will recus
 
 You are also able to report abusive content via your chosen Matrix client, by clicking the event in question and selecting report. Please note these reports go to your homeserver administrator.
 
-We use [Mjolnir](https://github.com/matrix-org/mjolnir) to handle the moderation of rooms under this Code of Conduct, via the bot @administrator:matrix.org. Please note that pinging this account, or any other staff accounts, is not the appropriate reporting mechanism. Repeated in-room reports might result in moderation action.
+We use [Mjolnir](https://github.com/matrix-org/mjolnir) to handle the moderation of rooms under this Code of Conduct, via the bot @abuse:matrix.org. Please note that pinging this account, or any other staff accounts, is not the appropriate reporting mechanism. Repeated in-room reports might result in moderation action.
 
 |
 


### PR DESCRIPTION
The mjolnir that is used to protect the rooms covered under the matrix.org COC is as far as the community can tell the `@abuse:matrix.org` bot. The `@administrator:matrix.org` account doesnt even have a profile that i can lookup on feline.support meanwhile the `@abuse:matrix.org` account has a profile and its the profile we all know.


Signed-off-by: Catalan Lover <catalanlover@protonmail.com>