### PR TITLE
Integrations: update info of etke.cc-maintained projects; add baibot and go-msc1929

### DIFF
--- a/content/ecosystem/integrations/integrations.toml
+++ b/content/ecosystem/integrations/integrations.toml
@@ -7,7 +7,7 @@ A CLI tool that joins the room and exports last N messages to the file(-s) you s
 maintainer = "etke.cc"
 language = "Go"
 licence = "GPL-3.0-or-later"
-repository = "https://gitlab.com/etke.cc/emm"
+repository = "https://github.com/etkecc/emm"
 room = "#emm:etke.cc"
 
 [[integrations]]
@@ -30,7 +30,7 @@ A Matrix helpdesk bot
 maintainer = "etke.cc"
 language = "Go"
 licence = "AGPL-3.0-only"
-repository = "https://gitlab.com/etke.cc/honoroit"
+repository = "https://github.com/etkecc/honoroit"
 room = "#honoroit:etke.cc"
 
 [[integrations]]
@@ -85,7 +85,7 @@ Demo instance: https://matrixrooms.info
 maintainer = "etke.cc"
 language = "Go"
 licence = "GPL-3.0-only"
-repository = "https://gitlab.com/etke.cc/mrs/api"
+repository = "https://github.com/etkecc/mrs/api"
 room = "#mrs:etke.cc"
 
 [[integrations]]
@@ -207,7 +207,7 @@ and some other info (like exit status) to matrix room.
 maintainer = "etke.cc"
 language = "Go"
 licence = "MIT"
-repository = "https://gitlab.com/etke.cc/ttm"
+repository = "https://github.com/etkecc/ttm"
 room = "#ttm:etke.cc"
 
 [[integrations]]
@@ -229,7 +229,7 @@ Matrix authentication plugin for Radicale
 maintainer = "etke.cc"
 language = "Python"
 licence = "AGPL-3.0-only"
-repository = "https://gitlab.com/etke.cc/radicale-auth-matrix"
+repository = "https://github.com/etkecc/radicale-auth-matrix"
 room = "#source:etke.cc"
 
 [[integrations]]

--- a/content/ecosystem/integrations/integrations.toml
+++ b/content/ecosystem/integrations/integrations.toml
@@ -6,9 +6,20 @@ A CLI tool that joins the room and exports last N messages to the file(-s) you s
 """
 maintainer = "etke.cc"
 language = "Go"
-licence = "GPL-3.0-or-later"
+licence = "AGPL-3.0-only"
 repository = "https://github.com/etkecc/emm"
 room = "#emm:etke.cc"
+
+[[integrations]]
+name = "baibot"
+description = """
+🤖 A Matrix bot for using diffent capabilities (text-generation, text-to-speech, speech-to-text, image-generation, etc.) of AI / Large Language Models (OpenAI, Anthropic, etc.)
+"""
+maintainer = "etke.cc"
+language = "Rust"
+licence = "AGPL-3.0-only"
+repository = "https://github.com/etkecc/baibot"
+room = "#baibot:etke.cc"
 
 [[integrations]]
 name = "Hemppa"
@@ -84,8 +95,8 @@ Demo instance: https://matrixrooms.info
 """
 maintainer = "etke.cc"
 language = "Go"
-licence = "GPL-3.0-only"
-repository = "https://github.com/etkecc/mrs/api"
+licence = "AGPL-3.0-only"
+repository = "https://github.com/etkecc/mrs"
 room = "#mrs:etke.cc"
 
 [[integrations]]
@@ -206,7 +217,7 @@ and some other info (like exit status) to matrix room.
 """
 maintainer = "etke.cc"
 language = "Go"
-licence = "MIT"
+licence = "AGPL-3.0-only"
 repository = "https://github.com/etkecc/ttm"
 room = "#ttm:etke.cc"
 
@@ -228,9 +239,17 @@ Matrix authentication plugin for Radicale
 """
 maintainer = "etke.cc"
 language = "Python"
-licence = "AGPL-3.0-only"
+licence = "LGPL-3.0-only"
 repository = "https://github.com/etkecc/radicale-auth-matrix"
-room = "#source:etke.cc"
+
+[[integrations]]
+name = "go-msc1929"
+language = "Go"
+licence = "LGPL-3.0-only"
+repository = "https://github.com/etkecc/go-msc1929"
+description = """
+Golang client for MSC1929 (/.well-known/matrix/support)
+"""
 
 [[integrations]]
 name = "Draupnir"


### PR DESCRIPTION
This PR contains updates for etke.cc-maintaned projects:
* Update links from GitLab to Github (we've moved all repos in 2024)
* Adjust license information (we've unified licenses used across the projects a while ago)
* Add [baibot](https://github.com/etkecc/baibot)
* Add [go-msc1929](https://github.com/etkecc/go-msc1929)

Signed-off-by: Aine <aine@etke.cc>