### PR TITLE
Fix date for 2025 Matrix Community Summit

### DIFF
--- a/content/blog/2025/05/2025-05-30-twim.md
+++ b/content/blog/2025/05/2025-05-30-twim.md
@@ -38,7 +38,7 @@ category = ["This Week in Matrix"]
 
 [Yan](https://matrix.to/#/@yan:datanauten.de) says
 
-> **July 31 – August 2 · c-base · Berlin**
+> **July 31 – August 3 · c-base · Berlin**
 > #### Why a Community Summit Matters
 > 
 > Matrix is more than a protocol – it's a social, technical, and political project.


### PR DESCRIPTION
Official documentation says 4 days, 31st to 3rd.