### PR TITLE
feat(accessibility): improve accessibility of shop link button

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,7 @@ build_search_index = false
 
 default_language = "en"
 
-generate_feed = true
+generate_feeds = true
 
 taxonomies = [
     { name = "author", feed = false, paginate_by = 10 },

--- a/templates/support.html
+++ b/templates/support.html
@@ -13,6 +13,9 @@
                 <img src="/assets/donorbox-icon.svg" alt="" />
                 Donate with Donorbox
             </a>
+            <a class="call-to-action" href="https://shop.matrix.org">
+                Visit Our Shop
+            </a>
             <a class="call-to-action inverted" href="#help-us">More options</a>
         </div>
     </div>


### PR DESCRIPTION
Fixes #2260 

This adds the shop link as a Call to Action button on the support page, instead of it being hidden below in the footer, in order to make the shop link for shirts more accessible. 