### PR TITLE
Set width and height on the images in the footer to reduce the layout shift

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -7,7 +7,8 @@
     <div class="external-links">
         <div>
             {% for link in navigation.footer_external %}
-            <a href="{{ link.href }}" rel="me"><img src="/assets/{{ link.image }}" alt="{{ link.alt }}"></a>
+            <a href="{{ link.href }}" rel="me"><img width="24px" height="24px" src="/assets/{{ link.image }}"
+                    alt="{{ link.alt }}"></a>
             {% endfor %}
         </div>
     </div>


### PR DESCRIPTION
Fixes #2463 

This changes nothing visual apart from causing the width and height being allocated before the css loaded which causes the footer to shift less vertically while images are loading.