### PR TITLE
Blog categories update and related misc fixes

### DIFF
--- a/content/blog/2014/09/2014-09-09-techcrunch-update.md
+++ b/content/blog/2014/09/2014-09-09-techcrunch-update.md
@@ -7,10 +7,10 @@ author = ["Matthew Hodgson"]
 category = ["Events"]
 +++
 
-The Matrix team is at <a href="http://techcrunch.com/events/disrupt-sf-2014/">TechCrunch Disrupt SF 2014</a> this week - we had a great time at the hackathon on Saturday/Sunday where we were really excited to see several teams building their hacks on Matrix APIs - we stayed the night to support whilst building out our own hack (experimenting with sending collaborative 3D animations over Matrix as JSON)!  Huge thanks to everyone who built on top of Matrix - hope you had as much fun as we did :)
+The Matrix team is at <a href="http://techcrunch.com/events/disrupt-sf-2014/">TechCrunch Disrupt SF 2014</a> this week - we had a great time at the hackathon on Saturday/Sunday where we were really excited to see several teams building their hacks on Matrix APIs - we stayed the night to support whilst building out our own hack (experimenting with sending collaborative 3D animations over Matrix as JSON)! Huge thanks to everyone who built on top of Matrix - hope you had as much fun as we did :)
 
 Please come talk to us in person in Startup Alley (next to the Brazilian Pavilion) if you're attending Disrupt and find out all about Matrix first hand!
 
 <a href="http://matrix.org/blog/wp-content/uploads/2014/09/6am.jpg"><img class="aligncenter size-large wp-image-138" src="http://matrix.org/blog/wp-content/uploads/2014/09/6am-1024x768.jpg" alt="6am Hackathon..." width="625" height="468" /></a>
 
-(Photo shows us somehow surviving in the 6am slot.  Mental note to never try to do raycasting vector maths after being up for 24 hours again...)
+(Photo shows us somehow surviving in the 6am slot. Mental note to never try to do raycasting vector maths after being up for 24 hours again...)

--- a/content/blog/2014/12/2014-12-24-matrix-wins-best-innovation-award-at-webrtc-paris.md
+++ b/content/blog/2014/12/2014-12-24-matrix-wins-best-innovation-award-at-webrtc-paris.md
@@ -4,7 +4,7 @@ path = "/blog/2014/12/24/matrix-wins-best-innovation-award-at-webrtc-paris"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["Events"]
+category = ["Events", "News"]
 +++
 
 Last week we had a great time attending WebRTC Conference Expo Paris 2014 - chatting to lots of new folks about Matrix; speaking in the "To Build or Not To Build" panel discussion; giving a general presentation on Matrix, and participating in the Demo shoot-out.

