### PR TITLE
update rust-sdk maturity from beta to stable

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -507,7 +507,7 @@ featured_in = []
 [[sdks]]
 name = "matrix-rust-sdk"
 maintainer = "poljar"
-maturity = "Beta"
+maturity = "Stable"
 language = "Rust"
 licence = "Apache-2.0"
 repository = "https://github.com/matrix-org/matrix-rust-sdk"


### PR DESCRIPTION
To better reflect the maturity of the SDK to help new client developers parse the SDK ecosystem.
cc @poljar 