### PR TITLE
Fix well known CORS to allow looking up support info from browser clients

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -14,7 +14,7 @@
 
 
 # Allow ACAO for well-known client
-/.well-known/matrix/client
+/.well-known/matrix/*
   Access-Control-Allow-Origin: *
 
 # Add content type for jira archive

--- a/static/_headers
+++ b/static/_headers
@@ -13,7 +13,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
 
 
-# Allow ACAO for well-known client
+# Allow ACAO for well-known records
 /.well-known/matrix/*
   Access-Control-Allow-Origin: *
 


### PR DESCRIPTION
Adds cross-origin headers to well-known records to support looking up support info and future records.

This change also includes the `server` record, as it's useful in the context of LibMatrix/RMU to correctly address a server when looking up implementation type (which enables some implementation-specific optimisations and features).

I can downgrade this to only cover client and support records if wanted.