### PR TITLE
Sort foundation members alphabetically in display

### DIFF
--- a/templates/macros/supporters.html
+++ b/templates/macros/supporters.html
@@ -1,0 +1,25 @@
+{% macro case_insensitive_sort_supporters(supporters) %}
+    {# Step 1: Extract all supporter names in lower case #}
+    {% set lower_names = [] %}
+    {% for supporter in supporters %}
+        {% set_global lower_names = lower_names | concat(with=[supporter.name | lower]) %}
+    {% endfor %}
+
+    {# Step 2: Sort lower-case names #}
+    {% set sorted_lower_names = lower_names | sort %}
+
+    {# Step 3: Re-match sorted names with original supporter objects #}
+    {% for lower_name in sorted_lower_names %}
+        {% for supporter in supporters %}
+            {% if supporter.name | lower == lower_name %}
+                {% set_global current_supporter = supporter %}
+                {% break %}
+            {% endif %}
+        {% endfor %}
+
+        <a href="{{ current_supporter.website }}" target="_blank" class="supporters-card">
+            <img src="/support/{{ current_supporter.logo }}" alt="{{ current_supporter.name }}'s logo">
+            <span>{{ current_supporter.name }}</span>
+        </a>
+    {% endfor %}
+{% endmacro %}

--- a/templates/support.html
+++ b/templates/support.html
@@ -1,5 +1,6 @@
 {% extends "section.html" %}
 {% import "macros/banner.html" as banner %}
+{% import "macros/supporters.html" as supporters_macros %}
 {% block head_extra %}
 <meta name="description" content="{{ section.extra.summary }}">
 {% endblock head_extra %}
@@ -37,56 +38,31 @@
         <div class="supporters-section" id="platinum-supporters">
             <h2>Platinum Members</h2>
             <div class="cards">
-                {% for supporter in supporters.platinum | sort(attribute="name") %}
-                <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
-                    <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
-                    <span>{{ supporter.name }}</span>
-                </a>
-                {% endfor %}
+               {{ supporters_macros::case_insensitive_sort_supporters(supporters=supporters.platinum) }}
             </div>
         </div>
         <div class="supporters-section" id="gold-supporters">
             <h2>Gold Members</h2>
             <div class="cards">
-                {% for supporter in supporters.gold | sort(attribute="name") %}
-                <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
-                    <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
-                    <span>{{ supporter.name }}</span>
-                </a>
-                {% endfor %}
+              {{ supporters_macros::case_insensitive_sort_supporters(supporters=supporters.gold) }}
             </div>
         </div>
         <div class="supporters-section" id="silver-supporters">
             <h2>Silver Members</h2>
             <div class="cards">
-                {% for supporter in supporters.silver | sort(attribute="name") %}
-                <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
-                    <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
-                    <span>{{ supporter.name }}</span>
-                </a>
-                {% endfor %}
+                {{ supporters_macros::case_insensitive_sort_supporters(supporters=supporters.silver) }}
             </div>
         </div>
         <div class="supporters-section" id="ecosystem-supporters">
             <h2>Ecosystem Members</h2>
             <div class="cards">
-                {% for supporter in supporters.ecosystem | sort(attribute="name") %}
-                <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
-                    <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
-                    <span>{{ supporter.name }}</span>
-                </a>
-                {% endfor %}
+                {{ supporters_macros::case_insensitive_sort_supporters(supporters=supporters.ecosystem) }}
             </div>
         </div>
         <div class="supporters-section" id="associate-supporters">
             <h2>Associate Members</h2>
             <div class="cards">
-                {% for supporter in supporters.associate | sort(attribute="name") %}
-                <a href="{{ supporter.website }}" class="supporters-card">
-                    <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
-                    <span>{{ supporter.name }}</span>
-                </a>
-                {% endfor %}
+                {{ supporters_macros::case_insensitive_sort_supporters(supporters=supporters.associate) }}
             </div>
         </div>
     </div>

--- a/templates/support.html
+++ b/templates/support.html
@@ -37,7 +37,7 @@
         <div class="supporters-section" id="platinum-supporters">
             <h2>Platinum Members</h2>
             <div class="cards">
-                {% for supporter in supporters.platinum %}
+                {% for supporter in supporters.platinum | sort(attribute="name") %}
                 <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
                     <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
                     <span>{{ supporter.name }}</span>
@@ -48,7 +48,7 @@
         <div class="supporters-section" id="gold-supporters">
             <h2>Gold Members</h2>
             <div class="cards">
-                {% for supporter in supporters.gold %}
+                {% for supporter in supporters.gold | sort(attribute="name") %}
                 <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
                     <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
                     <span>{{ supporter.name }}</span>
@@ -59,7 +59,7 @@
         <div class="supporters-section" id="silver-supporters">
             <h2>Silver Members</h2>
             <div class="cards">
-                {% for supporter in supporters.silver %}
+                {% for supporter in supporters.silver | sort(attribute="name") %}
                 <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
                     <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
                     <span>{{ supporter.name }}</span>
@@ -70,7 +70,7 @@
         <div class="supporters-section" id="ecosystem-supporters">
             <h2>Ecosystem Members</h2>
             <div class="cards">
-                {% for supporter in supporters.ecosystem %}
+                {% for supporter in supporters.ecosystem | sort(attribute="name") %}
                 <a href="{{ supporter.website }}" target="_blank" class="supporters-card">
                     <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
                     <span>{{ supporter.name }}</span>
@@ -81,7 +81,7 @@
         <div class="supporters-section" id="associate-supporters">
             <h2>Associate Members</h2>
             <div class="cards">
-                {% for supporter in supporters.associate %}
+                {% for supporter in supporters.associate | sort(attribute="name") %}
                 <a href="{{ supporter.website }}" class="supporters-card">
                     <img src="/support/{{ supporter.logo }}" alt="{{ supporter.name }}'s logo">
                     <span>{{ supporter.name }}</span>


### PR DESCRIPTION
Solves Issue (#2756 )
This PR updates the Tera template to sort Foundation members alphabetically by name within each tier (Platinum, Gold, Silver, etc.) during rendering. The supporters.toml file remains unchanged.

Thank you for the clarification! I've implemented the sorting directly in the Tera template as suggested. Let me know if any changes are needed.
