### PR TITLE
fix nameclash in navbar template page variable

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -20,15 +20,15 @@
                 <div class="section-submenu">
                     {% for subsection_path in section.subsections %}
                     {% set subsection = get_section(path=subsection_path) %}
-                    <!-- We ignore subsections with "navigation" key being false in the metadata. Note this variable may be unset -->
+                    {# We ignore subsections with "navigation" key being false in the metadata. Note this variable may be unset #}
                     {% if subsection.extra.navigation is not defined or subsection.extra.navigation %}
                     <a href="{{ subsection.path }}">{{ subsection.title }}</a>
                     {% endif %}
                     {% endfor %}
-                    {% for page in section.pages %}
-                    <!-- We ignore subsections with "navigation" key being false in the metadata. Note this variable may be unset -->
-                    {% if page.extra.navigation is not defined or page.extra.navigation %}
-                    <a href="{{ page.path }}">{{ page.title }}</a>
+                    {% for mypage in section.pages %}
+                    {# We ignore subsections with "navigation" key being false in the metadata. Note this variable may be unset #}
+                    {% if mypage.extra.navigation is undefined or mypage.extra.navigation %}
+                    <a href="{{ mypage.path }}">{{ mypage.title }}</a>
                     {% endif %}
                     {% endfor %}
                 </div>


### PR DESCRIPTION
the iterator variable `page` nameclashed with the page variable of the current page (https://www.getzola.org/documentation/templates/pages-sections/#page-variables: "Whichever template you decide to render, you will get a page variable in your template [...]"), which means from a page with the navigation disabled you would override the other individual pages' setting.

This led to the following bug on the elections page:
![image](https://github.com/user-attachments/assets/c299bebf-7cac-4136-bec5-bab1fdfe1028)

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>