### PR TITLE
Rename responsible disclosure to CVD

### DIFF
--- a/content/security-disclosure-policy.md
+++ b/content/security-disclosure-policy.md
@@ -4,7 +4,7 @@ title = "Security Disclosure Policy"
 
 Matrix.org greatly appreciates investigative work into security vulnerabilities
 carried out by well-intentioned, ethical security researchers. We follow the
-practice of [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure)
+practice of [coordinated vulnerability disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure)
 in order to best protect Matrix's user base from the impact of security issues.
 On our side, this means:
 


### PR DESCRIPTION
Given how the industry has moved on from calling it "responsible" disclosure and even the wikipedia page has been renamed (https://en.wikipedia.org/wiki/Responsible_disclosure redirects to https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure), I think it makes sense to switch this on the Matrix website too.