### PR TITLE
Update telodendria room alias

### DIFF
--- a/content/ecosystem/servers/servers.toml
+++ b/content/ecosystem/servers/servers.toml
@@ -127,7 +127,7 @@ maturity = "Alpha"
 language = "C"
 licence = "MIT"
 repository = "https://git.telodendria.io/Telodendria/Telodendria"
-room = "#telodendria-general:bancino.net"
+room = "#general:synapse.telodendria.io"
 
 [[servers]]
 name = "conduwuit"


### PR DESCRIPTION
The old alias is inaccessible.

The telodendria room in the servers subspace (https://matrix.to/#/!JxVdjluQhAiplXpUpi:t2l.io?via=matrix.org&via=envs.net&via=tchncs.de) of Matrix Community will tell you the room ID !ykbwcwqRyRJhteUiDp:bancino.net which you can try to guess some vias for to join, e.g. https://matrix.to/#/!ykbwcwqRyRJhteUiDp:bancino.net?via=matrix.org&via=t2l.io. Once in, the room announces #general:synapse.telodendria.io as its canonical alias.

Calling @jordanbancino to confirm :)