### PR TITLE
Update for Dendrite

### DIFF
--- a/content/ecosystem/servers/servers.toml
+++ b/content/ecosystem/servers/servers.toml
@@ -11,11 +11,11 @@ room = "#synapse:matrix.org"
 [[servers]]
 name = "Dendrite"
 description = "Dendrite is a second-generation Matrix homeserver written in Go!"
-author = "Matrix.org team"
+author = "Element"
 maturity = "Beta"
 language = "Go"
-licence = "Apache-2.0"
-repository = "https://github.com/matrix-org/dendrite"
+licence = "AGPL-3.0-only OR Element Commercial License"
+repository = "https://github.com/element-hq/dendrite"
 room = "#dendrite:matrix.org"
 
 [[servers]]


### PR DESCRIPTION
Dendrite is outside the foundation :cry:

License should be `AGPL-3.0-only OR LicenseRef-Element-Commercial`, but the second part in SPDX may be unreadable, so it is `Element Commercial License`