### PR TITLE
Initial Governing Board pages

### DIFF
--- a/content/foundation/governing-board-elections/index.md
+++ b/content/foundation/governing-board-elections/index.md
@@ -6,6 +6,8 @@ extra.summary = """
 The list of candidates and their information.
 """
 weight = 2
+# Hidden from navigation. The links are still accessible.
+extra.navigation = false
 +++
 
 Announcements are posted on our blog, our social channels, as well as in the [Office of the Matrix.org Foundation](https://matrix.to/#/#foundation-office:matrix.org) room and the [Matrix News](https://matrix.to/#/#matrix-news:matrix.org) room.
@@ -97,25 +99,25 @@ We intend to charter committees – such as for finance, which would review our 
 
 These are the candidates who are now elected representatives:
 
-- Andy Balaam (he/him), Individual Member
-- Greg Sutcliffe (he/him), Individual Member
-- J.B. Crawford (they/them), Individual Member
-- Sumner Evans, Individual Member
-- Bram van den Heuvel (he/they), Elm SDK, Ecosystem Member
-- Kim Brose (he/him), Matrix Community Events, Ecosystem Member
-- Nicolas Werner (he/him), Nheko-Reborn, Ecosystem Member
-- Cleo Menenez Jr. (he/him), GNOME Foundation, Associate Member
-- Tobias Fella (he/him), KDE e.V., Associate Member
-- Neil Johnson (he/him), Element, Platinum Member
-- Brad Murray (he/him), Automattic (Beeper), Gold Member
-- Kevin Boos (he/him), Futurewei Technologies, Gold Member
-- Jan Kohnert (he/him), Gematik GmbH, Silver Member
-- Thor Arne Johansen, Verji Tech AS, Silver Member
-- Amandine Le Pape (she/her), Guardian
-- Matthew Hodgson (he/him), Guardian
-- Ross Schulman, Guardian
-- Richard van der Hoff (he/him), Spec Core Team
-- Travis Ralston (he/him), Spec Core Team
+* Andy Balaam (he/him), Individual Member
+* Greg Sutcliffe (he/him), Individual Member
+* J.B. Crawford (they/them), Individual Member
+* Sumner Evans, Individual Member
+* Bram van den Heuvel (he/they), Elm SDK, Ecosystem Member
+* Kim Brose (he/him), Matrix Community Events, Ecosystem Member
+* Nicolas Werner (he/him), Nheko-Reborn, Ecosystem Member
+* Cleo Menenez Jr. (he/him), GNOME Foundation, Associate Member
+* Tobias Fella (he/him), KDE e.V., Associate Member
+* Neil Johnson (he/him), Element, Platinum Member
+* Brad Murray (he/him), Automattic (Beeper), Gold Member
+* Kevin Boos (he/him), Futurewei Technologies, Gold Member
+* Jan Kohnert (he/him), Gematik GmbH, Silver Member
+* Thor Arne Johansen, Verji Tech AS, Silver Member
+* Amandine Le Pape (she/her), Guardian
+* Matthew Hodgson (he/him), Guardian
+* Ross Schulman, Guardian
+* Richard van der Hoff (he/him), Spec Core Team
+* Travis Ralston (he/him), Spec Core Team
 
 And these elected representatives are joined by the Foundation's Managing Director, Robin Riley (they/them), who represents the Foundation in an ex officio capacity.
 

--- a/content/foundation/governing-board/index.md
+++ b/content/foundation/governing-board/index.md
@@ -1,0 +1,121 @@
++++
+title = "Governing Board"
+weight = 3
+extra.summary = """
+The Governing Board is an advisory board that is made up of elected representatives from all across the Matrix ecosystem. The role of the Governing Board is to offer guidance and support to the Guardians, Foundation staff, and Spec Core Team.
+"""
++++
+
+The Governing Board is an advisory board that is made up of elected representatives from all across the Matrix ecosystem. The role of the Governing Board is to offer guidance and support to the Guardians, Foundation staff, and Spec Core Team. It is organized under [these bylaws](/media/2024-04-governing-board-terms-of-reference.pdf) (v1.2, last updated April 2024).
+
+There are nine different constituency groups that are allocated seats on the Governing Board, across three categories:
+
+* **Community representatives**
+  * 4 seats for Individual Members – these are people who currently provide financial support to the Foundation.
+  * 3 seats for Ecosystem Members – these are FOSS projects and communities around Matrix.
+  * 2 seats for Associate Members – these are FOSS foundations, academic institutions, and other communities that are aligned with key parts of our mission.
+* **Funder representatives**
+  * 4 seats for Platinum Members – these organisations sponsor at the highest level.
+  * 3 seats for Gold Members — these organisations sponsor at a high level.
+  * 2 seats for Silver Members — these organisations sponsor at a level commensurate with the size of their organisation.
+* **Foundation representatives**
+  * 3 seats for Guardians – these are the members of the Foundation's board of directors.
+  * 2 seats for the Spec Core Team – these are the members of the Spec Core Team that looks after the spec.
+  * Managing Director – this is the Foundation's head of staff.
+
+Elections are being held in the second quarter of each calendar year, alternating halves of the Consituency Groups representatives on the Governing Board as per the following calendar:
+
+* April-June 2024, and any subsequent even-numbered years: Guardians, SCT, Platinum and Ecosystem
+* April-June 2025, and any subsequent odd-numbered years: Gold, Silver, Individual, Associate
+
+## Elected representatives
+
+The current elected representatives are:
+
+<div class="two-column">
+<div>
+
+### Individual Members
+
+* Andy Balaam (he/him)
+* Greg Sutcliffe (he/him)
+* J.B. Crawford (they/them)
+* Sumner Evans
+
+</div>
+<div>
+
+### Ecosystem Members
+
+* Bram van den Heuvel (he/they), Elm SDK
+* Kim Brose (he/him), Matrix Community Events
+* Nicolas Werner (he/him), Nheko-Reborn
+
+</div>
+<div>
+
+### Associate Members
+
+* Cleo Menenez Jr. (he/him), GNOME Foundation
+* Tobias Fella (he/him), KDE e.V.
+
+</div>
+<div>
+
+### Platinum Members
+
+* Neil Johnson (he/him), Element
+
+</div>
+<div>
+
+### Gold Members
+
+* Brad Murray (he/him), Automattic (Beeper)
+* Kevin Boos (he/him), Futurewei Technologies
+
+</div>
+<div>
+
+### Silver Members
+
+* Jan Kohnert (he/him), Gematik GmbH
+* Thor Arne Johansen, Verji Tech AS
+
+</div>
+<div>
+
+### Guardians
+
+* Amandine Le Pape (she/her)
+* Matthew Hodgson (he/him)
+* Ross Schulman
+
+</div>
+<div>
+
+### Spec Core Team
+
+* Richard van der Hoff (he/him)
+* Travis Ralston (he/him)
+
+</div>
+
+</div>
+
+## Where can I reach the Governing Board?
+
+The Governing Board has a dedicated room on Matrix, [#governing-board-office:matrix.org](https://matrix.to/#/#governing-board-office:matrix.org), where you can reach out to them.
+
+## Committees
+
+There are currently 4 Committees:
+
+* Community
+* Governance
+* Trust & Safety
+* Finance & Fundraising
+
+## Working Groups
+
+The Working Groups are a collection of groups that are formed to work on specific tasks or projects that are important to the Matrix ecosystem. The Working Groups are made up of members from the Matrix ecosystem and are overseen by the Governing Board. You can find more information about the Working Groups [here](/foundation/working-groups).

--- a/content/foundation/working-groups/index.md
+++ b/content/foundation/working-groups/index.md
@@ -1,0 +1,10 @@
++++
+title = "Governing Board Working Groups"
+template = "governing-board/working_groups.html"
+weight = 4
+extra.summary = """
+The Working Groups are a collection of groups that are formed to work on specific tasks or projects that are important to the Matrix ecosystem. The Working Groups are made up of members from the Matrix ecosystem and are overseen by the Governing Board.
+"""
++++
+
+The Working Groups are a collection of groups that are formed to work on specific tasks or projects that are important to the Matrix ecosystem. The Working Groups are made up of members from the Matrix ecosystem and are overseen by the Governing Board.

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -1,0 +1,14 @@
+[[working_groups]]
+name = "Website Working Group"
+summary = "Editoral and technical oversight of the main websites and socials"
+description = """
+The website working group is responsible for the editorial and technical oversight of the main Matrix websites and social media channels.
+This includes the main matrix.org website, Event website, and the various social media channels.
+The group is responsible for ensuring that the websites are up to date, accurate, and reflect the current state of the Matrix ecosystem.
+The group is not responsible for domain-specific content of other Teams like the spec.matrix.org website, matrix.org Homeserver related configuraions or the legal and security sections of the website.
+
+Note that this is not the complete list of responsibilities, but a high level overview.
+"""
+members = ["Thib", "HarHarLinks", "MTRNord"]
+matrix_room_alias = "#matrix.org-website:matrix.org"
+committee = "Community"

--- a/sass/_governing-board.scss
+++ b/sass/_governing-board.scss
@@ -1,0 +1,11 @@
+.two-column {
+    display: block;
+}
+
+
+@media (min-width: 768px) {
+    .two-column {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+    }
+}

--- a/sass/_working-groups.scss
+++ b/sass/_working-groups.scss
@@ -1,0 +1,116 @@
+.working-group-content {
+    font-size: 1.25rem;
+    font-weight: lighter;
+    line-height: 1.5;
+}
+
+.working_group {
+    margin-top: 2rem;
+    font-size: 1rem;
+    font-weight: normal;
+    line-height: 1.75;
+
+    header {
+        hr {
+            margin: 0.125rem;
+        }
+    }
+
+    .summary {
+        font-size: 1.25rem;
+        font-weight: 300;
+        margin-bottom: 0.5rem;
+    }
+
+    .description {
+        p {
+            margin-bottom: 0.5rem;
+        }
+    }
+
+    .button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: row;
+        width: min-content;
+        gap: 0.5rem;
+
+        cursor: pointer;
+        user-select: none;
+        border: 1px solid black;
+        border-radius: 0.25rem;
+        background-color: white;
+        padding: 0.5rem;
+
+        transition: fill 0.15s ease-in-out, color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+
+        svg {
+            /* Center the icon vertically next to the text */
+            vertical-align: middle;
+            width: 0.9rem;
+            height: 0.9rem;
+            display: inline-block;
+
+            path {
+                fill: #000000;
+                transition: fill 0.15s ease-in-out, color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+            }
+        }
+
+        span {
+            white-space: nowrap;
+            font-size: 1rem;
+            line-height: 1;
+            color: black;
+            text-decoration: none;
+            text-align: center;
+            vertical-align: middle;
+
+            transition: fill 0.15s ease-in-out, color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        }
+
+        &:hover {
+            span {
+                color: white;
+            }
+
+            background-color: black;
+            border-color: black;
+
+            path {
+                fill: #ffffff;
+            }
+        }
+    }
+
+    .comittee-pill {
+        border-radius: 0.25rem;
+        color: white;
+        padding: 0.5rem;
+        text-align: center;
+        font-size: 0.75rem;
+        font-weight: 500;
+        vertical-align: middle;
+        margin-left: 0.5rem;
+
+        background-color: #6c757d;
+
+        &.community {
+            background-color: #007bff;
+        }
+
+        &.governence {
+            background-color: #28a745;
+        }
+
+        &.trust-and-safety {
+            background-color: #dc3545;
+        }
+
+        &.finance {
+            background-color: #ffc107;
+        }
+    }
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -21,3 +21,5 @@
 @import '_support';
 @import '_howitworks';
 @import '_elections';
+@import '_working-groups';
+@import '_governing-board';

--- a/templates/governing-board/working_groups.html
+++ b/templates/governing-board/working_groups.html
@@ -1,0 +1,46 @@
+{% extends "page.html" %}
+{% block content -%}
+<article class="content working-group-content">
+    <header>
+        <h1>{{ page.title }}</h1>
+    </header>
+
+    {{ page.content | safe }}
+
+    {% set wg_path = page.path ~ "working_groups.toml" %}
+    {% set working_groups = load_data(path=wg_path, format="toml") %}
+
+    {% for wg in working_groups.working_groups %}
+    {% if wg.committee == "Community" %}
+    {% set committee_id = "community" %}
+    {% elif wg.committee == "Governance" %}
+    {% set committee_id = "governance" %}
+    {% elif wg.committee == "Trust & Safety" %}
+    {% set committee_id = "trust-and-safety" %}
+    {% elif wg.comittee == "Finance & Fundraising" %}
+    {% set committee_id = "finance" %}
+    {% endif %}
+
+    <section class="working_group">
+        <header>
+            <h2>{{ wg.name }} <span class="comittee-pill {{ committee_id }}">{{ wg.committee
+                    }}</span>
+                <hr />
+        </header>
+        <p class="summary">{{ wg.summary }}</p>
+        <div class="description">
+            <p class="members"><strong>Members:</strong> {{ wg.members | join(sep=", ") }}</p>
+            <p>{{ wg.description | markdown(inline=true) | safe }}</p>
+            <a href="https://matrix.to/#/{{ wg.matrix_room_alias }}" class="button"><svg viewBox="0 0 32 32"
+                    xmlns="http://www.w3.org/2000/svg">
+                    <path d="M 30,2.0000001 V 30 h -1 -2 v 2 h 5 V -3.3333334e-8 L 27,0 v 2 z" />
+                    <path
+                        d="M 9.9515939,10.594002 V 12.138 h 0.043994 c 0.3845141,-0.563728 0.8932271,-1.031728 1.4869981,-1.368 0.580003,-0.322998 1.244999,-0.485 1.993002,-0.485 0.72,0 1.376999,0.139993 1.971998,0.42 0.595,0.279004 1.047001,0.771001 1.355002,1.477001 0.338003,-0.500001 0.795999,-0.941 1.376999,-1.323001 0.579999,-0.382998 1.265998,-0.574 2.059998,-0.574 0.602003,0 1.160002,0.074 1.674002,0.220006 0.514,0.148006 0.953998,0.382998 1.321999,0.706998 0.36601,0.322999 0.653001,0.746 0.859,1.268002 0.205001,0.521998 0.307994,1.15 0.307994,1.887001 v 7.632997 h -3.127 v -6.463997 c 0,-0.383002 -0.01512,-0.743002 -0.04399,-1.082003 -0.02079,-0.3072 -0.103219,-0.607113 -0.242003,-0.881998 -0.133153,-0.25081 -0.335962,-0.457777 -0.584001,-0.596002 -0.257008,-0.146003 -0.605998,-0.220006 -1.046997,-0.220006 -0.440002,0 -0.796003,0.085 -1.068,0.253002 -0.272013,0.170003 -0.485001,0.390002 -0.639001,0.662003 -0.159119,0.287282 -0.263585,0.601602 -0.307994,0.926997 -0.05197,0.346923 -0.07801,0.697217 -0.07801,1.048002 v 6.353999 h -3.128005 v -6.398 c 0,-0.338003 -0.0072,-0.673001 -0.02116,-1.004001 -0.01134,-0.313663 -0.07487,-0.623229 -0.187994,-0.915999 -0.107943,-0.276623 -0.300435,-0.512126 -0.550001,-0.673001 -0.25799,-0.168 -0.636,-0.253002 -1.134999,-0.253002 -0.198123,0.0083 -0.394383,0.04195 -0.584002,0.100006 -0.258368,0.07446 -0.498455,0.201827 -0.704999,0.373985 -0.227981,0.183987 -0.421999,0.449 -0.583997,0.794003 -0.161008,0.345978 -0.242003,0.797998 -0.242003,1.356998 v 6.618999 H 6.99942 V 10.590001 Z" />
+                    <path d="M 2,2.0000001 V 30 h 3 v 2 H 0 V 9.2650922e-8 L 5,0 v 2 z" />
+                </svg><span>Chat</span></a>
+        </div>
+    </section>
+    {% endfor %}
+
+</article>
+{%- endblock content %}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -20,10 +20,16 @@
                 <div class="section-submenu">
                     {% for subsection_path in section.subsections %}
                     {% set subsection = get_section(path=subsection_path) %}
+                    <!-- We ignore subsections with "navigation" key being false in the metadata. Note this variable may be unset -->
+                    {% if subsection.extra.navigation is not defined or subsection.extra.navigation %}
                     <a href="{{ subsection.path }}">{{ subsection.title }}</a>
+                    {% endif %}
                     {% endfor %}
                     {% for page in section.pages %}
+                    <!-- We ignore subsections with "navigation" key being false in the metadata. Note this variable may be unset -->
+                    {% if page.extra.navigation is not defined or page.extra.navigation %}
                     <a href="{{ page.path }}">{{ page.title }}</a>
+                    {% endif %}
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
Adds a GB page and a working groups page. It also hides the elections page from the menu. The page is NOT removed to preserve links.

Review from @HarHarLinks or @GregSutcliffe for the content would be appreciated.

A sentence for the committee section might also be nice. I am not sure enough what's happening there so I only filled it very very basic.

If there are already more working groups to add, I can also take the toml data if sent as a comment and add it to the PR :)