### PR TITLE
Allow setting author metadata and merge author aliases

### DIFF
--- a/content/authors.toml
+++ b/content/authors.toml
@@ -1,0 +1,30 @@
+[author.josh_simmons]
+name = "Josh Simmons"
+description = """
+
+"""
+aliases = ["Josh Simmons (m.org)"]
+mastodon = "@josh@josh.tel"
+
+[author.thib]
+name = "Thib"
+description = """
+
+"""
+aliases = ["Thib (m.org)"]
+mastodon = "@thibaultamartin@mamot.fr"
+
+[author.matthew]
+name = "Matthew Hodgson"
+description = """
+
+"""
+aliases = []
+mastodon = "@matthew@mastodon.matrix.org"
+
+[author.mtrnord]
+name = "MTRNord"
+description = """
+"""
+aliases = ["MTRNord (they/them)"]
+mastodon = "@mtrnord@mastodon.mtrnord.blog"

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -16,11 +16,19 @@
                 {%- if not loop.last %}, {% endif %}{% endfor %}
                 {% endif %}
                 —
-                {% for author in page.taxonomies.author %}
-                <a href="/author/{{ author | default(value=['unknown author']) | slugify }}">
-                    {{- author | default(value=["unknown author"]) -}}
-                </a>
-                {%- if not loop.last %}, {% endif %}
+                {% set authors = load_data(path="content/authors.toml") %}
+                {% set author_details = authors.author %}
+                {% for author_alias in page.taxonomies.author %}
+                    {% set_global author_name = author_alias %}
+                    {% for key, value in author_details %}
+                        {% if value.name == author_alias or author_alias in value.aliases %}
+                            {% set_global author_name = value.name %}
+                        {% endif %}
+                    {% endfor %}
+                    <a href="/author/{{ author_name | slugify }}">
+                        {{- author_name -}}
+                    </a>
+                    {%- if not loop.last %}, {% endif %}
                 {% endfor %}
             </span>
             {% if page.updated -%}

--- a/templates/post.html
+++ b/templates/post.html
@@ -10,6 +10,25 @@
 {{ throw(message="Please put author under the taxonomies area.") }}
 {%- endif -%}
 
+{% set authors = load_data(path="content/authors.toml") %}
+{% set author_details = authors.author %}
+{% set author_meta = [] %}
+{% for author_alias in page.taxonomies.author %}
+    {% set_global author_name = author_alias %}
+    {% for key, value in author_details %}
+        {% if value.name == author_alias or author_alias in value.aliases %}
+            {% set_global author_name = value.name %}
+            {% set_global author_meta = author_meta | concat(with=value) %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% for author in author_meta %}
+    {% if author.mastodon %}
+<meta name="fediverse:creator" content="{{ author.mastodon }}" />
+    {% endif %}
+{% endfor %}
+
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",
@@ -33,12 +52,18 @@
     ],
     {% endif %}
     "author": [
-    {% for author in page.taxonomies.author %}
-    {
-        "@type": "Person",
-        "name": "{{ author }}",
-        "url": "{{ config.base_url | safe }}/authors/{{ author | slugify }}"
-    }{% if not loop.last %},{% endif %}
+    {% for author_alias in page.taxonomies.author %}
+        {% set_global author_name = author_alias %}
+        {% for key, value in author_details %}
+            {% if value.name == author_alias or author_alias in value.aliases %}
+                {% set_global author_name = value.name %}
+            {% endif %}
+        {% endfor %}
+        {
+            "@type": "Person",
+            "name": "{{ author_name }}",
+            "url": "{{ config.base_url | safe }}/authors/{{ author_name | slugify }}"
+        }{% if not loop.last %},{% endif %}
     {% endfor %}
     ]
 }
@@ -59,11 +84,17 @@
             {%- if not loop.last %}, {% endif %}{% endfor %}
             {% endif %}
             —
-            {% for author in page.taxonomies.author %}
-                <a href="/author/{{ author | default (value=['unknown author']) | slugify }}">
-                    {{- author | default (value=["unknown author"]) -}}
+            {% for author_alias in page.taxonomies.author %}
+                {% set_global author_name = author_alias %}
+                {% for key, value in author_details %}
+                    {% if value.name == author_alias or author_alias in value.aliases %}
+                        {% set_global author_name = value.name %}
+                    {% endif %}
+                {% endfor %}
+                <a href="/author/{{ author_name | slugify }}">
+                    {{- author_name -}}
                 </a>
