### PR TITLE
make link between Element and the rust+js sdks clear

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -13,7 +13,7 @@ Matrix Application Service framework in Node.js.
 
 [[sdks]]
 name = "Matrix.org JS SDK"
-maintainer = "Matrix.org team"
+maintainer = "Element, on behalf of the Matrix.org Foundation"
 maturity = "Stable"
 language = "JavaScript"
 licence = "Apache-2.0"
@@ -506,7 +506,7 @@ featured_in = []
 
 [[sdks]]
 name = "matrix-rust-sdk"
-maintainer = "The Matrix.org Foundation"
+maintainer = "Element, on behalf of the Matrix.org Foundation"
 maturity = "Stable"
 language = "Rust"
 licence = "Apache-2.0"


### PR DESCRIPTION
See https://github.com/matrix-org/matrix-rust-sdk/pull/5341 and https://github.com/matrix-org/matrix-js-sdk/pull/4901