### PR TITLE
Add Law Enforcement Guidelines Link to Footer 

### DIFF
--- a/navigation.toml
+++ b/navigation.toml
@@ -15,6 +15,7 @@ footer_internal = [
     { title = "Security Hall of Fame", href = "/security-hall-of-fame" },
     { title = "Code of Conduct", href = "/legal/code-of-conduct" },
     { title = "Legal", href = "/legal" },
+    { title = "Law Enforcement Guidelines", href = "/legal/law-enforcement-guidelines" },
     { title = "Contact", href = "/contact" },
     { title = "Site Source", href = "https://github.com/matrix-org/matrix.org/" },
 ]


### PR DESCRIPTION
Resolves #2793 
This PR adds a separate "Law Enforcement Guidelines" link to the site footer to provide direct access to the law enforcement guidelines