--- a/content/blog/2015/01/2015-01-29-looking-forward-to-fosdem.md
+++ b/content/blog/2015/01/2015-01-29-looking-forward-to-fosdem.md
@@ -4,7 +4,7 @@ path = "/blog/2015/01/29/looking-forward-to-fosdem"
 
 [taxonomies]
 author = ["Oddvar Lovaas"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 +++
 
 This weekend, Matrix is heading to FOSDEM (Free and Open Source Software Developers' European Meeting) in Brussels, Belgium. We will be hosting two events: a <a href="https://fosdem.org/2015/schedule/event/matrix/" title="lightning talk">lightning talk</a> on Saturday at 16:30 in room H.2215 (Ferrer), and an <a href="https://fosdem.org/2015/schedule/event/deviot04/" title="IoT devroom talk">IoT devroom talk</a> on Sunday morning at 11:00 in room H.2213.

--- a/content/blog/2015/02/2015-02-04-back-from-fosdem.md
+++ b/content/blog/2015/02/2015-02-04-back-from-fosdem.md
@@ -4,7 +4,7 @@ path = "/blog/2015/02/04/back-from-fosdem"
 
 [taxonomies]
 author = ["Oddvar Lovaas"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 +++
 
 <a href="http://fosdem.org" title="FOSDEM">FOSDEM</a> was great fun! Two days full of conferences and demos; lots of interesting technologies and interested people - and most of all: talking to so many new faces about Matrix and potential uses and integration ideas. 

--- a/content/blog/2015/05/2015-05-26-next-up-kamailio-world.md
+++ b/content/blog/2015/05/2015-05-26-next-up-kamailio-world.md
@@ -7,7 +7,9 @@ author = ["Oddvar Lovaas"]
 category = ["Events"]
 +++
 
-<a href="http://conference.kamailio.com/k03/"><img src="http://matrix.org/blog/wp-content/uploads/2015/05/kamailio-world-banner-2014-200x90.png" alt="kamailio-world-banner-2014-200x90" width="200" height="90" class="alignleft size-full wp-image-1031" /></a>In our continuous journey around the world to promote Matrix, this week we have come to <a href="http://conference.kamailio.com/k03/" alt="Kamailio World">Kamailio World</a> in Berlin, Germany. During the conference, there will be 5 technical workshops and 28 presentations about SIP, VoIP, WebRTC and other real time communication technologies - and Matthew will talk about Matrix at 11am on Friday.
+<a href="http://conference.kamailio.com/k03/"><img src="http://matrix.org/blog/wp-content/uploads/2015/05/kamailio-world-banner-2014-200x90.png" alt="kamailio-world-banner-2014-200x90" width="200" height="90" class="alignleft size-full wp-image-1031" /></a>
+
+In our continuous journey around the world to promote Matrix, this week we have come to <a href="http://conference.kamailio.com/k03/" alt="Kamailio World">Kamailio World</a> in Berlin, Germany. During the conference, there will be 5 technical workshops and 28 presentations about SIP, VoIP, WebRTC and other real time communication technologies - and Matthew will talk about Matrix at 11am on Friday.
 
 I'm looking forward to lots of interesting talks (full schedule <a href="http://conference.kamailio.com/k03/schedule/">here</a>), including an open discussion panel with Randy Resnick about real-time communications at 17:10 Thursday evening. Of course there will also be dangerous demos - and hopefully lots of people interested in Matrix! If you are going to the conference, please come and say hello - we will be exhibiting as well as presenting, and we will be there all day Thursday and Friday. 
 

--- a/content/blog/2015/12/2015-12-14-webrtc-conference-expo-in-paris.md
+++ b/content/blog/2015/12/2015-12-14-webrtc-conference-expo-in-paris.md
@@ -7,7 +7,9 @@ author = ["Oddvar Lovaas"]
 category = ["Events"]
 +++
 
-<a href="http://www.uppersideconferences.com/webrtc/"><img src="/blog/wp-content/uploads/2015/12/a4webrtc_2015_v2.jpg" alt="a4webrtc_2015_v2" width="300" height="424" class="alignleft size-full wp-image-1419" /></a>Matrix will again be represented at the <a href="http://www.uppersideconferences.com/webrtc/">WebRTC Conference & Expo</a> in Paris. Daniel and myself are catching the Eurostar tomorrow afternoon, and the conference will start early Wednesday morning with a panel about WebRTC for Mobile, where Daniel is one of the participants.
+<a href="http://www.uppersideconferences.com/webrtc/"><img src="/blog/wp-content/uploads/2015/12/a4webrtc_2015_v2.jpg" alt="a4webrtc_2015_v2" width="300" height="424" class="alignleft size-full wp-image-1419" /></a>
+
+Matrix will again be represented at the <a href="http://www.uppersideconferences.com/webrtc/">WebRTC Conference & Expo</a> in Paris. Daniel and myself are catching the Eurostar tomorrow afternoon, and the conference will start early Wednesday morning with a panel about WebRTC for Mobile, where Daniel is one of the participants.
 
 I'm sure we will have three days full of interesting talks and discussions (see the <a href="http://www.uppersideconferences.com/webrtc/webrtc_2015_program_day_1.html">full schedule here</a>). There will be demos as well, and Matrix is (of course!) also joining the demo competition. We hope to see many familiar faces - and hopefully meet some new ones as well!
 

--- a/content/blog/2015/12/2015-12-25-the-matrix-holiday-special.md
+++ b/content/blog/2015/12/2015-12-25-the-matrix-holiday-special.md
@@ -9,7 +9,7 @@ category = ["Events"]
 
 Hi all,
 
-We've been pretty bad at updating the blog over the last few months with all the progress that's been happening with Matrix.  Whilst Matrix rooms like #matrix:matrix.org and #matrix-dev:matrix.org have been very active (and our <a href="https://twitter.com/matrixdotorg">twitter account</a> too), in general we've ended up spending way too much time actually writing software and not enough time talking about it, at least here. When a blog goes quiet it normally means that either the authors have got bored, or they're too busy building cool stuff to keep it updated. I'm happy to say that option 2 is the case here!
+We've been pretty bad at updating the blog over the last few months with all the progress that's been happening with Matrix. Whilst Matrix rooms like #matrix:matrix.org and #matrix-dev:matrix.org have been very active (and our <a href="https://twitter.com/matrixdotorg">twitter account</a> too), in general we've ended up spending way too much time actually writing software and not enough time talking about it, at least here. When a blog goes quiet it normally means that either the authors have got bored, or they're too busy building cool stuff to keep it updated. I'm happy to say that option 2 is the case here!
 
 As a result, there's a huge backlog of really cool stuff we should have talked about. Hopes of writing an Advent Calendar series of blog posts also went out the window as we set Christmas as an arbitrary deadline for loads of work on Synapse, the Matrix Spec and matrix-react-sdk.
 

--- a/content/blog/2015/12/2015-12-25-the-matrix-holiday-special.md
+++ b/content/blog/2015/12/2015-12-25-the-matrix-holiday-special.md
@@ -4,7 +4,7 @@ path = "/blog/2015/12/25/the-matrix-holiday-special"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["Events"]
+category = ["General", "Holiday Special"]
 +++
 
 Hi all,
@@ -14,6 +14,8 @@ We've been pretty bad at updating the blog over the last few months with all the
 As a result, there's a huge backlog of really cool stuff we should have talked about. Hopes of writing an Advent Calendar series of blog posts also went out the window as we set Christmas as an arbitrary deadline for loads of work on Synapse, the Matrix Spec and matrix-react-sdk.
 
 So, to try to break the impasse, here's a slightly unorthodox whistle-stop tour of all the amazing blogposts we *would* have written if we'd had time. And perhaps some of them will actually expand into full write-ups when we have more time to spare in the future :)
+
+<!-- more -->
 
 ## End to End Encryption Update
 

--- a/content/blog/2016/01/2016-01-18-fosdem-16.md
+++ b/content/blog/2016/01/2016-01-18-fosdem-16.md
@@ -4,7 +4,7 @@ path = "/blog/2016/01/18/fosdem-16"
 
 [taxonomies]
 author = ["Oddvar Lovaas"]
-category = ["Events"]
+category = ["FOSDEM", "Events"]
 +++
 
 <img src="http://matrix.org/blog/wp-content/uploads/2016/01/wide.png" alt="wide" width="468" height="60" class="alignleft size-full wp-image-1466" />

--- a/content/blog/2016/02/2016-02-03-fosdem-16-retrospective.md
+++ b/content/blog/2016/02/2016-02-03-fosdem-16-retrospective.md
@@ -4,7 +4,7 @@ path = "/blog/2016/02/03/fosdem-16-retrospective"
 
 [taxonomies]
 author = ["Oddvar Lovaas"]
-category = ["Events"]
+category = ["FOSDEM", "Events"]
 +++
 
 <img src="/blog/wp-content/uploads/2016/02/stand.jpg" alt="stand" width="1024" height="576" class="aligncenter size-full wp-image-1493" />

--- a/content/blog/2016/03/2016-03-26-the-matrix-spring-special.md
+++ b/content/blog/2016/03/2016-03-26-the-matrix-spring-special.md
@@ -4,22 +4,22 @@ path = "/blog/2016/03/26/the-matrix-spring-special"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General", "GSOC"]
+category = ["General", "GSOC", "Holiday Special"]
 +++
 
 It's been 3 months since the <a href="/blog/2015/12/25/the-matrix-holiday-special/">Matrix Holiday Special</a> and once again we've all been too busy writing code to put anything that detailed on the blog.  So without further a do here's a quick overview of how things have progressed so far in 2016!
 
-### Home servers
+## Home servers
 
-<br/>
-
-#### Synapse
+### Synapse
 
 Work on <a href="http://github.com/matrix-org/synapse">Synapse</a> (our reference homeserver) has been primarily focused on improving performance.  This may sound boring, but there's been a huge amount of improvement here since synapse 0.12 was released on Jan 4. Synapse 0.13 on Feb 10 brought huge CPU savings thanks to a whole fleet of caching and other optimisation work - the best way of seeing the difference here is to look at the load graph of the server that hosts matrix.org's synapse+postgres over the last few months:
 
 <img src="/blog/wp-content/uploads/2016/03/matrix-org-load.png" alt="matrix-org-load" width="497" height="173" class="aligncenter size-full wp-image-1563" />
 
 Ignoring the unrelated blip during March, you can see an enormous step change in system load (which had a matching decrease in actual CPU usage) at the beginning of Feb when the 0.13 optimisations landed on matrix.org :)
+
+<!-- more -->
 
 Meanwhile, Synapse 0.14 is due any day now with <a href="https://github.com/matrix-org/synapse/releases/tag/v0.14.0-rc2">0.14.0-rc2</a> released on Wednesday.  Here, the focus has been all about memory optimisation - anyone who's run a Synapse seriously will be aware that it can be a memory hog thanks to aggressively caching as much state and history in RAM as possible to avoid hitting the database and keeping everything responsive.  0.14 should improve memory usage just as dramatically as 0.13 improved CPU utilisation - introducing a quick-and-dirty SYNAPSE_CACHE_FACTOR environment variable that lets admins dial down the aggressiveness of the caching (at the expense of performance), but more interestingly implementing string interning and ensuring that events are cached by ID rather than duplicated across multiple caches in order to make memory usage more efficient.  It's too early to have impressive looking graphs, and there are still a few memory spikes being tracked down before we release 0.14, but we're hoping for at least a 50% reduction in memory footprint.
 
@@ -29,29 +29,21 @@ Finally, Synapse is now part of <a href="http://www.freshports.org/net/py-matrix
 
 It's incredibly exciting to see Synapse's maturity improving and hitting the optimisation stage of its life; huge kudos to Erik for spearheading the optimisation work.  We strongly recommend folks upgrade to 0.14 when it's available; it's never been a better time to run a homeserver! :D
 
-<br/>
-
-#### Dendron
+### Dendron
 
 Meanwhile, <a href="https://github.com/matrix-org/dendron">Dendron</a> (our next generation homeserver) development has been progressing interestingly: we finished an initial spike to get a Golang skeleton server in place, albeit one that delegates most of the endpoints through to Synapse.  In fact, matrix.org itself has been running via Dendron since February!
 
 The whole point of Dendron is to provide an architecture where we can split apart the various endpoints that Synapse provides today, re-implementing them where appropriate in Golang, and critically letting the endpoints scale horizontally with clusters of backend servers abstracted by the single Dendron API facade.  As a result, most of the Dendron work has actually ended up going into restructuring Synapse such that multiple Synapses can be run in a cluster behind a single Dendron, allowing us to horizontally scale API endpoints at last.  This takes the form of adding <a href="https://github.com/matrix-org/synapse/commit/1acc319070c0390d2330003bdc1e71cc66383dbb">cluster replication support</a> to Synapse.  This is still work-in-progress as we go through fixing up more and more state to be replicable (replicatable?) between synapses - hopefully it should land in the Synapse 0.15 timeframe.  And then we enter a very very interesting new world of horizontally scalable homeservers...
 
-<br/>
-
-#### Ruma
+### Ruma
 
 <a href="https://ruma.dev/">Ruma</a> has also seen some progress over the last few months - Ruma is an independent Rust language homeserver project led by Jimmy Cuadra, and whilst in early development still (currently focusing on the user login and registration system) shows a lot of promise.  Lots of work has ended up going into the required Rust dependencies rather than the Matrix code itself, but if you're interested in Rust then please drop by <a href="https://vector.im/beta/#/room/#ruma:matrix.org">#ruma:matrix.org</a> or #ruma on Freenode and say hi!
 
-<br/>
-
-### Clients
+## Clients
 
 Whilst homeserver development is mainly all about performance and scaling work currently, the client side of the Matrix ecosystem is the polar opposite - with lots of rapid progress on exciting new clients happening from all over the community.
 
-<br/>
-
-#### Perpetually Talking Online (PTO)
+### Perpetually Talking Online (PTO)
 
 <a href="http://pto.im/">PTO</a> has evolved enormously since Torrie Fischer first revealed it at the end of 2015.  PTO is an independent project that acts as a Matrix client that exposes an IRC server interface - effectively turning any Matrix homeserver into an ircd; letting folks hook their favourite IRC clients directly into Matrix and use it as an enormous decentralised IRC network.  (N.B. this is not to be confused with <a href="https://github.com/matrix-org/matrix-appservice-irc">matrix-appservice-irc</a>, which acts as a server-side bridge between Matrix rooms and IRC channels.)  Obviously you lose some of the Matrix specific features (read receipts, typing notifs, VoIP, etc) but there's clearly a huge benefit for the IRC community to be able to use Matrix as if it were an IRC network.
 
@@ -63,23 +55,17 @@ There's one catch though - XChat was never quite built to handle the hundreds of
 
 Come hang out in <a href="https://vector.im/beta/#/room/#pto:oob.systems">#pto:oob.systems</a> if you're interested in PTO!
 
-<br/>
-
-#### Quaternion
+### Quaternion
 
 <a href="https://github.com/Fxrh/Quaternion">Quaternion</a> is a new Qt/QML/C++ desktop client created by Felix Rohrbach.  It's a fairly early alpha but still quite usable and in very active development. <a href="https://vector.im/beta/#/room/#quaternion:matrix.org">#quaternion:matrix.org</a> is the place to talk all things Quaternion :)
 
 <img src="/blog/wp-content/uploads/2016/03/quaternion-1024x702.png" alt="quaternion" width="1024" height="702" class="aligncenter size-large wp-image-1566" />
 
-<br/>
-
-#### matrix-glib-sdk
+### matrix-glib-sdk
 
 Meanwhile, over on the GTK side of the world, Gergely Polonkai has been been making great progress on his <a href="https://github.com/gergelypolonkai/matrix-glib-sdk">matrix-glib-sdk</a> Glib client SDK for Matrix.  The end goal here is to implement a full <a href="https://telepathy.freedesktop.org">Telepathy</a> plugin for Matrix on top of the SDK.  Originally written in C, but now shifted to Vala, the SDK is in very active development and now implements all(?) of the Matrix client-server API - a snapshot of the work-in-progress SDK API docs can be found at <a href="http://gergely.polonkai.eu/matrix-glib-sdk/">http://gergely.polonkai.eu/matrix-glib-sdk</a>.  Next up is a formal release and building out clients on top!
 
-<br/>
-
-#### matrix-react-sdk, matrix-ios-sdk, matrix-android-sdk and Vector
+### matrix-react-sdk, matrix-ios-sdk, matrix-android-sdk and Vector
 
 Finally, huge amounts of time and effort have continued to be pumped into the official <a href="http://github.com/matrix-org/matrix-react-sdk">matrix-react-sdk</a>, <a href="http://github.com/matrix-org/matrix-ios-sdk">matrix-ios-sdk</a> and <a href="http://github.com/matrix-org/matrix-android-sdk">matrix-android-sdk</a> - driven substantially by requirements for <a href="http://vector.im">Vector</a>, the <a href="http://github.com/vector-im">FOSS</a> Matrix-powered collaboration app that we've been helping with:
 
@@ -110,9 +96,7 @@ The best way of seeing what's been going on here is probably by considering Vect
 
 All that remains right now is yet more bugfixing and incorporating feedback from the current betas!  Please give as much feedback as possible in <a href="https://vector.im/beta/#/room/#vector:matrix.org">#vector:matrix.org</a> :)
 
-<br/>
-
-### Bridges & Bots
+## Bridges & Bots
 
 Bridges, bots, and other integrations and application services have inevitably taken slightly lower priority whilst we've been focusing on the core server and client bits of the ecosystem.  However, as of March we've started a major new project to get these moving again, starting with a big update to the <a href="https://github.com/matrix-org/matrix-appservice-irc">IRC Bridge</a>.  This is due to be released next week, but you can get a sneak peek at what's going into the release at the <a href="https://github.com/matrix-org/matrix-appservice-irc/commits/develop">commit log</a>.  Highlights include the ability to persist nicks; connect via IPv6; improve formatted message handling; actually feed error messages from IRC back to Matrix; and much much more.
 
@@ -126,29 +110,21 @@ Totally forgot to mention a few of the key new bridges which have been contribut
 
 Similarly, <a href="https://github.com/matrix-org/matrix-appservice-gitter">matrix-appservice-gitter</a> is a Gitter<->Matrix bridge built by Leonerd on top of the <a href="https://github.com/matrix-org/matrix-appservice-bridge">matrix-appservice-bridge</a> Node library.  Again, it's early days but is working well for 'hardcoded' bridging - supporting dynamic rooms and users is next on the todo list :)
 
-<br/>
-
-### The Spec
+## The Spec
 
 We started our formal release process for the spec just before Christmas with r0.0.0 - and released <a href="http://matrix.org/docs/spec/r0.0.1">r0.0.1</a> in January with <a href="http://matrix.org/docs/spec/r0.0.1/client_server.html#changelog">minor clarifications and updates</a>.  In practice the spec feels quite stable right now, although things have moved on a bit since January and r0.0.2 is definitely overdue at this point.
 
 In the meantime, you can always get the very latest bleeding edge copy of the spec via <a href="http://matrix.org/speculator">the speculator</a>.  We've also added an initial cut at a spec for the <a href="http://matrix.org/speculator/spec/HEAD/identity_service.html">Identity Service</a> at last.
 
-<br/>
-
-### Events
+## Events
 
 We've been focusing on writing code than evangelising Matrix recently, although we did get out to <a href="/blog/2016/02/03/fosdem-16-retrospective/">FOSDEM 2016</a> and <a href="/blog/2016/02/09/matrix-in-japan/">TADHack Mini Japan and WebRTC Conference</a> and <a href="https://twitter.com/matrixdotorg/status/706916982960967680">Enterprise Connect 2016</a> where we showed off Matrix & Vector in the WebRTC Real World Innovation showcase.
 
-<br/>
-
-### GSoC
+## GSoC
 
 We are incredibly grateful to have been accepted as an organisation into Google Summer of Code 2016!  The last two weeks have been the window for students to propose projects to us that they could work on over the course of the summer, and it's been fascinating to meet the GSoCers and see a whole new community pop up on Matrix and advise and mentor applicants through their proposals.  At the last count we've received 35 proposals, many inspired by <a href="https://github.com/matrix-org/GSoC/blob/master/IDEAS.md">our list of ideas</a>, including some really impressive candidates - many thanks to all the students who have applied to us.  We don't know yet how many slots Google will allocate to us, but one way or another we're really looking forward to helping the GSoCers make the most out of their summer of Matrix!  All GSoC discussion is happening in <a href="https://vector.im/beta/#/room/#gsoc:matrix.org">#gsoc:matrix.org</a>.
 
-<br/>
-
-### What's next?
+## What's next?
 
 In no particular order, the urgent stuff that still remains includes:
 

--- a/content/blog/2016/07/2016-07-04-the-matrix-summer-special.md
+++ b/content/blog/2016/07/2016-07-04-the-matrix-summer-special.md
@@ -4,12 +4,14 @@ path = "/blog/2016/07/04/the-matrix-summer-special"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General", "GSOC"]
+category = ["General", "GSOC", "Holiday Special"]
 +++
 
 Hi folks - another few months have gone by and once again the core Matrix team has ended up too busy hacking away on the final missing pieces of the Matrix jigsaw puzzle to have been properly updating the blog; sorry about this. The end is in sight for the current crunch however, and we expect to return to regular blog updates shortly! Meanwhile, rather than letting news stack up any further, here's a quick(?) attempt to summarise all the things which have been going on!
 
-### Synapse 0.16.1 released!
+<!-- more -->
+
+## Synapse 0.16.1 released!
 
 This one's a biggy: in the mad rush during June to support the public debut for <a href="https://vector.im">Vector</a>, we made a series of major <a href="https://github.com/matrix-org/synapse">Synapse</a> releases which apparently we forgot to tell anyone about (sorry!). The full changelog is at the bottom of the post as it's huge, but the big features are:
 <ul>
@@ -28,7 +30,7 @@ There's also been a huge amount of work going on behind the scenes on horizontal
 
 In future we'll actually document how to run these, as well as making it easy to spin up multiple concurrent instances - in the interim if you find you're hitting performance limits running high-traffic synapses come talk to us about it on <a href="https://matrix.to/#/#matrix-dev:matrix.org">#matrix-dev:matrix.org</a>.  And the longer term plan continues to be to switch out these python endpoint implementations in future for more efficient implementations.  For instance, there's a golang implementation of the media repository currently in development which could run as another endpoint cluster.
 
-### Vector released!
+## Vector released!
 
 <a href="https://medium.com/@Vector/2d33b23a787">Much has been written</a> about this <a href="https://news.ycombinator.com/item?id=11871527">elsewhere</a>, but Web, iOS and Android versions of the <a href="https://www.vector.im">Vector</a> clients were finally released to the general public on June 9th at the <a href="http://www.decentralizedweb.net/">Decentralised Web Summit</a> in San Francisco.  Vector is a relatively thin layer on top of the <a href="https://github.com/matrix-org/matrix-react-sdk">matrix-react-sdk</a>, <a href="https://github.com/matrix-org/matrix-ios-sdk">matrix-ios-sdk</a> and <a href="https://github.com/matrix-org/matrix-android-sdk">matrix-android-sdk</a> Matrix.org client SDKs which showcases Matrix's collaboration and messaging capabilities in a mass-market usable app.  There's been huge amounts of work here across the SDKs for the 3 platforms, with literally thousands of issues resolved.  You can find the full SDK changelogs on github for <a href="https://github.com/matrix-org/matrix-react-sdk/blob/master/CHANGELOG.md">React</a>, <a href="https://github.com/matrix-org/matrix-ios-kit/blob/master/CHANGES.rst">iOS</a> and <a href="https://github.com/matrix-org/matrix-android-sdk/blob/master/CHANGES.rst">Android</a>.  Some of the more interesting recent additions to Vector include improved room notifications, URL previews, configurable email notifications, and huge amounts of performance stability work.
 
@@ -38,27 +40,27 @@ If you haven't checked it out recently, it's really worth a look :)
 
 <a href="https://vector.im"><img class="aligncenter size-large wp-image-1658" src="/blog/wp-content/uploads/2016/07/Screen-Shot-2016-07-04-at-12.18.10-1024x591.png" alt="Vector" width="1024" height="591" /></a>
 
