### PR TITLE
Advertise MAS through the old MSC2965 discovery mechanism

### DIFF
--- a/static/.well-known/matrix/client
+++ b/static/.well-known/matrix/client
@@ -5,6 +5,10 @@
     "m.identity_server": {
         "base_url": "https://vector.im"
     },
+    "org.matrix.msc2965.authentication": {
+        "issuer": "https://account.matrix.org/",
+        "account": "https://account.matrix.org/account/"
+    },
     "org.matrix.msc4143.rtc_foci": [
         {
             "type": "livekit",


### PR DESCRIPTION
Turns out, some clients (like Element iOS and Android legacy) still use the old way of discovering MAS for linking some account management features, and we forgot to update the well-known when we deployed MAS on matrix.org.
