### PR TITLE
fix a11y of the figure shortcode

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -53,8 +53,9 @@ It is possible to add pictures to your posts in markdown. First you need to drop
 ```jinja
 {{ figure(
     img="/blog/img/your-picture-name.avif"
-    caption="A description of the picture")
-}}
+    caption="A description of the picture"          # can be set to an empty string
+    alt="A picture description for screen readers"  # optional, should only be used when leaving the caption empty
+) }}
 ```
 
 This shortcode ensures that images have a consistent look across posts.

--- a/templates/shortcodes/figure.html
+++ b/templates/shortcodes/figure.html
@@ -1,4 +1,4 @@
 <figure style="height:100%;">
-    <img src="{{ img }}" alt="{{ caption }}" />
+    <img src="{{ img }}" {% if alt %}alt="{{ alt }}{% endif %}" />
     <figcaption>{{ caption | markdown | safe }}</figcaption>
 </figure>


### PR DESCRIPTION
🎩 Website & Content WG

I have been advised that it is counter productive to double up alt and caption as screen readers will already read the caption anyway. This PR gives us the option to add alt in cases where we don't want to include a caption.

Signed-off-by: HarHarLinks <2803622+HarHarLinks@users.noreply.github.com>