### PR TITLE
mark mx-puppet-bridges as obsolete

### DIFF
--- a/content/ecosystem/bridges/groupme/bridges.toml
+++ b/content/ecosystem/bridges/groupme/bridges.toml
@@ -4,7 +4,7 @@ maintainer = "kfatehi"
 summary = """
 This is a Matrix bridge for GroupMe
 """
-maturity = "Beta"
+maturity = "Obsolete"
 language = "TypeScript"
 license = "Apache-2.0"
 repo = "https://gitlab.com/robintown/mx-puppet-groupme"

--- a/content/ecosystem/bridges/slack/bridges.toml
+++ b/content/ecosystem/bridges/slack/bridges.toml
@@ -104,7 +104,7 @@ matrix together via (double)puppeting. Additionally a relay mode can be enabled.
 This bridge is part of the [mx-puppet-bridge](https://github.com/Sorunome/mx-puppet-bridge)
 suite of puppeting bridges.
 """
-maturity = "Alpha"
+maturity = "Obsolete"
 language = "TypeScript"
 license = "Apache-2.0"
 docs = "https://gitlab.com/mx-puppet/slack/mx-puppet-slack#quick-start-using-docker"


### PR DESCRIPTION
Resolves #2579
Supersedes #2621

Seems like we didn't have a lot of them on the page in the first place https://github.com/spantaleev/matrix-docker-ansible-deploy?tab=readme-ov-file#bridges

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>