### PR TITLE
Make floating images ultrawide screen freindly

### DIFF
--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -326,6 +326,10 @@
             top: 100px;
             left: calc(60dvw - 800px);
 
+            @media (min-width: 2000px) {
+                left: 20dvw;
+            }
+
             width: 240px;
             height: 287px;
         }
@@ -335,6 +339,10 @@
             bottom: 50px;
             left: calc(60dvw - 800px);
 
+            @media (min-width: 2000px) {
+                left: 20dvw;
+            }
+
             width: 230px;
             height: 235px;
         }
@@ -343,6 +351,10 @@
             position: absolute;
             top: calc(200px - 4dvw);
             right: calc(60dvw - 800px);
+
+            @media (min-width: 2000px) {
+                right: 20dvw;
+            }
         }
 
         .call-to-action {


### PR DESCRIPTION
On ultrawide monitors, the dynamic view width calculations for the images ended up causing them to overlay buttons which would cause half the button to stop working.

![image](https://github.com/user-attachments/assets/a41901fb-c1fd-4e1a-af21-4dbb097e2648)

This better places the elements in a better looking place and doesn't affect the buttons functionally anymore.
Before:
![image](https://github.com/user-attachments/assets/bc2ee780-ecd9-4f76-b937-655849d19a81)


After:
![image](https://github.com/user-attachments/assets/603311ca-ea8e-421e-9663-275c7d4ee7f3)


Signed-off-by: Louis Harshman <lewisharshman1@gmail.com>