-### Matrix Spec 0.1.0
+## Matrix Spec 0.1.0
 
 In case you didn't notice, we also released <a href="http://matrix.org/docs/spec/">v0.1.0 of the Matrix spec</a> itself in May - this is a fairly minor update which improves the layout of the document somewhat (thanks to a PR from Jimmy Cuadra) and a some bugfixes.  You can see the <a href="http://matrix.org/docs/spec/client_server/r0.1.0.html#changelog">full changelog here</a>. We're overdue a new release since then (albeit again with relatively minor changes).
 
-### Google Summer of Code
+## Google Summer of Code
 
 We're in the middle of the second half of GSoC right now, with our GSoC students Aviral and Half-Shot hacking away on Vector and Microblogging projects respectively.  There's a lot of exciting stuff coming out of this - Aviral contributing Rich Text Editing, Emoji autocompletion, DuckDuckGo and other features into Vector (currently on branches, but will be released soon) and Half-Shot building a Twitter bridge as part of his Matrix-powered microblogging system.  Watch this space for updates!
 
-### Ruma
+## Ruma
 
 Lots of exciting stuff has been happening recently over at <a href="https://ruma.dev/">Ruma.io</a> - an independent Matrix homeserver implementation written in Rust.  Over the last few weeks Jimmy and friends have got into the real meat of implementing e<a href="https://github.com/ruma/ruma/commit/8a2fe269196dfd5b629c6e301e8d78e19ae6d279">vents</a> and the core of the Matrix CS API, and as of the time of writing they're the <a href="https://news.ycombinator.com/item?id=12028475">topmost link</a> on HackerNews!  There's a lot of work involved in writing a homeserver, but Ruma is looking incredibly promising and the feedback from their team has been incredibly helpful in keeping us honest on the Matrix spec and ensuring that it's fit for purpose for 3rd party server implementers.
 
 Also, Ruma just released some <a href="https://ruma.dev/docs/matrix">truly excellent documentation</a> as a high-level introduction to Matrix (thanks to Leah and Jimmy) - much better than anything we have on the official Matrix.org site.  Go check it out if you haven't already!
 
-### End to End Encryption
+## End to End Encryption
 
 There has been *LOADS* of work happening on End to End encryption: finalising the core 1:1 "<a href="/git/olm">Olm</a>" cryptographic ratchet; implementing the group "<a href="http://matrix.org/git/olm/tree/src/megolm.c">Megolm</a>" ratchet (which shares a single ratchet over all the participants of a room for scalability); fully hooking Olm into matrix-js-sdk and Vector-web at last, and preparing for a formal and published-to-the-public 3rd party security audit on Olm which will be happening during July.
 
 This deserves a post in its own right, but the key thing to know is that Olm is almost ready - and indeed the work-in-progress E2E UX is even available on the <a href="https://vector.im/develop">develop branch of vector</a> if you enable E2E in the new 'Labs' section in User Settings.  Olm itself is usable only for 'burn after reading' strictly PFS messages, but Megolm integration with Vector & Synapse will follow shortly afterwards which will finally provide the E2E nirvana we've all been waiting for :)
 
-### Decentralised Web Summit
+## Decentralised Web Summit
 
 Matrix had a major presence as a sponsor at the first ever <a href="http://www.decentralizedweb.net/">Decentralised Web Summit</a> hosted by the Internet Archive in San Francisco back in June.  This was a truly incredible event - with folks gathering from across the world to discuss, collaborate and debate on ensure that the web is not fragmented or trapped into proprietary silos - with the likes of Tim Berners-Lee, Vint Cerf and Brewster Kahle in attendance.  We ran a long 2 hour workshop on Matrix and showed off Vector to anyone and everyone - and meanwhile the organisers were kind enough to promote Matrix as the main decentralised chat interface for the conference itself (bridged with their Slack).  A full writeup of the conference really merits a blog post in its own right, but the punchline is that you could genuinely tell that this is the beginning of a new era of the internet - whether it's using Merkle DAGs (like Matrix) or Blockchain or similar technologies: we are about to see a major shift in the balance of power on the internet back towards its users.
 
@@ -66,13 +68,13 @@ We strongly recommend checking out the videos which have all been published at 
 
 <a href="https://twitter.com/parkan/status/740324969884700672"><img class="aligncenter wp-image-1660 size-large" src="/blog/wp-content/uploads/2016/07/timbl-768x1024.jpg" alt="Matthew, Tim Berners-Lee and Matrix" width="384" height="512" /></a>
 
-### Matrix.to
+## Matrix.to
 
 Not the most exciting thing ever, but heads up that there's a simple site up at <a href="https://matrix.to">https://matrix.to</a> to provide a way of doing client-agnostic links to content in Matrix.  For instance, rather than linking specifically into an app like Vector, you can now say <a href="https://matrix.to/#/#matrix:matrix.org">https://matrix.to/#/#matrix:matrix.org</a> to go there via whatever app you choose.  This is basically a bootstrapping process towards having proper mx:// URLs in circulation, but given mx:// doesn't exist yet, https://matrix.to hopefully provides a useful step in the right direction :)
 
 PRs very welcome at <a href="https://github.com/matrix-org/matrix.to">https://github.com/matrix-org/matrix.to</a>.
 
-### Bridges and Bots
+## Bridges and Bots
 
 Much of the promise of Matrix is the ability to bridge through to other silos, and we've been gradually adding more and more bridging capabilities in.
 
@@ -108,7 +110,7 @@ Finally, <a href="https://github.com/matrix-org/Matrix-NEB">NEB</a> - the Matri
 
 There's little point in all of the effort going into bridges and bots if it's too hard for normal users to deploy them, so on the Vector side of things there's an ongoing project to build a commercial-grade bot/bridge hosted service offering for Matrix which should make it *much* easier for non-sysadmins to quickly add their own bots and bridges into their rooms.  There's nothing to see yet, but we'll be yelling about it when it's ready!
 
-### Conclusion
+## Conclusion
 
 I'm sure there's a lot of stuff missing from the quick summary above - suffice it to say that the Matrix ecosystem is growing so fast and so large that it's pretty hard to keep track of everything that's going on.  The big remaining blockers we see at this point are:
 <ul>
@@ -128,7 +130,7 @@ Thanks, once again, to everyone who's been supporting and using Matrix - whether
 
 Matthew, Amandine & the Matrix Team.
 
-### Appendix: The Missing Synapse Changelogs
+## Appendix: The Missing Synapse Changelogs
 
 ### Changes in synapse v0.16.1 (2016-06-20)
 

--- a/content/blog/2016/11/2016-11-12-the-matrix-autumn-special.md
+++ b/content/blog/2016/11/2016-11-12-the-matrix-autumn-special.md
@@ -4,12 +4,14 @@ path = "/blog/2016/11/12/the-matrix-autumn-special"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["In the News", "GSOC"]
+category = ["In the News", "GSOC", "Holiday Special"]
 +++
 
 Another season has passed; the leaves are dropping from the trees in the northern hemisphere (actually, in the time it's taken us to finish this post, most of them have dropped :-/) and once again the Matrix team has been hacking away too furiously to properly update the blog. So without further delay here's an update on all things Matrix!
 
-### Synapse 0.18
+<!-- more -->
+
+## Synapse 0.18
 
 Back in September, we forgot to properly announce the 0.18 release of Synapse! This is a major oversight given that 0.18 was a huge update with some critical performance improvements, but hopefully everyone has upgraded by now anyway. If not, there's never been a better time to <a href="https://github.com/matrix-org/synapse">run your own homeserver</a>! The main improvement is that the Matrix room state updates are now stored as deltas in the database rather than snapshots, which reduces the size of the database footprint by around 5 - 7x. The first time you run synapse after upgrading to 0.18 it will go through your database deleting all the historical data, after which you can VACUUM the db to reclaim the freed diskspace.
 
@@ -27,7 +29,7 @@ Spec for all of these new APIs are currently making their way into the official 
 
 To find out more and get upgraded if you haven't already, please check out <a href="https://github.com/matrix-org/synapse/releases/tag/v0.18.3">the full changelog</a>.
 
-### Synapse scalability
+## Synapse scalability
 
 Something which we've been quietly adding over the last 6 months is support for running large synapse deployments like the Matrix.org homeserver. Matrix.org has around 500K accounts on it, 50k rooms, and relays around 500K messages per day and obviously the community expects it to have good performance and availability (even though we'd prefer if you ran your own server, for obvious reasons!)
 
@@ -35,7 +37,7 @@ The current scaling approach for this is called 'Workers' - where we've split ou
 
 You can read more about the architecture and how to run your Synapse in worker-mode over at <a href="https://github.com/matrix-org/synapse/blob/master/docs/workers.rst">https://github.com/matrix-org/synapse/blob/master/docs/workers.rst</a>.
 
-### Starting a Riot (now Element)
+## Starting a Riot (now Element)
 
 Meanwhile, the biggest news in Matrixland has probably been the renaming of Vector as Riot (now Element) and the 'mass market' launch of Riot as a flagship Matrix client at the <a href="http://pulverhwc.evolero.com/monage">MoNage</a> conference on Sept 19th in Boston. The reasons for renaming Vector have been done to death by now and hopefully folks have got over the shock, but the rationale is to have a more distinctive and memorable (and controversial!) name, which is more aligned with the idea of returning control of communication back to the people :) Amandine has the full story over at the <a href="https://medium.com/@RiotChat/lets-riot-f5b0aa99dc8e">Riot blog</a>.
 
@@ -63,13 +65,13 @@ Stuff on the horizon includes:
 </ul>
 Riot (now Element) releases are announced on <a href="https://matrix.to/#/#riot:matrix.org">#riot:matrix.org</a>, the <a href="https://medium.com/@RiotChat">Riot blog</a> and <a href="http://twitter.com/@RiotChat">Twitter</a> - keep your eyes peeled for updates!
 
-### End to End Encryption
+## End to End Encryption
 
 Full cross-platform end-to-end encryption is incredibly close now, with the develop branches of iOS & Android SDKs and Riot (now Element) currently in internal testing as of Nov 7 - expect a Big Announcement very shortly.  We're very optimistic based on how the initial implementation on Riot/Web (now Element)has been behaving so far.
 
 When E2E first landed on Riot/Web (now Element) in September we were missing mobile support, encrypted attachments, encrypted VoIP signalling, and the ability to retrieve encrypted history on new devices - as well as a formal audit of the underlying <a href="/docs/spec/olm.html">Olm</a> and <a href="/docs/spec/megolm.html">Megolm</a> libraries. Since then things have progressed enormously with most of the core team working since September on filling in the gaps, as well as getting audited and fixing all the weird and wonderful edge cases that the audit showed up. All the missing stuff has been landing on the develop branches over the last few weeks, with encrypted attachments landing on web on Nov 10; encrypted VoIP landing on Nov 11; etc. Watch this space for news on the upcoming cross-platform public beta!
 
-### Hosted Integrations and introducing go-neb
+## Hosted Integrations and introducing go-neb
 
 One of the new features which arrived in Riot (now Element) is the ability to add "single click" integrations (i.e. bots, bridges, application services) into rooms from Riot/Web (now Element) by clicking the "Manage Integrations" button in Room Settings. These integrations are hosted for free by Riot (now Element) in its production infrastructure (codenamed Scalar), but all the actual bots/bridges/services themselves are normal opensource Matrix apps and you can of course run them yourself too.
 
@@ -81,13 +83,13 @@ If you like Go and you like Matrix, we'd strongly suggest having a go (hah) at a
 
 If Matrix is to provide a good FOSS alternative to systems like Slack it's critical to have a large array of available integrations, so we really hope that the community will help us grow the list!
 
-### Building Bridges
+## Building Bridges
 
 There have been vast improvements to bridging over the last few months, including the ability to "plumb" bridges into arbitrary rooms (letting you link a single Matrix room through to multiple remote networks). Like go-neb, Riot (now Element) is providing free bridge hosting with the ability to add to rooms with a "single click" via the Manage Integrations button in Room Settings. For now, Riot (now Element) is hosting any bridges built on the <a href="https://github.com/matrix-org/matrix-appservice-bridge">matrix-appservice-bridge</a> codebase.
 
 In short, this means that any user can go and take an existing Matrix room and link it through to Slack, IRC, Gitter, and more.
 
