### PR TITLE
Update to v1.0.1 of the GB bylaws

### DIFF
--- a/content/foundation/governing-board/bylaws/02-bylaws.md
+++ b/content/foundation/governing-board/bylaws/02-bylaws.md
@@ -159,10 +159,10 @@ access or responsibilities they deal with. It is acceptable for the Working
 Group to define this for themselves, providing:
 
 1. They document the process (ideally publicly on their Working
-   Group website page on matrix.org, but at least for the Board)
+   Group website page on matrix.org, but at least for the Board).
 2. The process does not loosen the existing restrictions on
    participating with the Foundation in general (i.e. members should
-   be in good standing and aim to improve Matrix as a whole)
+   be in good standing and aim to improve Matrix as a whole).
 
 ### Working Group Chairs and Vice Chairs Expectations
 

--- a/content/foundation/governing-board/bylaws/02-bylaws.md
+++ b/content/foundation/governing-board/bylaws/02-bylaws.md
@@ -93,8 +93,8 @@ to the 'Committee Creation Process' section in
 ### Committee Chair and Vice Chair Expectations
 
 Committee chairs are facilitators, their job is to enable the Committee to keep
-moving, create/retire Working Groups, and recommend reports to the Board and
-the Foundation. Chairs are expected to:
+moving, work with Sponsors on Working Groups, and recommend reports to the Board
+and the Foundation. Chairs are expected to:
 - be responsive to the Committee's members and to the broader Governing Board.
 - lead their committee in a fair, transparent, and accountable manner.
 - report up to the Board Chair on a regular basis to keep the Board informed of
@@ -113,15 +113,20 @@ Committee. Anyone in good standing may participate in a Working Group.
 Membership is expected to ebb and flow; what matters is clarity of purpose (the
 Charter), progress (meeting minutes), and outstanding tasks.
 
-Working Groups must have at least three members, including a Chair and a Vice
-Chair. Upon creation, each Working Group selects a provisional Chair, creates a
-charter, and sets up a meeting or discussion cadence/process. Working Groups
-belong to one Committee, but may work closely with several Committees. 
+Working Groups must have at least three members initially. Upon
+creation, each Working Group selects a provisional Chair, creates a
+charter, and sets up a meeting or discussion cadence/process.
+Working Groups belong to one Committee, but may work closely with
+several Committees.
 
