### PR TITLE
Added operating_since value for Ossrox

### DIFF
--- a/content/ecosystem/hosting/providers.toml
+++ b/content/ecosystem/hosting/providers.toml
@@ -82,7 +82,7 @@ etke.cc is the only fully FOSS-based Matrix Hosting service. It's operated by a 
 name = "Ossrox"
 image = "ossrox.svg"
 website = "https://ossrox.org"
-operating_since = "TBC"
+operating_since = "2022"
 description = """
 - Hosted Homeservers
 


### PR DESCRIPTION
I have added the year since Ossrox is operating. (I am one of the managing directors.)