-#### matrix-appservice-irc
+### matrix-appservice-irc
 
 Huge amounts of work have gone into improving the IRC bridge - both adding new features to try to give the most IRC-friendly experience when bridging into IRC, as well as lots of maintenance and performance work to ensure that the matrix.org hosted bridges can scale to the large amounts of traffic we're seeing going through Freenode and others. We've also added hosted bridges for OFTC and Snoonet, and turned on connecting via IPv6 by default for networks which support it.
 
@@ -115,7 +117,7 @@ matrix-appservice-irc 0.5.0:
 </ul>
 Next up is automating NickServ login, and generally continuing to make the IRC experience as good as we possibly can.
 
-#### matrix-appservice-slack
+### matrix-appservice-slack
 
 Similarly, the Slack bridge has had loads of work. The main changes include:
 <ul>
@@ -126,13 +128,13 @@ Similarly, the Slack bridge has had loads of work. The main changes include:
 </ul>
 We're currently looking at shifting over to Slack's RTM (Real Time Messaging) API rather than using webhooks in order to get an even better fit with Slack and support bridging DMs, but the current setup is still very usable. For more details: <a href="https://github.com/matrix-org/matrix-appservice-slack">https://github.com/matrix-org/matrix-appservice-slack</a>.
 
-#### matrix-appservice-gitter
+### matrix-appservice-gitter
 
 The Gitter bridge has provided a lot of inspiration for the more recent work on the Slack bridge. Right now it provides straightforward bridging into Gitter rooms, albeit proxied via a 'matrixbot' user on the Gitter side. We're currently looking at letting also users authenticate using their Gitter credentials so they are bridged through to their 'real' Gitter user - watch this space. For more details: <a href="https://github.com/matrix-org/matrix-appservice-gitter">https://github.com/matrix-org/matrix-appservice-gitter</a>.
 
-### Community updates
+## Community updates
 
-#### matrix-ircd
+### matrix-ircd
 
 matrix-ircd is a rewrite of the old PTO project (<a href="http://pto.im">pto.im</a>): a Rust application that turns Matrix into a single great big decentralised IRC network. PTO itself has unfortunately been on hiatus and is rather bitrotted, so Erik from the core Matrix Team picked it up to see if it could be resurrected. This ended up turning into a complete rewrite (switching from mio to tokio etc), and the new project can be found at <a href="https://github.com/matrix-org/matrix-ircd">https://github.com/matrix-org/matrix-ircd</a>.
 
@@ -140,22 +142,22 @@ matrix-ircd really is an incredibly promising way of getting folks onto Matrix, 
 
 The project is currently alpha but provides a good functioning base to extend, and Erik's explicitly asking for help from the Rust and Matrix community to fill in all the missing features. If you're interested in helping, please come talk on <a href="https://matrix.to/#/#matrix-ircd:matrix.org">#matrix-ircd:matrix.org</a>!.
 
-#### matrix-appservice-gitter-twisted
+### matrix-appservice-gitter-twisted
 
 Not to be confused with the Node-based <a href="https://github.com/matrix-org/matrix-appservice-gitter">matrix-appservice-gitter</a>, <a href="https://github.com/remram44/matrix-appservice-gitter-twisted">matrix-appservice-gitter-twisted</a> is an entirely separate project written in Python/Twisted by Remram (Remi Rampin) that has the opposite architecture: rather than bridging existing rooms into Matrix, matrix-appservice-gitter-twisted lets you provide your Gitter credentials and acts instead as a Gitter client, bridging your personal view of a Gitter room into a private Matrix room just for you.
 
 This obviously has some major advantages (your actions on Gitter use your real Gitter account rather than a bot), and some disadvantages too (you can't use Matrix features when interacting with other Matrix users in the same room, and the Gitter channel itself is not decentralised into Matrix). However, it's a really cool example of how the other model can work - and within the core team, we've been arguing back and forth for ages now on whether normal bridges or "sidecar" bridges like this one are a more preferable architecture. Thanks to Remram's work we can try both side by side! Go check it out at <a href="https://github.com/remram44/matrix-appservice-gitter-twisted">https://github.com/remram44/matrix-appservice-gitter-twisted</a>.
 
-#### telematrix
+### telematrix
 
 Telematrix is Telegram&lt;-&gt;Matrix bridge, written by Sijmen Schoon using python3 and asyncio. Right now it's a fairly early alpha hardcoded to bridge a specific Telegram channel into a specific Matrix room, but it works and in use and could be an excellent base for folks interested in a more comprehensive Matrix/Telegram bridge. Go check it out at <a href="https://github.com/SijmenSchoon/telematrix">https://github.com/SijmenSchoon/telematrix</a>
 <img class="aligncenter wp-image-1832" src="/blog/wp-content/uploads/2016/11/telematrix-1024x828.png" alt="telematrix" width="641" height="518" />
 
-#### Ruma
+### Ruma
 
 Meanwhile, the Ruma project to write a Matrix homeserver in Rust has been progressing steadily, with more and more checkboxes appearing on the <a href="https://github.com/ruma/ruma/blob/master/STATUS.md">status page</a>, with significant new contributions from mujx and farodin91. The best way to keep track of Ruma is to read Jimmy's excellent <a href="https://ruma.dev/news/">This Week in Ruma</a> updates and of course hang out on <a href="https://matrix.to/#/#ruma:matrix.org">#ruma:matrix.org</a>.
 
-#### NaChat
+### NaChat
 
 An entirely new client on the block since the last update is <a href="http://github.com/ralith/nachat">NaChat</a>, written by Ralith. NaChat is a pure cross-platform Qt/C++ desktop client written from the ground up, supporting local history synchronisation, excellent performance, native Qt theming, and generally being a lean and mean Matrix client machine. It's still alpha, but it's easy to build and a lot of fun to play with.
 
@@ -163,13 +165,13 @@ An entirely new client on the block since the last update is <a href="http://git
 
 Please give a spin, encourage Ralith to finish the <a href="https://github.com/ralith/nachat/tree/timeline-view-rewrite">timeline-view-rewrite</a> branch (which is probably the one you want to be running!), and come hang out on <a href="https://matrix.to/#/#nachat:matrix.org">#nachat:matrix.org</a>.
 
-#### Quaternion
+### Quaternion
 
 Meanwhile, the <a href="https://github.com/fxrh/quaternion">Quaternion</a> Qt/QML desktop client and its <a href="https://github.com/fxrh/libqmatrixclient">libqmatrixclient</a> library has been making sure and steady progress, with fxrh, kitsune, maralorn and others working away at it. The difference with NaChat here is using QML rather than native Qt widgets, and a focus on more advanced UX features like a custom infinite-scrolling scrollbar widget, unread message notifications, and read-up-to markers.  Recent developments include the <a href="https://github.com/Fxrh/Quaternion/releases/tag/v0.0.1">first official release (0.0.1)</a> on Sept 12, official Windows builds, lots of work on implementing better Read-up-to Markers, scrolling behaviour etc. Again, it's worth keeping a checkout of Quaternion handy and playing with the client - it's loads of fun!
 
 <img class="aligncenter size-large wp-image-1829" src="/blog/wp-content/uploads/2016/11/Screen-Shot-2016-11-12-at-12.12.48-1024x535.png" alt="screen-shot-2016-11-12-at-12-12-48" width="1024" height="535" />
 
-### Google Summer of Code 2016 Retrospective
+## Google Summer of Code 2016 Retrospective
 
 The summer is long gone now, and along with it Google Summer of Code. This was the first year we've <a href="https://summerofcode.withgoogle.com/archive/2016/organizations/6552738187968512/">participated in GSoC</a>, and it was an incredible experience - both judging all the applications, and then working with Aviral Dasgupta and Will Hunt (Half-Shot) who joined the core team as part of their GSoC endeavours.
 
@@ -181,7 +183,7 @@ Finally, as a bit of a wildcard, we discovered the other day that there was also
 
 Either way, it's been a pleasure to work with the GSoC community and we owe Aviral and Half-Shot (and Waqee!) a huge debt of gratitude for spending their summers (and more!) hacking away improving Matrix. So, thanks Google for making GSoC possible and thanks to the GSoCers for all their contributions, effort & enthusiasm! Watch this space for updates on RTE, new-autocomplete and the twitter bridge going live...
 
-### Matrix in the news
+## Matrix in the news
 
 Just in case you missed them, there have been a couple of high profile articles flying around about Matrix recently - we made the <a href="http://www.linux-magazine.com/Issues/2016/189/Matrix">front cover of Linux Magazine in August</a> with a comprehensive review of Matrix and Vector (now Riot (now Element)). Then when we launched Riot (now Element) itself we got a cautiously <a href="https://techcrunch.com/2016/09/19/riot-wants-to-be-like-slack-but-with-the-flexibility-of-an-underlying-open-source-platform/">positive write-up from Mike Butcher at Techcrunch</a>. We also wrote an guest column for Techcrunch about the <a href="https://techcrunch.com/2016/10/09/a-decentralized-web-would-give-power-back-to-the-people-online/">importance of bringing power back to the people via decentralisation</a>, which got a surprising amount of attention on <a href="https://news.ycombinator.com/item?id=12670958">HackerNews</a> and elsewhere.
 
@@ -191,7 +193,7 @@ More recently, we were lucky enough to get an <a href="https://www.youtube.com/w
 
 Huge thanks to everyone who's been nice enough to spread the word of Matrix!
 
-### Matrix In Real Life
+## Matrix In Real Life
 
 Finally, we've been present at a slew of different events. In August we attended FOSSCON again in Philadelphia to give a general update on Matrix to the Freenode community...
 
@@ -233,7 +235,7 @@ The same weekend also featured TADHack Global - we were present at the London si
 
 Meanwhile, coming up on the horizon we have TADSummit in Lisbon next week, where we'll be giving an update on Matrix to the global Telco Application Developer community, and then the week after we'll be in Israel as part of the Geektime Techfest, Devfest and Chatbot Summit. So if you're in Lisbon or Tel Aviv do give us a ping on Matrix and come hang out!
 
-### Matrixing for fun and profit!
+## Matrixing for fun and profit!
 
 If you've read this far, we're guessing you're hopefully quite interested in Matrix (or just skipping to the end ;).  Something we don't talk about as much as we should is that if you're interested in being paid to work on Matrix full time, we're always interested in expanding the core team.  Right now we're particularly looking for:
 <ul>
@@ -245,7 +247,7 @@ If you've read this far, we're guessing you're hopefully quite interested in Ma
 </ul>
 Most of the core team hangs out in London or Rennes (France), but we're also open to remote folks where it makes sense.  If this sounds interesting, please shoot us a mail to jobs@matrix.org.  Obviously it helps enormously if we already know you from the Matrix community, and you have a proven FOSS track record.
 
-### Conclusion
+## Conclusion
 
 Apologies once again for an overdue and overlong update, but hopefully this gives a good taste of how Matrix is progressing. Just to give a different datapoint: this graph is quite interesting - showing the volume of events per day sent by native (i.e. non-bridged) Matrix users visible to the matrix.org homeserver since we turned the service on back in 2014:
 

--- a/content/blog/2016/12/2016-12-26-the-matrix-holiday-special-2016-edition.md
+++ b/content/blog/2016/12/2016-12-26-the-matrix-holiday-special-2016-edition.md
@@ -4,12 +4,14 @@ path = "/blog/2016/12/26/the-matrix-holiday-special-2016-edition"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 +++
 
 We seem to have fallen into the pattern of giving seasonal 'state of the union' updates on the Matrix blog, despite best intentions to blog more frequently... although given the <a href="/blog/2016/11/12/the-matrix-autumn-special/">Autumn Update</a> ended up being posted in November this one is going to be a relatively incremental update.  Let's jump straight in:
 
-### E2E Encryption
+<!-- more -->
+
+## E2E Encryption
 
 Unless you've been in a coma for the last month you'll have hopefully noticed that we <a href="/blog/2016/11/21/matrixs-olm-end-to-end-encryption-security-assessment-released-and-implemented-cross-platform-on-riot-at-last/">launched the formal beta for E2E Encryption</a> across matrix-{'{'}js,ios,android{'}'}-sdk (and thus Riot/{'{'}Web, iOS, Android{'}'}) in November, complete with the successful <a href="http://nccgroup.trust/us/our-research/matrix-olm-cryptographic-review">independent public security assessment</a> of our Olm and Megolm cryptography library from NCC Group.  So far the beta has gone well in parts: the core Olm/Megolm crypto library has held up well with no bugfixes at all required since the audit (yay!).  However, we've hit a lot of different edge cases in the wild where devices can fail to share their outbound session ratchet state to other devices present in the room.  This results in the infamous "Unknown Inbound Session ID" (UISI) errors which many folks will have seen (now renamed to the more meaningful "Unable to decrypt: The sender's device has not sent us the keys for this message" error).
 
@@ -22,11 +24,11 @@ Unfortunately there's a bunch of entirely different causes for this, both platfo
 </ul>
 Thanks to everyone who's been using E2E and reporting issues - given the number of different UISI error causes out there, it's been really useful to go through the different bug reports that folks have submitted.  Please continue to submit them when you see unexpected problems (especially over the coming months as stability improves!)
 
-### New Projects!
+## New Projects!
 
 There have been a tonne of new projects popping up from all over the place since the last update.  Looking at the <a href="https://github.com/matrix-org/matrix-doc/commits/master/supporting-docs">git history</a> of the <a href="/docs/projects">projects page</a>, we've been adding one every few days!  Highlights include:
 
-#### Bridges:
+### Bridges:
 
 <ul>
  	<li><a href="https://github.com/kfatehi/matrix-appservice-imessage">https://github.com/kfatehi/matrix-appservice-imessage</a> - A solid foundation for an iMessage bridge from kfatehi, built on top of the official matrix-appservice-bridge stack.  iMessage and FaceTime's crypto is tied into Apple's Fairplay DRM (famous for securing the iTunes Music Store and App Store) and is locked all the way down to the <a href="https://www.apple.com/business/docs/iOS_Security_Guide.pdf">keypair baked into your Apple device's CPU</a> at fabrication time, so for now the bridge has to be run on a macOS device in order to bridge.  It's very promising indeed, and exciting to see bridges to relatively inhospitable environments like iMessage popping up!</li>
@@ -36,7 +38,7 @@ There have been a tonne of new projects popping up from all over the place sinc
  	<li><a href="https://github.com/CyrusTheHedgehog/Hangouts-Bridge">https://github.com/CyrusTheHedgehog/Hangouts-Bridge</a> - A basic PoC of a Hangouts bridge, written in python3 asyncio</li>
 </ul>
 
-#### Clients
+### Clients
 
 <ul>
  	<li><a href="https://github.com/lukebarnard1/j">https://github.com/lukebarnard1/j</a> - A blogging and journalism platform built on Matrix from Luke (moonlighting from the core team!)</li>
@@ -45,7 +47,7 @@ There have been a tonne of new projects popping up from all over the place sinc
  	<li><a href="https://github.com/tjgillies/freebird">https://github.com/tjgillies/freebird</a> - a basic twitter clone built on Matrix by tjgillies</li>
 </ul>
 
-#### Other projects
+### Other projects
 
 <ul>
  	<li><a href="https://github.com/slp/matrix-pushgw">https://github.com/slp/matrix-pushgw</a> - A Matrix push gateway written in Golang which exposes a custom TCP push protocol to apps, letting them get push notifications directly from your own gateway rather than via GCM or APNS.  The intention is to use it for Sailfish and Fdroid.  The initial implementation looks very promising - just needs the clientside support, and then folks who don't trust Google with their notifications can run completely indie at last!</li>
@@ -54,7 +56,7 @@ There have been a tonne of new projects popping up from all over the place sinc
  	<li><a href="https://github.com/mlopezr/node-red-contrib-matrixbot">https://github.com/mlopezr/node-red-contrib-matrixbot</a> - Matrix bot plugin for the <a href="https://nodered.org/">Node-RED</a> IOT platform</li>
 </ul>
 
-### Bots and Bridges
+## Bots and Bridges
 
 There's been a bunch of work from the core team on bots & bridges infrastructure over the last month:
 
@@ -75,15 +77,15 @@ Meanwhile there's been a lot of work going into supporting the IRC bridge. Main 
 </ul>
 Last but not least, we've just released <a href="https://github.com/matrix-org/gomatrix">gomatrix - a new official Matrix client SDK for golang</a>!  <a href="https://github.com/matrix-org/go-neb">Go-neb</a> (the reference golang Matrix bot framework) has been entirely refactored to use gomatrix, which should keep it honest as a 1st class Matrix client SDK for those in the Golang community.  We highly recommend all Golang nuts to go <a href="https://godoc.org/github.com/matrix-org/gomatrix">read the documentation</a> and give it a spin!
 
-### Riot Desktop
+## Riot Desktop
 
 Riot development has been largely preoccupied with E2E debugging in the respective Matrix Client SDKs, but <a href="https://medium.com/@RiotChat/introducing-riot-0-9-and-desktop-riot-3585d1027243">0.9.3 was released last week adding in Electron-based desktop app support</a>.  (Remember, if you hate Electron-style desktop apps which provide a desktop app by embedded a webbrowser, you can always use another Matrix client!).  If you've been missing having Riot as a proper desktop app, go get involved!
 
 <img class="aligncenter size-large wp-image-1874" src="/blog/wp-content/uploads/2016/12/Screen-Shot-2016-12-26-at-01.00.12-1024x687.png" alt="screen-shot-2016-12-26-at-01-00-12" width="1024" height="687" />
 
-### Next Generation Homeservers
+## Next Generation Homeservers
 
-#### Ruma
+### Ruma
 
 <a href="https://ruma.dev/">Ruma</a> is a project led by Jimmy Cuadra to build a Matrix homeserver in Rust - the project has been ploughing steadily onwards through 2016 with a bit of an acceleration during December.  You can follow progress at the excellent <a href="https://ruma.dev/news/">This Week in Ruma</a> blog, <a href="https://github.com/ruma/ruma/pulse/monthly">watching the project on Github</a>, and tracking the <a href="https://github.com/ruma/ruma/blob/master/STATUS.md">API status dashboard</a>.  Some of the latest PRs are looking very promising in terms of getting the core remaining CS APIs working, e.g:
 <ul class="simple-conversation-list varied-states">
@@ -103,7 +105,7 @@ Riot development has been largely preoccupied with E2E debugging in the respecti
 </ul>
 Needless to say, we've been keeping an eye on Ruma with extreme interest, not least as some of the Matrix core team are rabid Rustaceans too :)  We can't wait to see it exposing a usable CS API in the hopefully not-too-distant future!!
 
-#### Dendrite
+### Dendrite
 
 Meanwhile, in the core team, we've been doing some fairly serious experimentation on next-generation homeservers.  Synapse is in a relatively stable state currently, and we've implemented most of the horizontal scalability tricks available to us there (e.g. splitting out <a href="https://github.com/matrix-org/synapse/blob/master/docs/workers.rst">worker processes</a>).  Instead we're starting to hit some fundamental limitations of the architecture: the fact that the whole codebase effectively assumes that it's talking to a single consistent database instance; python's single-threadedness and memory inefficiency; twisted's lack of profiling; being limited to sqlite's featureset; the fact that the schema has grown organically and is difficulty to refactor aggressively; the fact the app papers over SQL problems by caching everything in RAM (resulting in synapse's high RAM requirements); the constant bugs caused by lack of type safety; etc.
 