-Working Groups are expected to maintain a dedicated Matrix room and Discourse
-category for communication, documentation, and voting. In order to ensure
-transparency and accountability, Working Groups should take notes in meetings
-and generally do their best to make their work public where possible.
+Working Groups must have a dedicated public Matrix room (which will
+be listed on
+[the Working Groups webpage](https://matrix.org/foundation/working-groups/)
+and the [Working Groups Matrix space](https://matrix.to/#/#matrix-wgs:matrix.org))
+and have access to a Discourse category for communication with the Board,
+documentation, and voting. In order to ensure transparency and
+accountability, Working Groups should take notes in meetings and
+generally do their best to make their work public where possible.
 
 ### Proposing New Working Groups
 
@@ -148,6 +153,16 @@ thing. The community will naturally have various people interested in different
 topics. What matters is that the Working Group is clear on its purpose (the
 Charter), its progress (the meeting minutes), and its outstanding tasks. This
 will allow prospective members to contribute.
+
+Some Working Groups will need a more formal membership process, because of the
+access or responsibilities they deal with. It is acceptable for the Working
+Group to define this for themselves, providing:
+
+1. They document the process (ideally publicly on their Working
+   Group website page on matrix.org, but at least for the Board)
+2. The process does not loosen the existing restrictions on
+   participating with the Foundation in general (i.e. members should
+   be in good standing and aim to improve Matrix as a whole)
 
 ### Working Group Chairs and Vice Chairs Expectations
 
@@ -186,7 +201,7 @@ but one should strive for these qualities:
 * High integrity  
 * Adaptable
 
-Vice Chairs (or the Board and of Committees) are able to act in the stead of
+Vice Chairs (of the Board and of Committees) are able to act in the stead of
 the Chair whenever the Chair is not available (ideally with notice and
 permission from the Chair). In the event that a Chair is not re-elected (or
 steps down), the Vice Chair is likely the best candidate to be named as the new

--- a/content/foundation/governing-board/bylaws/03-social-contract.md
+++ b/content/foundation/governing-board/bylaws/03-social-contract.md
@@ -46,9 +46,9 @@ set expectations for how we communicate externally.
 
    * The [**Discourse Forum**](https://matrix.discourse.group) is the official,
      primary place for our Board’s discussions and decision-making. While other
-     communication channels (e.g., chat) may be used for informal discussions,
-     **Board members should be active on the forum** to ensure that decisions are
-     made with transparency and all members are fully informed.  
+     communication channels (e.g., chat, Google Drive, etc) may be used for informal
+     discussions & collaboration, **Board members should be active on the forum** to
+     ensure that decisions are made with transparency and all members are fully informed.
    * The **Discourse Forum** will relay new topics & posts to the **Governing
      Board Matrix room** to try and keep members informed.  
    * This forum should serve as the **central hub** for documentation,

--- a/content/foundation/governing-board/bylaws/04-processes.md
+++ b/content/foundation/governing-board/bylaws/04-processes.md
@@ -16,8 +16,8 @@ A simple majority vote of the Board is sufficient to create the committee.
 ## Working Group Creation Process
 
 We intend for the community to be able to propose new Working Groups, as the
-community has many talented and knowledgable members - but we do not wish for
-additional loads to be placed upon the Board without it’s approval, and we want
+community has many talented and knowledgeable members - but we do not wish for
+additional loads to be placed upon the Board without its approval, and we want
 to ensure that new Working Groups have some support rather than being a
 one-person idea.
 
@@ -35,12 +35,24 @@ membership of the new Working Group and a rough draft of its potential charter
 with the initiator(s). Finally the Sponsor brings the proposal up with the rest
 of the Board for discussion.
 
-Ultimately, if the Board approve the initial members and scope, the Working
-Group will be created and place under an appropriate Committee, and will report
-it’s activities & recommendations to that Committee. It’s first task would be
+Ultimately, if the Board approves the initial members and scope, the Working
+Group will be created and placed under an appropriate Committee, and will report
+its activities & recommendations to that Committee. Its first task would be
 to refine the initial rough charter, and have it ratified by the Committee.
 
-## Chair Re-election Process
+## Chair Election Process
+
+When a Chair or Vice Chair position needs to be filled, the following process
+applies:
+
+1. **Notification Period**: The Board shall be notified that a position needs
+   to be filled, and nominations requested. This will generally last 1-2 weeks.
+2. **Election Period**: The Board / Committee will start a Discourse poll. This
+   will be a ranked-choice vote on the nominees, with the winner taking the
+   post (if one post is open) or the top two taking the posts (winner is Chair,
+   2nd is Vice Chair).
+
+### Chair Re-election Process
 
 If a Chair of a Committee or the Board is not re-elected during the election
 cycle (or wishes to step down), the following process shall be followed in
@@ -55,7 +67,7 @@ Chairs.
 2. **Transition Period**: The outgoing Chair shall have four weeks to complete
    all outstanding tasks and hand over to the incoming Chair. During this period,
    the outgoing Chair shall:
-    * Work with the committee to select a new Chair.
+    * Work with the Committee/Board to select a new Chair.
     * Ensure all ongoing work is completed, or delegated to other Board members
       where possible.
     * Document all relevant information and tasks to be completed.
@@ -142,7 +154,7 @@ action.
    Member, outlining the specific reasons for the removal. If appropriate, the
    Board shall also schedule a call or discussion with the Board Member to discuss
    the reasons for the removal, and to work together to develop a plan to address
-   the issues.  As part of this notification, the Board shall also:
+   the issues. As part of this notification, the Board shall also:
    * immediately suspend the Board Member's access to Matrix Foundation
      systems, repositories and infrastructure;
    * suspend the Board Member's voting rights until the situation is resolved;

--- a/content/foundation/governing-board/index.md
+++ b/content/foundation/governing-board/index.md
@@ -132,8 +132,8 @@ processes. The content is divided into the following sections:
 
 The Governance Committee is responsible for adapting these documents as needed,
 with the exception of the TOR, which requires formal amendment from the
-Guardians. These documents are currently v1.0 and were last modified on
-2025-05-09. The canonical versions of the bylaws and expectations, social contract,
+Guardians. These documents are currently v1.0.1 and were last modified on
+2025-05-21. The canonical versions of the bylaws and expectations, social contract,
 and processes are the markdown sources available through the matrix
 [website's git repo](https://github.com/matrix-org/matrix.org/tree/main/content/foundation/governing-board/bylaws).
 


### PR DESCRIPTION
When I created #2740 I accidentally used the initial version I proposed to the Board, rather than the version we approved in the meeting. There were a number of minor differences that had been proposed & accepted internally that got missed as a result.

I went though and diffed the internal version with this repo, and made the necessary changes. This PR brings the published doc back to the the approved version, as it *should* have been the first time.

As these are minor edits, I've bumped the version to 1.0.1, following something semver-ish :)

cc @HarHarLinks 