### PR TITLE
Initial archive page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,8 @@ taxonomies = [
 highlight_code = true
 highlight_theme = "visual-studio-dark"
 
+lazy_async_image = true
+
 [link_checker]
 skip_prefixes = [
     # This page is not a real page. You need to open https://circu.li/fdroid/repo/index-v1.json for a response
@@ -49,4 +51,3 @@ conference_location = "Berlin, Germany"
 
 governence_board_elections = false
 governence_board_elections_page = "/governing-board/elections/2024"
-

--- a/content/blog/archive/_index.md
+++ b/content/blog/archive/_index.md
@@ -1,0 +1,3 @@
++++
+template = "archive.html"
++++

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,0 +1,56 @@
+{% extends "section.html" %}
+{% block content -%}
+{% set blog_section = get_section(path="blog/_index.md") %}
+<div class="content">
+    {% set_global all_pages = [] %}
+
+    {% for year_section_name in blog_section.subsections %}
+    {% set year_section = get_section(path=year_section_name) %}
+    {% set_global all_pages = all_pages | concat(with=year_section.pages) %}
+    {% endfor %}
+    {% set posts_by_year = all_pages | group_by(attribute="year") %}
+
+    {% set_global years = [] %}
+    {% for year, ignored in posts_by_year %}
+    {% set_global years = years | concat(with=year) %}
+    {% endfor %}
+
+    {% for year in years | sort | reverse %}
+    {% set posts = posts_by_year[year] | sort(attribute="date") | reverse %}
+    <h1>{{ year }}</h1>
+    <hr />
+    {% for page in posts %}
+    <article class="post">
+        <header>
+            <h1><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h1>
+            <span>
+                {{ page.date | date(format="%d.%m.%Y %H:%M") }}
+                {% if page.taxonomies.category -%}
+                —
+                {% for category in page.taxonomies.category %}
+                <a href="/category/{{ category | slugify }}">
+                    {{- category -}}
+                </a>
+                {%- if not loop.last %}, {% endif %}{% endfor %}
+                {% endif %}
+                —
+                {% for author in page.taxonomies.author %}
+                <a href="/author/{{ author | default(value=['unknown author']) | slugify }}">
+                    {{- author | default(value=["unknown author"]) -}}
+                </a>
+                {%- if not loop.last %}, {% endif %}
+                {% endfor %}
+            </span>
+            {% if page.updated -%}
+            <br>
+            <small>Last update: {{ page.updated | date(format="%d.%m.%Y %H:%M") }}</small>
+            {%- endif %}
+        </header>
+        <div>
+            {{ page.content | safe }}
+        </div>
+    </article>
+    {% endfor %}
+    {% endfor %}
+</div>
+{%- endblock content %}

--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,4 +1,4 @@
 <figure style="height:100%;">
-    <img src="{{ img }}" alt="{{ caption }}" />
+    <img decoding="async" loading="lazy" src="{{ img }}" alt="{{ caption }}" />
     <figcaption>{{ caption | markdown | safe }}</figcaption>
 </figure>


### PR DESCRIPTION
Currently it shows the full content.

Lighthouse is obviously unhappy.
Async loading of images reduces this page from ~500MB of content to ~50MB. It technically is global though. However it is most likely fine.

#2545 Would (according to lighthouse) reduce it up to another ~30MB in transmitted size. So this would help.

There is no final decission yet if we want full posts or just links