### PR TITLE
Fix broken TLD in today's blog post

### DIFF
--- a/content/blog/2024/11/2024-11-29-twim.md
+++ b/content/blog/2024/11/2024-11-29-twim.md
@@ -203,7 +203,7 @@ A Qt5 library to write cross-platform clients for Matrix
 > client.run(access_token="foobar")
 > ```
 > 
-> Contact us here: [#niobot:nexy7574.co](https://matrix.to/#/#niobot:nexy7574.co).uk | GitHub: <https://github.com/nexy7574/nio-bot> | Documentation: <https://docs.nio-bot.dev/v1.2.0/>
+> Contact us here: [#niobot:nexy7574.co.uk](https://matrix.to/#/#niobot:nexy7574.co.uk) | GitHub: <https://github.com/nexy7574/nio-bot> | Documentation: <https://docs.nio-bot.dev/v1.2.0/>
 
 ## Dept of Events and Talks 🗣️
 


### PR DESCRIPTION
Under the "Dept of Bots", "NioBot" section, the .uk part got cut out of .co.uk in the room link. this PR re-adds it.