@@ -117,7 +119,7 @@ So instead, a month or so ago we started a new project codenamed Dendrite (aka D
 </ol>
 It's too early to share more at this stage, but thought we should give some visibility on where things are headed!  Needless to say, Synapse is here for the foreseeable - we think of it as being the Matrix equivalent of the role Apache httpd played for the Web.  It's not enormously efficient, but it's popular and relatively mature, and isn't going away.  Meanwhile, new generations of servers like Ruma and Dendrite will come along for those seeking a sleeker but more experimental beast, much as nginx and lighttpd etc have come along as alternatives to Apache.  Time will tell how the server ecosystem will evolve in the longer term, but it's obviously critical to the success of Matrix to have multiple active independent server implementations, and we look forward to seeing how Synapse, Ruma & Dendrite progress!
 
-### 2017
+## 2017
 
 Looking back at where we were at <a href="/blog/2015/12/25/the-matrix-holiday-special/">this time last year</a>, 2016 has been a critical year for Matrix as the ecosystem has matured - rolling out E2E encryption; building out proper bot & bridge infrastructure; stabilising and tuning Synapse to keep up with the exponential traffic growth; seeing the explosion of contributors and new projects; seeing Riot edging closer to becoming a viable mainstream communication app.
 

--- a/content/blog/2017/02/2017-02-06-fosdem-2017-report.md
+++ b/content/blog/2017/02/2017-02-06-fosdem-2017-report.md
@@ -4,7 +4,7 @@ path = "/blog/2017/02/06/fosdem-2017-report"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 +++
 
 Hi all,

--- a/content/blog/2017/10/2017-10-11-tadhack-global-2017-and-the-port-2017.md
+++ b/content/blog/2017/10/2017-10-11-tadhack-global-2017-and-the-port-2017.md
@@ -13,7 +13,7 @@ At the end of September, TADHack Global was held where almost 150 teams spent t
 
 Out of 10 hacks, 2 of 4 local winners won prizes locally and went on to be <a href="http://blog.tadhack.com/2017/10/02/tadhack-global-2017-winners/">global winners </a>alongside 6 other teams using Matrix as part of their hacks. Checkout the <a href="http://blog.tadhack.com/2017/10/03/tadhack-london-2017/">TADHack London Wrap-up</a> for details on all of the awesome hacks, especially <a href="https://github.com/aviraldg">Aviral Dasgupta</a>'s <a href="https://www.youtube.com/watch?v=lOmhgSNS_6E&feature=youtu.be">Pushtime</a> and <a href="https://youtu.be/qOYdDyRlDNE" target="_blank">Polite.ai</a>.
 
-https://twitter.com/TADHack/status/915284069046419456
+<https://twitter.com/TADHack/status/915284069046419456>
 
 Well done to everyone who took part, and a special thanks to those flying Matrix :)
 
@@ -23,6 +23,6 @@ The following weekend was THE Port 2017, a humanitarian-themed hackathon held at
 
 The hack we made was a communications system backed by Matrix for use in refugee camps, an idea that hatched at the start of the hackathon (whereas the other projects were well established ideas up to 6 weeks before the event). Check out <a href="https://github.com/theport2017-matrix">the code on GitHub</a> if you're interested in the client-side apps we made over the weekend.
 
-https://twitter.com/matrixdotorg/status/916672581473890304
+<https://twitter.com/matrixdotorg/status/916672581473890304>
 
 It was another fun weekend for the Matrix team and we look forward to the next one. Stay tuned for updates on upcoming Matrix events!

--- a/content/blog/2017/12/2017-12-25-the-matrix-holiday-mini-special-2017-edition.md
+++ b/content/blog/2017/12/2017-12-25-the-matrix-holiday-mini-special-2017-edition.md
@@ -4,7 +4,7 @@ path = "/blog/2017/12/25/the-matrix-holiday-mini-special-2017-edition"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 +++
 
 Hi folks,
@@ -12,6 +12,8 @@ Hi folks,
 Since we began Matrix it's been a sort of tradition to do a huge update on Christmas Eve to reflect on the past year and tease the future - you can check out the <a href="/blog/2016/12/26/the-matrix-holiday-special-2016-edition/">2016 edition</a> or the <a href="/blog/2015/12/25/the-matrix-holiday-special/">2015 edition</a> and a sort of <a href="/blog/2015/01/07/synapse-0-6-1-released-and-other-news/">proto-update for 2014</a> too if you're feeling nostalgic.  This year I'm going to try to keep it short though, as I'm hoping to write a Very Big Update related to long-term-funding progress in the relatively near future.
 
 2017 has been a weird year for us: progress in the core team has been relatively badly impacted by the mission to secure long-term funding, with myself (Matthew) & Amandine spending the vast majority of our time handling the meta-problem of keeping the core team secure rather than actually working on the project itself.  Meanwhile we've lost a few of the original team during the disruption, which has particularly impacted Spec, E2E and Dendrite progress (such are the risks of running a very lean team in the first place!).  However, against the odds, we have (hopefully) prevailed - and this is almost <strong>entirely</strong> due to the massive support we've seen through donations via <a href="https://patreon.com/matrixdotorg">Patreon</a>, <a href="https://liberapay.com/matrixdotorg">Liberapay</a>, Ethereum, Bitcoin and <a href="https://paypal.me/matrixdotorg">PayPal</a>, and some much-appreciated paid consulting work.
+
+<!-- more -->
 
 Simply put, without the donation support we would have not been able to pay the core team over the last 3 months, and we would not be able to pay for the legal costs of setting up the team as an independent company, and we would be completely screwed for securing large-scale long-term funding if we couldn't point to the community's support as evidence that Matrix is worthy of funding.  So: we sincerely owe our thanks to those who heeded the <a href="/blog/2017/07/07/a-call-to-arms-supporting-matrix/">call to arms</a> and are supporting us.  We've also been pretty lucky in benefiting from the skyrocketing value of Ethereum and Bitcoin donations.  And even if/when long-term funding is secured for New Vector (the company we formed in July to hire the core team), donations will continue to be vital to support the Matrix.org Foundation itself as an independent non-profit entity - as it's obviously not in Matrix.org's interests to be entirely financially dependent on New Vector.  Hopefully this whole episode will end up being a bit like a <a href="http://www.startrek.com/article/john-trimbles-contribution-to-saving-star-trek">Save Star Trek</a> scenario - where something fun and amazing almost gets almost wiped out when it's only a few years old due to corporate factors... only for the community to band together to save it, and then for it to go from strength to strength for the next 50 years or more! :D
 

