### PR TITLE
Sort Foundation guardians alphabetically in the template using Tera's…

### DIFF
--- a/templates/shortcodes/guardians.html
+++ b/templates/shortcodes/guardians.html
@@ -1,6 +1,6 @@
 <div>
     {% set guardians_data = load_data(path="content/foundation/about/guardians.toml") %}
-    {% for guardian in guardians_data.guardians %}
+    {% for guardian in guardians_data.guardians | sort(attribute="name") %}
     <div class="guardian {% if loop.index % 2 != 0 %}reverse{% endif %}">
         <div class="guardian-details">
             <h4 class="guardian-name">{{ guardian.name }}</h4>


### PR DESCRIPTION
Sort Foundation Guardians Alphabetically in the Template

Summary:
This PR updates the [guardians.html](https://bug-free-waddle-r47vvx9x6q25vv9.github.dev/) Tera template to automatically sort the Foundation guardians alphabetically by name when rendering the page. This ensures the list is always presented in a consistent, easy-to-navigate order, without requiring manual sorting in the data source.
Details:

Uses Zola’s Tera template filter:
{% for guardian in guardians_data.guardians | sort(attribute="name") %}

No changes to the underlying TOML data file; sorting is handled at display time.
Addresses #2755 and improves maintainability for future additions.

Why:
Keeps the Foundation members list organized and user-friendly.