-            {%- if not loop.last %}, {% endif %}
+                {%- if not loop.last %}, {% endif %}
             {% endfor %}
         </span>
         {% if page.updated %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -7,11 +7,69 @@
             <h1>{{ taxonomy.name | capitalize }}</h1>
         </header>
         <div class="grid">
-            {% for term in terms %}
+            {% if taxonomy.name == "author" %}
+                {# Load the authors data #}
+                {% set authors = load_data(path="content/authors.toml") %}
+                {# Set the clean terms #}
+                {% set clean_terms = [] %}
+                {# Loop over the terms and only add terms of users which either have no entry in the authors.toml or only the name of an author but not the aliases #}
+                {% for term in terms %}
+                    {% set_global found = false %}
+                    {% set_global is_alias = false %}
+                    {% for key, author in authors.author %}
+                        {% if author.name == term.name %}
+                            {% set_global found = true %}
+                        {% endif %}
+                        {% if term.name in author.aliases %}
+                            {% set_global is_alias = true %}
+                        {% endif %}
+                    {% endfor %}
+                    {% if not found %}
+                        {% if not is_alias %}
+                            {% set_global clean_terms = clean_terms | concat(with=term) %}
+                        {% endif %}
+                    {% endif %}
+                    {% if not is_alias and found %}
+                        {% set_global clean_terms = clean_terms | concat(with=term) %}
+                    {% endif %}
+                {% endfor %}
+
+                {# Sort the terms #}
+                {% set clean_terms = clean_terms | sort(attribute="name") %}
+            {% else %}
+                {# Filter out the terms #}
+                {% set clean_terms = terms %}
+            {% endif %}
+
+            {# Loop over the terms #}
+            {% for term in clean_terms %}
+
+            {# If the terms is an author we append the pages of the aliases to the author #}
+            {% if taxonomy.name == "author" %}
+                {% set_global merged_pages = term.pages %}
+                {% for key, author in authors.author %}
+                    {% if author.name == term.name or term.name in author.aliases %}
+                        {% set author_term = get_taxonomy_term(kind="author", term=author.name) %}
+                        {% set_global merged_pages = merged_pages | concat(with=author_term.pages) %}
+                        {% for alias in author.aliases %}
+                            {% set alias_term = get_taxonomy_term(kind="author", term=alias, required=false) %}
+                            {% if alias_term %}
+                                {% set_global merged_pages = merged_pages | concat(with=alias_term.pages) %}
+                            {% endif %}
+                        {% endfor %}
+                    {% endif %}
+                {% endfor %}
+                {% set_global merged_pages = merged_pages | unique(attribute="title") | sort(attribute="date") | reverse %}
+            {% else %}
+                {% set_global merged_pages = term.pages %}
+            {% endif %}
+
+            {# Output the terms #}
+
             <div class="grid-container-third">
                 <h3>
                     <a href="{{ term.permalink | safe }}">{{ term.name }}</a>
-                    ({{ term.pages | length }})
+                    ({{ merged_pages | length }})
                 </h3>
                 {% if taxonomy.feed %}
                 <h4>
@@ -19,7 +77,7 @@
                 </h4>
                 {% endif %}
                 <ul>
-                    {% for page in term.pages | slice(end=4) %}
+                    {% for page in merged_pages | slice(end=4) %}
                     <li>
                         <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
                     </li>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -4,21 +4,60 @@
 {% endblock head_extra %}
 {% block html_title %}Matrix.org - {{ term.name }}{% endblock html_title %}
 {% block content %}
+
+{% if taxonomy.name == "author" %}
+    {% set authors = load_data(path="content/authors.toml") %}
+
+    {% set_global merged_pages = term.pages %}
+    {% for key, author in authors.author %}
+        {% if author.name == term.name or term.name in author.aliases %}
+            {% set author_term = get_taxonomy_term(kind="author", term=author.name) %}
+            {% set_global merged_pages = merged_pages | concat(with=author_term.pages) %}
+            {% for alias in author.aliases %}
+                {% set alias_term = get_taxonomy_term(kind="author", term=alias, required=false) %}
+                {% if alias_term %}
+                    {% set_global merged_pages = merged_pages | concat(with=alias_term.pages) %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+    {% set_global merged_pages = merged_pages | unique(attribute="title") | sort(attribute="date") | reverse %}
+{% else %}
+    {% set_global merged_pages = term.pages %}
+{% endif %}
+
 <div id="taxonomy-single">
     <div class="content">
         <header>
             <h1>{{ term.name }}</h1>
-            {{ term.pages | length }} posts tagged with "{{ term.name }}" <a href="/{{ taxonomy.name }}">(See all {{
-                taxonomy.name | capitalize
-                }})</a>
+            {% if taxonomy.name == "category" %}
+                {{ merged_pages | length }} posts tagged with "{{ term.name }}" <a href="/{{ taxonomy.name }}">(See all {{
+                    "categories" | capitalize
+                    }})</a>
+            {% else %}
+                {{ merged_pages | length }} posts tagged with "{{ term.name }}" <a href="/{{ taxonomy.name }}">(See all {{
+                    taxonomy.name | capitalize
+                    }}s)</a>
+            {% endif %}
             {% if taxonomy.feed %}
             <h2>
                 <small><a href="{{ term.permalink | safe }}atom.xml">Atom Feed</a></small>
             </h2>
             {% endif %}
+
+            {% if taxonomy.name == "author" %}
+                {# Find the description of the given term.name author and display it as a div of safe markdown #}
+                {% for key, author in authors.author %}
+                    {% if author.name == term.name or term.name in author.aliases %}
+                        <div class="author-description">
+                            {{ author.description | markdown | safe }}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
         </header>
 
-        {% for page in paginator.pages %}
+        {% for page in merged_pages %}
         <article class="post">
             <header>
                 <h2><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h2>


### PR DESCRIPTION
This allows to set a canonical name of people which have multiple aliases used as authors.
It will keep links intact and just merge the posts as needed.

It also updates the links in the posts to the correct name and slug.

Additionally this feature allows for a description on the author page to exist to introduce a person.

Last but not least this allows setting a mastaodon uri to allow using the fediverse:creator meta tag

Fixes #2567