--- a/content/blog/2018/02/2018-02-05-3d-video-calling-with-matrix-webrtc-and-webvr-at-fosdem-2018.md
+++ b/content/blog/2018/02/2018-02-05-3d-video-calling-with-matrix-webrtc-and-webvr-at-fosdem-2018.md
@@ -4,7 +4,7 @@ path = "/blog/2018/02/05/3d-video-calling-with-matrix-webrtc-and-webvr-at-fosdem
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 +++
 
 <strong>TL;DR: We built a proof-of-concept for <a href="https://fosdem.org/2018/schedule/event/matrix_webvr/">FOSDEM</a> of the world's first(?) 3D video calling using Matrix and the iPhone X... and it looks like this!!</strong>

--- a/content/blog/2018/08/2018-08-31-so-long-half-shot-thanks-for-all-the-bridges.md
+++ b/content/blog/2018/08/2018-08-31-so-long-half-shot-thanks-for-all-the-bridges.md
@@ -4,7 +4,7 @@ path = "/blog/2018/08/31/so-long-half-shot-thanks-for-all-the-bridges"
 
 [taxonomies]
 author = ["Ben Parsons"]
-category = ["Thoughts"]
+category = ["Thoughts", "Bridges"]
 +++
 
 Thank you to Half-Shot for all your work on Bridges over the last months and beyond. Today is your last day, but I'm sure we'll see you again before long. Text below is from Half-Shot.

--- a/content/blog/2018/12/2018-12-25-the-2018-matrix-holiday-special.md
+++ b/content/blog/2018/12/2018-12-25-the-2018-matrix-holiday-special.md
@@ -4,7 +4,7 @@ path = "/blog/2018/12/25/the-2018-matrix-holiday-special"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 +++
 
 Hi all,
@@ -19,6 +19,7 @@ It's fair to say that 2018 has been a pretty crazy year.  We have had one overr
 
 Well, in parallel with this we've also seen adoption of Matrix accelerating ahead of our dev plan at an unprecedented speed: with France selecting Matrix to power the communication infrastructure of its whole public sector - first <a href="/blog/2018/04/26/matrix-and-riot-confirmed-as-the-basis-for-frances-secure-instant-messenger-app/">trialling over the summer</a>, and now <a href="https://twitter.com/matrixdotorg/status/1070392608801910784">confirmed for full roll-out</a> as of a few weeks ago.  Meanwhile there are several other similar-sized projects on the horizon which we can't talk about yet.  We've had the growing pains of establishing <a href="https://vector.im">New Vector</a> as a startup in order to hire the core team and support these projects.  We've launched <a href="https://modular.im">Modular</a> to provide professional-quality SaaS Matrix hosting for the wider community and help fund the team.  And most importantly, we've also been establishing the non-profit <a href="/blog/2018/10/29/introducing-the-matrix-org-foundation-part-1-of-2/">Matrix.org Foundation</a> to formalise the open governance of the Matrix protocol and protect and isolate it from any of the for-profit work.
 
+<!-- more -->
 
 However: things have just about come together.  Almost all the spec work for 1.0 is done and we are now aiming to get a 1.0 released in time by the end of January (in time for FOSDEM).  Meanwhile Synapse has improved massively in terms of performance and stability (not least having migrated over to <a href="/blog/2018/12/21/porting-synapse-to-python-3/">Python 3</a>); Riot's spectacular redesign is now <a href="https://medium.com/@RiotChat/redesign-experimenters-needed-afa7c2d4c858">available for testing</a> right now; E2E encryption is more stable than ever with the usability rework <a href="https://github.com/matrix-org/matrix-js-sdk/compare/develop...uhoreg:e2e_cross-signing">landing</a> as we speak.  And we've even got a full rewrite of Riot/Android in the wings.
 

--- a/content/blog/2019/02/2019-02-04-matrix-at-fosdem-2019.md
+++ b/content/blog/2019/02/2019-02-04-matrix-at-fosdem-2019.md
@@ -4,7 +4,7 @@ path = "/blog/2019/02/04/matrix-at-fosdem-2019"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["In the News"]
+category = ["Events", "FOSDEM"]
 
 [extra]
 image = "https://matrix.org/blog/wp-content/uploads/2019/02/DyaWzqGW0AAk9pd.jpg"

--- a/content/blog/2019/06/2019-06-11-synapse-1-0-0-released.md
+++ b/content/blog/2019/06/2019-06-11-synapse-1-0-0-released.md
@@ -4,7 +4,7 @@ path = "/blog/2019/06/11/synapse-1-0-0-released"
 
 [taxonomies]
 author = ["Neil Johnson"]
-category = ["General", "Releases", "In the News"]
+category = ["General", "Releases", "News"]
 +++
 
 Well here it is: Synapse 1.0.

--- a/content/blog/2019/12/2019-12-24-the-2019-matrix-holiday-update.md
+++ b/content/blog/2019/12/2019-12-24-the-2019-matrix-holiday-update.md
@@ -4,7 +4,7 @@ path = "/blog/2019/12/24/the-2019-matrix-holiday-update"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 +++
 
 Hi all,
