### PR TITLE
Add script to sort supporter entries by name

### DIFF
--- a/content/support/supporters.toml
+++ b/content/support/supporters.toml
@@ -172,3 +172,4 @@ logo = "gnome.svg"
 name = "KDE e.V."
 website = "https://kde.org"
 logo = "kde.svg"
+

--- a/scripts/sort_supporters.py
+++ b/scripts/sort_supporters.py
@@ -1,0 +1,27 @@
+import toml
+
+def sort_supporters_by_name(file_in, file_out=None):
+    
+    with open(file_in, 'r', encoding='utf-8') as f:
+        data = toml.load(f)
+    
+    
+    for tier, entries in data.items():
+        if isinstance(entries, list):
+            
+            data[tier] = sorted(entries, key=lambda x: x.get('name', '').lower())
+    
+    
+    output_file = file_out or file_in
+    with open(output_file, 'w', encoding='utf-8') as f:
+        toml.dump(data, f)
+    print(f"Sorted supporters saved to: {output_file}")
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python sort_supporters.py supporters.toml [output.toml]")
+    else:
+        input_file = sys.argv[1]
+        output_file = sys.argv[2] if len(sys.argv) > 2 else None
+        sort_supporters_by_name(input_file, output_file)


### PR DESCRIPTION
This pull request introduces a Python utility script located in `scripts/sort_supporters.py` that sorts the entries in `content/support/supporters.toml` alphabetically by name within each tier (e.g., gold, silver).

Changes:
- Added `sort_supporters.py` script.
- Applied the sorting to `supporters.toml`.

Usage:
Run from the repo root:
    python scripts/sort_supporters.py content/support/supporters.toml
