### PR TITLE
update jwt service URL to the matrix.org instance

### DIFF
--- a/static/.well-known/matrix/client
+++ b/static/.well-known/matrix/client
@@ -7,8 +7,8 @@
     },
     "org.matrix.msc4143.rtc_foci": [
         {
-            "type":"livekit",
-            "livekit_service_url":"https://livekit-jwt.call.element.io"
+            "type": "livekit",
+            "livekit_service_url": "https://livekit-jwt.call.matrix.org"
         }
     ]
 }


### PR DESCRIPTION
Meanwhile matrix.org has its own instance of the jwt-service. This PR is updating the URL