@@ -13,7 +13,9 @@ Every year we do an annual wrap-up and retrospective of all the things happening
 
 That said, it’s hard to know where to start - Matrix accelerated more than ever before in 2019, and there’s been progress on pretty much all battlefronts.  So as a different format, let’s take the [stuff we said we had planned for 2019](https://matrix.org/blog/2018/12/25/the-2018-matrix-holiday-special#2019) from the end of last year’s update and see what we actually achieved...
 
-#### 2019: the immediate priorities
+<!-- more -->
+
+## 2019: the immediate priorities
 
 So, our immediate priorities for 2019 were:
 
@@ -62,7 +64,7 @@ The good news on E2E encryption is that we’ve been making solid progress throu
 
 That takes us to the end of the stuff we planned to prioritise in 2019 - but what about the more speculative medium-term stuff which was on the menu this time last year?
 
-#### 2019: the medium-term priorities
+## 2019: the medium-term priorities
 
 *   _Reworking and improving Communities/Groups._
 
@@ -145,7 +147,7 @@ We’ve just started looking at implementing these seriously via [MSC1228](https
 
 So that sums up progress on the medium term menu - as you can see, a bunch actually happened; a bunch made progress; a few didn’t happen at all.
 
-#### 2019: the longer-term priorities
+## 2019: the longer-term priorities
 
 Finally, on the longer term radar:
 
@@ -179,7 +181,7 @@ Sadly no progress here :(
 
 So, of all the myriad things on our radar for 2019 (as of Dec 2018), hopefully this gives some idea of where we hit the mark.
 
-#### 2019: the unpredictable bits
+## 2019: the unpredictable bits
 
 However, there’s also a tonne of other stuff which happened which wasn’t explicitly on the radar.  On the synapse side, we finished fully migrating from Python 2 to Python 3, and started using asyncio and all the latest Python 3 goodies!  We finally [implemented configurable history retention](https://github.com/matrix-org/synapse/pull/6358) for servers and rooms! We even implemented [self-destructing messages](https://github.com/matrix-org/synapse/pull/6409) in Synapse (not that Riot exposes them yet). And there has been loads of optimisation and performance work since 1.0 landed in June.
 
@@ -191,7 +193,7 @@ Meanwhile, mainstream uptake of Matrix has properly taken off, with the French G
 
 Alongside all this, [Mozilla announced](https://matrix.org/blog/2019/12/19/welcoming-mozilla-to-matrix/) they are replacing the Moznet IRC network with Matrix; [KDE joined Matrix](https://matrix.org/blog/2019/02/20/welcome-to-matrix-kde/) in Feb, [Wikimedia](https://phabricator.wikimedia.org/T230531) is getting set up on their server, and more and more massive players (including the largest in the world) keep getting in touch to find out how they can best get onboard Matrix - it’s incredibly exciting.  It also means that we were able to [raise capital](https://matrix.org/blog/2019/10/10/new-vector-raises-8-5-m-to-accelerate-matrix-riot-modular/) to keep folks employed to work on Matrix fulltime via [New Vector](https://vector.im) and scale up [Modular.im](https://modular.im) as a paid hosting platform - which massively helps support core Matrix development.
 
-#### 2020
+## 2020
 
 All that remains now is to make some predictions for 2020.  Our main priorities are:
 

--- a/content/blog/2020/01/2020-01-02-on-privacy-versus-freedom.md
+++ b/content/blog/2020/01/2020-01-02-on-privacy-versus-freedom.md
@@ -4,7 +4,7 @@ path = "/blog/2020/01/02/on-privacy-versus-freedom"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["Thoughts"]
+category = ["Thoughts", "Privacy"]
 +++
 
 A few years ago, back when Matrix was originally implementing end-to-end encryption, we asked Moxie (the project lead for Signal) whether he’d ever consider connecting Signal (then TextSecure) to Matrix.  After all, one of Matrix’s goals is to be an interoperability layer between other communication silos, and one of the reasons for us using Signal’s Double Ratchet Algorithm for Matrix’s encryption was to increase our chances of one day connecting with other apps using the same algorithm (Signal, WhatsApp, Google Allo, Skype, etc).  Moxie politely declined, and then a few months later wrote “[The ecosystem is moving](https://signal.org/blog/the-ecosystem-is-moving/)” to elaborate his thoughts on why he feels he “no longer believes that it is possible to build a competitive federated messenger at all.”

--- a/content/blog/2020/02/2020-02-03-matrix-at-fosdem-2020.md
+++ b/content/blog/2020/02/2020-02-03-matrix-at-fosdem-2020.md
@@ -6,7 +6,7 @@ path = "/blog/2020/02/03/matrix-at-fosdem-2020"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["Events"]
+category = ["FOSDEM", "Events"]
 
 [extra]
 image = "https://matrix.org/blog/img/2020-02-03-fosdem.jpg"

--- a/content/blog/2020/12/2020-12-25-the-matrix-holiday-special-2020.md
+++ b/content/blog/2020/12/2020-12-25-the-matrix-holiday-special-2020.md
@@ -1,10 +1,11 @@
 +++
 title = "The Matrix Holiday Special 2020"
+date = "2020-12-25T04:26:00Z"
 path = "/blog/2020/12/25/the-matrix-holiday-special-2020"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-logo.png"
@@ -12,7 +13,9 @@ image = "https://matrix.org/blog/img/matrix-logo.png"
 
 Hi all,
 
-Over the years it’s become a tradition to write an end-of-year wrap-up on Christmas Eve, reviewing all the things the core Matrix team has been up over the year, and looking forwards to the next (e.g. here’s [last year’s edition](https://matrix.org/blog/2019/12/24/the-2019-matrix-holiday-update)).  These days there’s so much going on in Matrix it’s impossible to cover it all (and besides, we now have [This Week In Matrix](https://matrix.org/blog/category/this-week-in-matrix) and better blogging in general to cover events as they happen).  So here’s a quick overview of the highlights:
+Over the years it’s become a tradition to write an end-of-year wrap-up on Christmas Eve, reviewing all the things the core Matrix team has been up over the year, and looking forwards to the next (e.g. here’s [last year’s edition](https://matrix.org/blog/2019/12/24/the-2019-matrix-holiday-update)).  These days there’s so much going on in Matrix it’s impossible to cover it all (and besides, we now have [This Week In Matrix](https://matrix.org/blog/category/this-week-in-matrix) and better blogging in general to cover events as they happen). So here’s a quick overview of the highlights:
+
+<!-- more -->
 
 Looking back at our [plans for 2020](https://matrix.org/blog/2019/12/24/the-2019-matrix-holiday-update#2020) in last year’s wrap-up, amazingly it seems we pretty much achieved what we set out to do.  Going through the bulletpoints in order:
 

--- a/content/blog/2021/01/2021-01-04-taking-fosdem-online-via-matrix.md
+++ b/content/blog/2021/01/2021-01-04-taking-fosdem-online-via-matrix.md
@@ -5,7 +5,7 @@ path = "/blog/2021/01/04/taking-fosdem-online-via-matrix"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 
 [extra]
 image = "https://matrix.org/blog/img/2021-01-04-fosdem.jpg"

--- a/content/blog/2021/02/2021-02-15-how-we-hosted-fosdem-2021-on-matrix.md
+++ b/content/blog/2021/02/2021-02-15-how-we-hosted-fosdem-2021-on-matrix.md
@@ -4,7 +4,7 @@ path = "/blog/2021/02/15/how-we-hosted-fosdem-2021-on-matrix"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 
 [extra]
 image = "https://matrix.org/blog/img/2021-01-04-fosdem.jpg"

--- a/content/blog/2021/12/2021-12-02-call-for-participation-for-the-fosdem-2022-matrix-dev-room.md
+++ b/content/blog/2021/12/2021-12-02-call-for-participation-for-the-fosdem-2022-matrix-dev-room.md
@@ -4,7 +4,7 @@ path = "/blog/2021/12/02/call-for-participation-for-the-fosdem-2022-matrix-dev-r
 
 [taxonomies]
 author = ["Thib"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 
 [extra]
 image = "https://matrix.org/blog/img/2021-01-04-fosdem.jpg"

--- a/content/blog/2021/12/2021-12-22-the-mega-matrix-holiday-special-2021.md
+++ b/content/blog/2021/12/2021-12-22-the-mega-matrix-holiday-special-2021.md
@@ -6,7 +6,7 @@ path = "/blog/2021/12/22/the-mega-matrix-holiday-special-2021"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-logo.png"
@@ -17,6 +17,8 @@ Hi all,
 If you’re reading this - congratulations; you made it through another year :)  Every winter we sit down and review Matrix’s progress over the last twelve months, and look forward to the next - for it’s all too easy to get lost in the day-to-day development and fail to realise how much the overall project is evolving, especially when it’s one as large and ambitious as Matrix!
 
 Looking back at 2021, it’s unbelievable how much stuff has been going on in the core team (as you can tell by the length of this post - sorry!).  There’s been a really interesting mix of activity too - between massive improvements to the core functionality and baseline features that Matrix provides, and also major breakthroughs on next generation work.  But first, let’s check out what’s been happening in the wider ecosystem…
+
+<!-- more -->
 
 ## The Matrix Ecosystem
 

--- a/content/blog/2022/02/2022-02-07-hosting-fosdem-2022-on-matrix.md
+++ b/content/blog/2022/02/2022-02-07-hosting-fosdem-2022-on-matrix.md
@@ -4,7 +4,7 @@ path = "/blog/2022/02/07/hosting-fosdem-2022-on-matrix"
 
 [taxonomies]
 author = ["Thib"]
-category = ["General"]
+category = ["Events", "FOSDEM", "News"]
 +++
 
 Last year was the first time FOSDEM was hosted on Matrix, and it was generally a huge success - and so the FOSDEM team trusted us again this year and we’re happy to say that it seems to have gone really well! This year’s FOSDEM was massive once again, featuring 654 speakers, 731 events, and 103 tracks.

--- a/content/blog/2022/08/2022-08-15-the-matrix-summer-special-2022.md
+++ b/content/blog/2022/08/2022-08-15-the-matrix-summer-special-2022.md
@@ -4,7 +4,7 @@ path = "/blog/2022/08/15/the-matrix-summer-special-2022"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-summer.jpg"
@@ -17,6 +17,8 @@ At the end of each year it’s been traditional to do a big review of everything
 This year is turning out to be slightly different, however.  Our plans for 2022 are particularly ambitious: to force a step change in improving Matrix’s performance and usability so that we firmly transition from our historical “make it work” and “make it work right” phases into “**making it fast**”.  Specifically: to succeed, Matrix **has** to succeed in powering apps which punch their weight in terms of performance and usability against the proprietary centralised alternatives of WhatsApp, Discord, Slack and friends.
 
 We’ve seen an absolute tonne of work happening on this so far this year… and somehow the end results all seem to be taking concrete shape at roughly the same time, despite summer traditionally being the quietest point of the year.  The progress is super exciting and we don’t want to wait until things are ready to enthuse about them, and so we thought it’d be fun to do a spontaneous Summer Special gala blog post so that everyone can follow along and see how things are going!
+
+<!-- more -->
 
 ## Making it fast
 

--- a/content/blog/2022/11/2022-11-16-call-for-participation-for-the-fosdem-2023-matrix-devroom.md
+++ b/content/blog/2022/11/2022-11-16-call-for-participation-for-the-fosdem-2023-matrix-devroom.md
@@ -4,7 +4,7 @@ path = "/blog/2022/11/16/call-for-participation-for-the-fosdem-2023-matrix-devro
 
 [taxonomies]
 author = ["Thib"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 +++
 
 This year, the Matrix.org Foundation is excited to host the first ever

--- a/content/blog/2022/12/2022-12-25-the-matrix-holiday-update-2022.md
+++ b/content/blog/2022/12/2022-12-25-the-matrix-holiday-update-2022.md
@@ -4,7 +4,7 @@ path = "/blog/2022/12/25/the-matrix-holiday-update-2022"
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-logo.png"
@@ -19,6 +19,8 @@ On one hand, the network has doubled in size (44.1M to 80.3M visible matrix IDs)
 On the other hand, only a handful of these initiatives have resulted in funding reaching the core Matrix team. **This is directly putting core Matrix development at risk.** We are witnessing a classic tragedy of the commons. We’ve released all the foundational code of Matrix as permissively-licensed open source and got it to the point that anyone can successfully run it at scale themselves. The network is expanding exponentially. But in return, it transpires that the vast majority of these commercial deployments fail to contribute financially to the Matrix Foundation - whether by donating directly or supporting indirectly by working with [Element](https://element.io), who fund the vast majority of core Matrix development today.
 
 In short: folks love the amazing decentralised encrypted comms utopia of Matrix.  But organisations also love that they can use it without having to pay anyone to develop or maintain it. **This is completely unsustainable**, and Element is now *literally* unable to fund the entirety of the Matrix Foundation on behalf of everyone else - and has had to lay off some of the folks working on the core team as a result.
+
+<!-- more -->
 
 The only viable solution to this is for organisations building on Matrix to contribute to sharing the costs of maintaining Matrix’s core projects.  We made [a proposal](https://matrix.org/blog/2022/12/01/funding-matrix-via-the-matrix-org-foundation) to address this a few weeks ago, which we’ll iterate on further in the new year to find an approach which both empowers the community and encourages organisations to participate.  In the interim, if you are an organisation who’s building on Matrix and you want the project to continue to flourish, **please** mail [funding@matrix.org](mailto:funding@matrix.org) to discuss how you can support the foundations that you are depending on.
 

--- a/content/blog/2023/02/2023-02-09-finally-a-hybrid-conference-that-worked.md
+++ b/content/blog/2023/02/2023-02-09-finally-a-hybrid-conference-that-worked.md
@@ -6,7 +6,7 @@ path = "/blog/2023/02/09/finally-a-hybrid-conference-that-worked"
 
 [taxonomies]
 author = ["Thib"]
-category = ["conferences", "fosdem"]
+category = ["FOSDEM", "Events"]
 
 [extra]
 image = "https://matrix.org/blog/img/fosdem2023_stand_blurred.jpg"

--- a/content/blog/2023/07/2023-07-04-deportalling-libera-chat.md
+++ b/content/blog/2023/07/2023-07-04-deportalling-libera-chat.md
@@ -1,6 +1,6 @@
 +++
 date = "2023-07-04T16:00:00Z"
-title = "Deportalling from Libera Chat"
+title = "Deportalling from Libera.Chat"
 
 [taxonomies]
 author = ["Neil Johnson"]

--- a/content/blog/2023/08/2023-08-04-libera-bridge-disabled.md
+++ b/content/blog/2023/08/2023-08-04-libera-bridge-disabled.md
@@ -3,7 +3,7 @@ date = "2023-08-04T22:30:00Z"
 title = "Libera.Chat bridge temporarily unavailable."
 
 [taxonomies]
-author = ["Neil"]
+author = ["Neil Johnson"]
 category = ["Bridges"]
 +++
 

--- a/content/blog/2023/11/2023-11-10-fosdem-cfp.md
+++ b/content/blog/2023/11/2023-11-10-fosdem-cfp.md
@@ -4,7 +4,7 @@ title = "Call for Participation to the FOSDEM 2024 Matrix Devroom"
 
 [taxonomies]
 author = ["Thib"]
-category = ["General"]
+category = ["FOSDEM", "Events"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-fosdem.png"

--- a/content/blog/2023/11/2023-11-28-liberachat.md
+++ b/content/blog/2023/11/2023-11-28-liberachat.md
@@ -1,6 +1,6 @@
 +++
 date = "2023-11-28"
-title = "Shutting down the Matrix bridge to Libera Chat"
+title = "Shutting down the Matrix bridge to Libera.Chat"
 path = "/blog/2023/11/28/shutting-down-bridge-to-libera-chat"
 
 [taxonomies]

--- a/content/blog/2023/12/2023-12-04-extension-fosdem-cfp.md
+++ b/content/blog/2023/12/2023-12-04-extension-fosdem-cfp.md
@@ -4,7 +4,7 @@ title = "Extending our Call for Participation to the FOSDEM 2024 Matrix Devroom"
 
 [taxonomies]
 author = ["Thib"]
-category = ["General"]
+category = ["Events", "FOSDEM"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-fosdem.png"

--- a/content/blog/2023/12/2023-12-25-the-matrix-holiday-update-2023.md
+++ b/content/blog/2023/12/2023-12-25-the-matrix-holiday-update-2023.md
@@ -5,7 +5,7 @@ aliases = ["/blog/2022/12/25/the-matrix-holiday-update-2023"]
 
 [taxonomies]
 author = ["Matthew Hodgson"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-logo.png"
@@ -18,6 +18,8 @@ Hi all,
 On the governance side, we are in an incredibly exciting new era with [Josh joining the Matrix.org Foundation](https://matrix.org/blog/2023/10/26/hello-world/) as its first ever Managing Director (and employee!), with a mandate to cement sustainable funding for Matrix as an independent foundation, governed by the forthcoming elected [open Governance Board](https://matrix.org/blog/2023/12/electing-our-first-governing-board/).  Now, **Matrix needs funding more than ever** - but rather than turning the entirety of this post into a plea for donations, I’m going to let Josh fly the flag in the coming weeks. Meanwhile, if you want Matrix to keep existing (especially if you’re an organisation who builds on Matrix) **[please join the Foundation](https://matrix.org/membership/) and [donate](https://matrix.org/support).**
 
 On the technical side: the theme of the year has been one of focus: extreme, overdue, focus.
+
+<!-- more -->
 
 Over the years, it’s fair to say that the core team has tried to strike a balance between building the core foundational technology of Matrix (the spec, a stable server implementation, client SDKs, end-to-end encryption, VoIP, etc)... and long-term forward-looking projects designed to futureproof Matrix (e.g. Account Portability, P2P Matrix, Dendrite, Hydrogen) and/or inspire developers to build on Matrix for more than just chat (e.g. Third Room, Applications Beyond Chat).  In retrospect, this was wildly optimistic: we underestimated the amount of remaining work needed to polish the foundational tech to mainstream quality - and despite Matrix uptake going through the roof, this hasn’t translated into sufficient funding to have the luxury to support folks to proactively work on next-gen projects (or foundational projects, for that matter).
 

--- a/content/blog/2024/01/2024-01-11-matrix-presence-fosdem.md
+++ b/content/blog/2024/01/2024-01-11-matrix-presence-fosdem.md
@@ -4,7 +4,7 @@ title = "Meet us at FOSDEM"
 
 [taxonomies]
 author = ["Thib"]
-category = ["FOSDEM", "Conferences"]
+category = ["FOSDEM", "Events"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-fosdem.png"

--- a/content/blog/2024/02/2024-02-08-fosdem-wrap-up.md
+++ b/content/blog/2024/02/2024-02-08-fosdem-wrap-up.md
@@ -4,7 +4,7 @@ title = "FOSDEM 2024 Wrap Up"
 
 [taxonomies]
 author = ["Thib"]
-category = ["FOSDEM"]
+category = ["FOSDEM", "Events"]
 
 [extra]
 image = "https://matrix.org/blog/img/fosdem2024-devroom.jpg"

--- a/content/blog/2024/06/2024-06-07-regulatory-update.md
+++ b/content/blog/2024/06/2024-06-07-regulatory-update.md
@@ -4,7 +4,7 @@ title = "Policy and regulation update 2024: Matrix and the GDPR"
 
 [taxonomies]
 author = ["Denise Almeida"]
-category = ["Foundation", "Compliance"]
+category = ["Foundation", "Compliance", "EU"]
 +++
 
 If you have been following the matrix.org blog for some time, you will know that we’ve never been ones to shy away from complex topics like public policy and its impacts on Matrix. With this blog post series, our aim is to introduce a more regular cadence to our regulatory updates and to be more transparent about where we are focusing our efforts in this area.

--- a/content/blog/2024/06/2024-06-12-matrix-conf-cfp.md
+++ b/content/blog/2024/06/2024-06-12-matrix-conf-cfp.md
@@ -5,7 +5,7 @@ updated = "2024-06-18T15:00:00Z"
 
 [taxonomies]
 author = ["Thib"]
-category = ["The Matrix Conference", "Conferences"]
+category = ["The Matrix Conference", "Events"]
 
 [extra]
 image = "https://matrix.org/img/matrix-conference-opengraph.png"

--- a/content/blog/2024/06/2024-06-12-matrix-conf-cfp.md
+++ b/content/blog/2024/06/2024-06-12-matrix-conf-cfp.md
@@ -5,7 +5,7 @@ updated = "2024-06-18T15:00:00Z"
 
 [taxonomies]
 author = ["Thib"]
-category = ["Conference"]
+category = ["The Matrix Conference", "Conferences"]
 
 [extra]
 image = "https://matrix.org/img/matrix-conference-opengraph.png"

--- a/content/blog/2024/08/2024-08-01-matrix-conf-schedule.md
+++ b/content/blog/2024/08/2024-08-01-matrix-conf-schedule.md
@@ -4,7 +4,7 @@ title = "The Matrix Conference Has an Exciting Lineup"
 
 [taxonomies]
 author = ["Thib"]
-category = ["Conference"]
+category = ["The Matrix Conference", "Conferences"]
 
 [extra]
 image = "https://matrix.org/img/matrix-conference-opengraph.png"

--- a/content/blog/2024/08/2024-08-01-matrix-conf-schedule.md
+++ b/content/blog/2024/08/2024-08-01-matrix-conf-schedule.md
@@ -4,7 +4,7 @@ title = "The Matrix Conference Has an Exciting Lineup"
 
 [taxonomies]
 author = ["Thib"]
-category = ["The Matrix Conference", "Conferences"]
+category = ["The Matrix Conference", "Events"]
 
 [extra]
 image = "https://matrix.org/img/matrix-conference-opengraph.png"

--- a/content/blog/2024/10/2024-10-29-matrixconf.md
+++ b/content/blog/2024/10/2024-10-29-matrixconf.md
@@ -5,7 +5,7 @@ path = "/blog/2024/10/29/matrixconf"
 
 [taxonomies]
 author = ["Josh Simmons"]
-category = ["Conference"]
+category = ["The Matrix Conference", "Conferences"]
 +++
 
 PHEW! One month later and I’m still buzzing from [the inaugural Matrix Conference](https://2024.matrix.org/) in Berlin. This was the first time we’ve gathered such a broad cross-section of the ecosystem both upstream and downstream, bringing together contributors, vendors, and end-users in the same place at the same time.

--- a/content/blog/2024/10/2024-10-29-matrixconf.md
+++ b/content/blog/2024/10/2024-10-29-matrixconf.md
@@ -5,7 +5,7 @@ path = "/blog/2024/10/29/matrixconf"
 
 [taxonomies]
 author = ["Josh Simmons"]
-category = ["The Matrix Conference", "Conferences"]
+category = ["The Matrix Conference", "Events"]
 +++
 
 PHEW! One month later and I’m still buzzing from [the inaugural Matrix Conference](https://2024.matrix.org/) in Berlin. This was the first time we’ve gathered such a broad cross-section of the ecosystem both upstream and downstream, bringing together contributors, vendors, and end-users in the same place at the same time.

--- a/content/blog/2024/11/2024-11-04-fosdem-cfp.md
+++ b/content/blog/2024/11/2024-11-04-fosdem-cfp.md
@@ -4,7 +4,7 @@ title = "Call for Participation to the FOSDEM 2025 Matrix Devroom"
 
 [taxonomies]
 author = ["Thib"]
-category = ["General", "Conferences", "FOSDEM"]
+category = ["FOSDEM", "Events"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-fosdem.png"

--- a/content/blog/2024/11/2024-11-19-matrix-fosdem-full-force.md
+++ b/content/blog/2024/11/2024-11-19-matrix-fosdem-full-force.md
@@ -4,7 +4,7 @@ title = "Matrix in full force at FOSDEM"
 
 [taxonomies]
 author = ["Thib"]
-category = ["Conferences", "FOSDEM"]
+category = ["Events", "FOSDEM"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-fosdem.png"

--- a/content/blog/2024/12/2024-12-25-the-matrix-holiday-update-2024.md
+++ b/content/blog/2024/12/2024-12-25-the-matrix-holiday-update-2024.md
@@ -4,7 +4,7 @@ path = "/blog/2024/12/25/the-matrix-holiday-special-2024"
 
 [taxonomies]
 author = ["Matthew Hodgson", "Josh Simmons"]
-category = ["General"]
+category = ["General", "Holiday Special"]
 
 [extra]
 image = "https://matrix.org/blog/img/matrix-logo.png"

--- a/content/blog/2025/02/2025-02-11-fosdem-wrap-up.md
+++ b/content/blog/2025/02/2025-02-11-fosdem-wrap-up.md
@@ -7,7 +7,7 @@ image = "https://matrix.org/blog/img/fosdem-25-group-picture.png"
 
 [taxonomies]
 author = ["Thib"]
-category = ["FOSDEM"]
+category = ["FOSDEM", "Events"]
 +++
 
 The Matrix.org Foundation and its growing community were once again present at the biggest OSS conference in Europe, and it's been a tremendous success! It was an opportunity for us to gather, share ideas and debate about ongoing topics, meet the broader FOSS community and present our work.

--- a/navigation.toml
+++ b/navigation.toml
@@ -25,5 +25,5 @@ footer_external = [
     { image = "mastodon.svg", alt = "Mastodon", href = "https://mastodon.matrix.org/@matrix" },
     { image = "twitter.svg", alt = "Twitter", href = "https://twitter.com/matrixdotorg" },
     { image = "youtube.svg", alt = "YouTube", href = "https://www.youtube.com/channel/UCVFkW-chclhuyYRbmmfwt6w" },
-    { image = "rss.svg", alt = "RSS", href = "/atom.xml" },
+    { image = "rss.svg", alt = "Atom Feed", href = "/atom.xml" },
 ]

--- a/taxonomy.toml
+++ b/taxonomy.toml
@@ -1,0 +1,3 @@
+[plurals]
+author = "authors"
+category = "categories"

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -11,7 +11,7 @@
                 {{ page.date | date(format="%d.%m.%Y %H:%M") }}
                 {% if page.taxonomies.category -%}
                 —
-                {% for category in page.taxonomies.category %}
+                {% for category in page.taxonomies.category | sort %}
                 <a href="/category/{{ category | slugify }}">
                     {{- category -}}
                 </a>

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -8,7 +8,7 @@
         <header>
             <h1><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h1>
             <span>
-                {{ page.date | date(format="%d.%m.%Y %H:%M") }}
+                {{ page.date | date(format="%Y-%m-%d %H:%M") }}
                 {% if page.taxonomies.category -%}
                 —
                 {% for category in page.taxonomies.category | sort %}
@@ -27,7 +27,7 @@
             </span>
             {% if page.updated -%}
             <br>
-            <small>Last update: {{ page.updated | date(format="%d.%m.%Y %H:%M") }}</small>
+            <small>Last update: {{ page.updated | date(format="%Y-%m-%d %H:%M") }}</small>
             {%- endif %}
         </header>
         <div>

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -8,7 +8,7 @@
         <header>
             <h1><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h1>
             <span>
-                {{ page.date | date(format="%Y-%m-%d %H:%M") }}
+                {{ page.date | date(format="%Y-%m-%d") }}
                 {% if page.taxonomies.category -%}
                 —
                 {% for category in page.taxonomies.category | sort %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -51,7 +51,7 @@
     <header>
         <h1>{{ page.title }}</h1>
         <span>
-            {{ page.date | date(format="%Y-%m-%d %H:%M") }}
+            {{ page.date | date(format="%Y-%m-%d") }}
             {% if page.taxonomies.category %}
             —
             {% for category in page.taxonomies.category | sort %}

--- a/templates/post.html
+++ b/templates/post.html
@@ -51,7 +51,7 @@
     <header>
         <h1>{{ page.title }}</h1>
         <span>
-            {{ page.date | date(format="%d.%m.%Y %H:%M") }}
+            {{ page.date | date(format="%Y-%m-%d %H:%M") }}
             {% if page.taxonomies.category %}
             —
             {% for category in page.taxonomies.category | sort %}
@@ -69,7 +69,7 @@
             {% endfor %}
         </span>
         {% if page.updated %}
-        <br><small>Last update: {{ page.updated | date(format="%d.%m.%Y %H:%M") }}</small>
+        <br><small>Last update: {{ page.updated | date(format="%Y-%m-%d %H:%M") }}</small>
         {% endif %}
     </header>
     <div class="post-main">

--- a/templates/post.html
+++ b/templates/post.html
@@ -54,7 +54,7 @@
             {{ page.date | date(format="%d.%m.%Y %H:%M") }}
             {% if page.taxonomies.category %}
             —
-            {% for category in page.taxonomies.category %}
+            {% for category in page.taxonomies.category | sort %}
                 <a href="/category/{{ category | slugify }}">
                     {{- category -}}
                 </a>

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -15,7 +15,7 @@
                 </h3>
                 {% if taxonomy.feed %}
                 <h4>
-                    <small><a href="{{ term.permalink | safe }}atom.xml">Atom Feed</a></small>
+                    <small><a href="{{ term.permalink | safe }}atom.xml"><img width="10px" height="10px" src="/assets/rss.svg" alt="Atom"> Category Atom Feed</a></small>
                 </h4>
                 {% endif %}
                 <ul>

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -24,9 +24,11 @@
                         <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
                     </li>
                     {% endfor %}
+                    {% if term.pages | length > 4 %}
                     <li>
-                        <a href="{{ term.permalink | safe }}">...more "{{ term.name }}" posts</a>
+                        <a href="{{ term.permalink | safe }}">... all "{{ term.name }}" posts</a>
                     </li>
+                    {% endif %}
                 </ul>
             </div>
             {% endfor %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -21,6 +21,7 @@
                 <ul>
                     {% for page in term.pages | slice(end=4) %}
                     <li>
+                        {{ page.date | date(format="%Y-%m-%d") }}:
                         <a href="{{ page.permalink | safe }}">{{ page.title }}</a>
                     </li>
                     {% endfor %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -24,17 +24,21 @@
                 <h2><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h2>
                 <span>
                     {{ page.date | date(format="%d.%m.%Y %H:%M") }}
-                    {% if page.taxonomies.category -%}
+                    {% if page.taxonomies.category %}
                     —
-                    <a href="/category/{{ page.taxonomies.category | first | slugify }}">
-                        {{ page.taxonomies.category | first }}
+                    {% for category in page.taxonomies.category %}
+                    <a href="/category/{{ category | slugify }}">
+                        {{- category -}}
                     </a>
-                    {% endif -%}
+                    {%- if not loop.last %}, {% endif %}{% endfor %}
+                    {% endif %}
                     —
-                    <a
-                        href="/author/{{ page.taxonomies.author | default(value=['unknown author']) | first | slugify }}">
-                        {{ page.taxonomies.author | default (value=["unknown author"]) | first }}
+                    {% for author in page.taxonomies.author %}
+                    <a href="/author/{{ author | default (value=['unknown author']) | slugify }}">
+                        {{- author | default (value=["unknown author"]) -}}
                     </a>
+                    {%- if not loop.last %}, {% endif %}
+                    {% endfor %}
                 </span>
                 {% if page.updated -%}
                 <br>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -24,7 +24,7 @@
             <header>
                 <h2><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h2>
                 <span>
-                    {{ page.date | date(format="%d.%m.%Y %H:%M") }}
+                    {{ page.date | date(format="%Y-%m-%d %H:%M") }}
                     {% if page.taxonomies.category %}
                     —
                     {% for category in page.taxonomies.category | sort %}
@@ -43,7 +43,7 @@
                 </span>
                 {% if page.updated -%}
                 <br>
-                <small>Last update: {{ page.updated | date(format="%d.%m.%Y %H:%M") }}</small>
+                <small>Last update: {{ page.updated | date(format="%Y-%m-%d %H:%M") }}</small>
                 {%- endif %}
             </header>
             <div>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -24,7 +24,7 @@
             <header>
                 <h2><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h2>
                 <span>
-                    {{ page.date | date(format="%Y-%m-%d %H:%M") }}
+                    {{ page.date | date(format="%Y-%m-%d") }}
                     {% if page.taxonomies.category %}
                     —
                     {% for category in page.taxonomies.category | sort %}

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -13,7 +13,7 @@
                 }})</a>
             {% if taxonomy.feed %}
             <h2>
-                <small><a href="{{ term.permalink | safe }}atom.xml">Atom Feed</a></small>
+                <small><a href="{{ term.permalink | safe }}atom.xml"><img width="10px" height="10px" src="/assets/rss.svg" alt="Atom"> Category Atom Feed</a></small>
             </h2>
             {% endif %}
         </header>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -27,7 +27,7 @@
                     {{ page.date | date(format="%d.%m.%Y %H:%M") }}
                     {% if page.taxonomies.category %}
                     —
-                    {% for category in page.taxonomies.category %}
+                    {% for category in page.taxonomies.category | sort %}
                     <a href="/category/{{ category | slugify }}">
                         {{- category -}}
                     </a>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -8,8 +8,9 @@
     <div class="content">
         <header>
             <h1>{{ term.name }}</h1>
+            {% set taxonomy = load_data(path="taxonomy.toml") %}
             {{ term.pages | length }} posts tagged with "{{ term.name }}" <a href="/{{ taxonomy.name }}">(See all {{
-                taxonomy.name | capitalize
+                taxonomy.plurals[taxonomy.name] | default(value=taxonomy.name)
                 }})</a>
             {% if taxonomy.feed %}
             <h2>


### PR DESCRIPTION
:tophat: Website & Content WG

This PR
- resolves #2661 by
  - moving blog posts about matrix conf from the `Conference`  to `The Matrix Conference` category
  - consolidating `Conferences` blog posts under `Events`
- tags old `FOSDEM` blog posts
- tags `Holiday Special` blog posts (includes season specials in order to not overdo it)
- updates some more categories and authors
- updates the category pages with
  - the ability to see all post authors and categories
  - introduces a map for displaying proper plurals of our taxonomies
  - removes redundant "more" links
  - improves the link to feed wording and adds icon
- somewhat unrelatedly fixes the alt text of the footer atom link
- fixes some typos

All this should be possible to review by individual commits.

Preview: https://harharlinks-update-blog.matrix-website.pages.dev/

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>