### PR TITLE
Suggest smarter cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Matrix.org Website
+# Matrix.org Website
 
 If you want to contribute to the website, make sure the problem you're trying to
 fix or the feature you want to implement has been discussed in our issue tracker
@@ -6,6 +6,22 @@ and that we are interested in reviewing and merging such a contribution.
 
 To discuss maintenance of this site, please come talk to the team in
 [#matrix.org-website:matrix.org](https://matrix.to/#/#matrix.org-website:matrix.org).
+
+## Cloning the Repository
+
+Due to historic growth and media the repository is quite large. Therefor we suggest the usage of `--filter=blob:none` when doing a fresh clone:
+
+```
+git clone --filter=blob:none git@github.com:matrix-org/matrix.org.git
+```
+
+This allows to only fetch the actually needed things from the git repository instead of all of the (at the time of writing) 1.18GiB of data.
+With this command at the time of writing this reduces the downloaded data to just 612MiB.
+
+For more information on this please check out these 2 articles which also explain why `--depth=1` is not ideal and which implications this has:
+
+- https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/
+- https://nayak.io/posts/git-clone-optimizations/
 
 ## Building the website
 


### PR DESCRIPTION
Using `--filter=blob:none` offers a smaller download size while not having a shallow clone in the end. This should reduce the issue of the size of the repository.

See https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/ and https://nayak.io/posts/git-clone-optimizations/ for the technical details.

Repo size without:

```
❯ git count-objects -vH
count: 0
size: 0 Bytes
in-pack: 69431
packs: 2
size-pack: 1.18 GiB
prune-packable: 0
garbage: 0
size-garbage: 0 Bytes
```

Reposize after:

```
❯ git count-objects -vH
count: 0
size: 0 Bytes
in-pack: 46580
packs: 2
size-pack: 612.00 MiB
prune-packable: 0
garbage: 0
size-garbage: 0 Bytes
```

a gc does _not_ help us here as it would be only local.

This does have the tradeoff of slower git blame. But I hope this is not too much of an issue in reality for most contributors.