### PR TITLE
Fix visualisation positioning on homepage

### DIFF
--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -324,25 +324,34 @@
         #bridge_visual {
             position: absolute;
             top: 100px;
-            left: calc(60dvw - 800px);
+            @media (max-width: 767px) {
+                top: 25px; // container padding
+            }
+            left: min(max(20%, calc(50% - 600px)), calc(50% - (var(--bridge-visual-width) / 2) - 300px));
 
-            width: 240px;
+            --bridge-visual-width: 240px;
+            width: var(--bridge-visual-width);
             height: 287px;
         }
 
         #homeserver {
             position: absolute;
             bottom: 50px;
-            left: calc(60dvw - 800px);
+            left: min(max(20%, calc(50% - 600px)), calc(50% - (var(--homeserver-width) / 2) - 300px));
 
-            width: 230px;
+            --homeserver-width: 230px;
+            width: var(--homeserver-width);
             height: 235px;
         }
 
         #federation_visual {
             position: absolute;
-            right: calc(60dvw - 800px);
             bottom: 75px;
+            right: min(max(12%, calc(50% - 650px)), calc(50% - (var(--federation-visual-width) / 2) - 300px));
+
+            --federation-visual-width: 457px;
+            width: var(--federation-visual-width);
+            height: 880px;
         }
 
         .call-to-action {

--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -322,6 +322,8 @@
         }
 
         #bridge_visual {
+            --bridge-visual-width: 240px;
+
             position: absolute;
             top: 100px;
             @media (max-width: 767px) {
@@ -329,27 +331,28 @@
             }
             left: min(max(20%, calc(50% - 600px)), calc(50% - (var(--bridge-visual-width) / 2) - 300px));
 
-            --bridge-visual-width: 240px;
             width: var(--bridge-visual-width);
             height: 287px;
         }
 
         #homeserver {
+            --homeserver-width: 230px;
+
             position: absolute;
             bottom: 50px;
             left: min(max(20%, calc(50% - 600px)), calc(50% - (var(--homeserver-width) / 2) - 300px));
 
-            --homeserver-width: 230px;
             width: var(--homeserver-width);
             height: 235px;
         }
 
         #federation_visual {
+            --federation-visual-width: 457px;
+
             position: absolute;
             bottom: 75px;
             right: min(max(12%, calc(50% - 650px)), calc(50% - (var(--federation-visual-width) / 2) - 300px));
 
-            --federation-visual-width: 457px;
             width: var(--federation-visual-width);
             height: 880px;
         }

--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -341,8 +341,8 @@
 
         #federation_visual {
             position: absolute;
-            top: calc(200px - 4dvw);
             right: calc(60dvw - 800px);
+            bottom: 75px;
         }
 
         .call-to-action {

--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -281,7 +281,7 @@
         overflow: hidden;
 
         @media (max-width: 767px) {
-            padding: 100px 35px 435px 35px;
+            padding: 100px 35px 335px 35px;
         }
 
         justify-content: space-around;

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,7 +61,7 @@
             Matrix is a rich ecosystem of clients, servers, bots and application
             services. Find out more in our developer documentation.
         </p>
-        <div class="cta-col">
+        <div class="cta-col" style="z-index: 1;">
             <a href="https://github.com/matrix-org" class="call-to-action inverted"><img
                     src="/assets/frontpage/github-mark.svg" alt="" /> We're open source</a>
             <a href="https://spec.matrix.org" class="call-to-action inverted">Browse the Specification</a>


### PR DESCRIPTION
supersedes #2732

- see individual commits
- reasoning for the horizontal position of the visualisations
  - place image responsively at 20% within viewport (this is done by feeling, it ignores the exact image width etc)
  - keep it within 600px from the center (content width)
  - keep it at least 300px from the center (leave space for the text and buttons)

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>

:tophat: Website & Content WG