### PR TITLE
Remove element wellknown for registration_helper_url

### DIFF
--- a/static/.well-known/element/element.json
+++ b/static/.well-known/element/element.json
@@ -1,3 +1,0 @@
-{
-    "registration_helper_url": "https://develop.element.io/#/mobile_register"
-}


### PR DESCRIPTION
:tophat: Website & Content WG

Per the removal deadline set by https://github.com/matrix-org/matrix.org/pull/2494#issuecomment-2355235778, I assume this helper can and should have been removed as matrix.org migrated to MAS.

@ara4n could you please merge or provide an update if that's not yet possible? :)