### PR TITLE
2025 gb results

### DIFF
--- a/content/blog/2025/06/2025-06-16-election-results.md
+++ b/content/blog/2025/06/2025-06-16-election-results.md
@@ -21,6 +21,8 @@ Our Governing Board has 8 constituencies that have elected representatives. Last
 
 This year we are seating representatives for the following constituencies: [Individual Members](https://opavote.com/results/5202655923666944), Associate Members, [Silver Members](https://opavote.com/results/5206099480805376), and Gold Members. Because we had fewer candidates than seats for Associate and Gold Members, we did not run elections in those categories.
 
+## Elected representatives
+
 These are the elected representatives for each of those constituencies:
 
 Individual Members

--- a/content/blog/2025/06/2025-06-16-election-results.md
+++ b/content/blog/2025/06/2025-06-16-election-results.md
@@ -1,0 +1,54 @@
++++
+date = "2025-06-16T17:00:00Z"
+title = "Introducing your new Governing Board representatives"
+
+[taxonomies]
+author = ["Robin Riley"]
+category = ["Foundation", "Elections", "Governing Board"]
++++
+
+It is an honor to unveil the election results and introduce the newest elected representatives of the Governing Board!
+
+Congratulations to the winning candidates, we thank you for your willingness to serve the community. We're also grateful to everyone who threw their hat in the ring, and hope that the candidates who did not get elected consider running again in the future. Thanks also to the outgoing members of the Governing Board for their service in the precedent-setting first cohort!
+
+I'd also like to express our gratitude to all the people who cast ballots in the election, and to everyone who asked questions along the way! We learn a lot in each election and we look forward to improving it each successive year.
+
+Read on to see who is on the Governing Board and a brief discussion of next steps.
+
+<!-- more -->
+
+Our Governing Board has 8 constituencies that have elected representatives. Last year was our first election, and so we ran an election for all 8 constituencies. Starting this year and moving forward, we run elections in only half of the constituencies. This staggered approach to our elections allows us to strike a balance between experienced representatives and fresh perspectives, and the continuity it affords allows us to build up institutional capacity and knowledge over time.
+
+This year we are seating representatives for the following constituencies: [Individual Members](https://opavote.com/results/5202655923666944), Associate Members, [Silver Members](https://opavote.com/results/5206099480805376), and Gold Members. Because we had fewer candidates than seats for Associate and Gold Members, we did not run elections in those categories.
+
+These are the elected representatives for each of those constituencies:
+
+Individual Members
+- Andy Balaam (he/him)
+- Gnuxie (she/her)
+- Greg Sutcliffe (he/him)
+- J.B. Crawford (they/them)
+
+Associate Members
+- Tobias Fella (he/him), KDE e.V.
+- One vacant seat
+
+Silver Members
+- Christian Kußowski (he/him), Famedly
+- Jan Kohnert (he/him), Gematik GmbH
+
+Gold Members
+- Brad Murray (he/him), Automattic (Beeper)
+- Two vacant seats
+
+Learn more about the Governing Board and see the full set of representatives on the [Governing Board information page](/foundation/governing-board/). You can find the entire slate of 2025 candidates on the [2025 election page](/foundation/governing-board-elections/2025/).
+
+## Next steps
+
+All of the elected representatives will soon receive a welcome email and details about onboarding which will take place over the next month. We'll hold a Governing Board meeting soon thereafter, in addition to the twice annual meetings that the Terms of Reference require us to convene.
+
+Our next meeting will include updating committee assignments, filling any vacant Chair or Vice Chair positions, and other agenda items within the Governing Board's remit.
+
+I'll be coordinating with our Governing Board Chair and Vice Chair in managing the onboarding and offboarding of Governing Board members to the private Matrix rooms, Discourse forums, and mailing list.
+
+Onwards and upwards 🚀

--- a/content/foundation/governing-board-elections/2025/index.md
+++ b/content/foundation/governing-board-elections/2025/index.md
@@ -13,8 +13,9 @@ Announcements are posted on our blog, our social channels, as well as in the [Of
 We encourage you to read our [membership page](/membership/) and announcements:
 
 * 2025-04 [Announcing the 2025 Governing Board elections](/blog/2025/04/election-announcement)
+* 2025-06 [Introducing newly elected Governing Board representatives](/blog/2025/06/election-results)
 
-Read on for our [election schedule](#schedule), all of [nominees](#nominees), and more information about the election process.
+Read on for our [election schedule](#schedule), our current [elected representatives](#elected-representatives), all of the [nominees](#nominees), and more information about the election process.
 
 ## What is the Governing Board
 
@@ -76,7 +77,7 @@ Thanks to a proactive member of the community, we have [a dedicated Matrix space
 
 ### Voting (May 31)
 
-The voting period will run from **May 31st to June 13th**. All eligible voters will receive an email from [OpaVote](https://www.opavote.com/) – the election system we have chosen for this year’s elections.
+Voting is complete and ran till June 13th. All eligible voters should have received an email from [OpaVote](https://www.opavote.com/) – the election system we have chosen for this year’s elections.
 
 All members of each constituency group are entitled to vote on the candidates within that constituency group. If you believe you are eligible to participate but have not heard from us, first check the inbox and spam folders of the email address you have on file with us through Donorbox. [Please email us](mailto:elections@foundation.matrix.org) if you have any questions.
 
@@ -84,7 +85,9 @@ We will hold an election for all of the four constituencies even if a given cons
 
 ### Results (June 16)
 
-Results will be announced on June 16th. All elected representatives will be added to a private mailing list and Matrix room so that they can introduce themselves and communicate in between meetings. The Foundation's Managing Director and the Governing Board's Chair and/or Vice Chair will be reaching out to every elected representative to get new members onboarded as quickly as possible.
+[All of the winners were announced](/blog/2025/06/election-results) on June 16th.
+
+All elected representatives will be added to a private mailing list and Matrix room so that they can introduce themselves and communicate in between meetings. The Foundation's Managing Director and the Governing Board's Chair and/or Vice Chair will be reaching out to every elected representative to get new members onboarded as quickly as possible.
 
 The Governing Board will meet as a full board at least twice a year, for at least 90 minutes each time. We'll aim to have a meeting shortly after the election, and you can expect one meeting before the end of the year and another before the next election.
 
@@ -93,6 +96,19 @@ Members of the Governing Board are likely to receive a packet of materials befor
 While the Governing Board is an advisory board, members are encouraged to play a role in helping to carry out the activities that support the staff in delivering on the Foundation’s collective remit, such as coalescing priorities to share with the Spec Core Team and connecting with contributors and funders to implement proposals.
 
 The Governing Board has a number of Committees and Working Groups which meet and work in between Governing Board meetings. These are where the bulk of the activity will take place since the board, which may have up to 24 members, is quite large.
+
+## Elected representatives
+
+Below is a list of this year's candidates who are now elected representatives. Visit the [Governing Board information page](/foundation/governing-board/) for a complete list of elected representatives regardless of which year they were elected.
+
+* Andy Balaam (he/him), Individual Member
+* Gnuxie (she/her), Individual Member
+* Greg Sutcliffe (he/him), Individual Member
+* J.B. Crawford (they/them), Individual Member
+* Tobias Fella (he/him), KDE e.V., Associate Member
+* Brad Murray (he/him), Automattic (Beeper), Gold Member
+* Jan Kohnert (he/him), Gematik GmbH, Silver Member
+* Christian Kußowski (he/him), Famedly, Silver Member
 
 ## Nominees
 

--- a/content/foundation/governing-board/index.md
+++ b/content/foundation/governing-board/index.md
@@ -41,9 +41,9 @@ The current elected representatives are:
 ### Individual Members
 
 * Andy Balaam (he/him)
+* Gnuxie (she/her)
 * Greg Sutcliffe (he/him)
 * J.B. Crawford (they/them)
-* Sumner Evans
 
 </div>
 <div>
@@ -59,8 +59,8 @@ The current elected representatives are:
 
 ### Associate Members
 
-* Cleo Menenez Jr. (he/him), GNOME Foundation
 * Tobias Fella (he/him), KDE e.V.
+* And one vacant seat
 
 </div>
 <div>
@@ -68,6 +68,7 @@ The current elected representatives are:
 ### Platinum Members
 
 * Neil Johnson (he/him), Element
+* Three vacant seats
 
 </div>
 <div>
@@ -75,15 +76,15 @@ The current elected representatives are:
 ### Gold Members
 
 * Brad Murray (he/him), Automattic (Beeper)
-* Kevin Boos (he/him), Futurewei Technologies
+* Two vacant seats
 
 </div>
 <div>
 
 ### Silver Members
 
+* Christian Kußowski (he/him), Famedly
 * Jan Kohnert (he/him), Gematik GmbH
-* Thor Arne Johansen, Verji Tech AS
 
 </div>
 <div>
@@ -118,7 +119,7 @@ The current elected representatives are:
 These documents cover the Matrix Governing Board, its purpose, operations, and
 processes. The content is divided into the following sections:
 
-- [**Terms of Reference (TOR)**](https://matrix.org/media/2024-04-governing-board-terms-of-reference.pdf):
+- [**Terms of Reference (TOR)**](https://matrix.org/media/2025-04-governing-board-terms-of-reference.pdf):
   The immutable basis for the Governing Board. The TOR outline the Board's
   purpose, mandate, and authority.
 - [**Bylaws and Expectations**](./bylaws/02-bylaws): The comprehensive rules,
@@ -164,14 +165,14 @@ The current chairs of the Governing Board are:
 ### Governance Committee
 
 * Bram van den Heuvel (he/they) — Chair
-* Sumner Evans — Vice Chair
+* Vacant seat — Vice Chair
 
 </div>
 <div>
 
 ### Community Committee
 
-* Sumner Evans — Chair
+* Vacant seat — Chair
 * Nicolas Werner (he/him) — Vice Chair
 
 </div>
@@ -180,7 +181,7 @@ The current chairs of the Governing Board are:
 ### Finance Committee
 
 * Robin Riley (they/them) — Chair
-* Kevin Boos (he/him) — Vice Chair
+* Vacant seat — Vice Chair
 
 </div>
 <div>


### PR DESCRIPTION
Publish results blog post, update GB page, and update GB 2025 elections page.

Only update not specific to the election: updated one link to point to the newest Terms of Reference.

Not included, and some guidance or an additional commit would be welcomed: an update to the site-wide banner that mentions the elections.