### PR TITLE
feat: include < polycule > into the client list

### DIFF
--- a/content/ecosystem/clients/polycule.md
+++ b/content/ecosystem/clients/polycule.md
@@ -1,0 +1,29 @@
++++
+title = "< polycule >"
+template = "ecosystem/client.html"
+[extra]
+thumbnail = "polycule.svg"
+maintainer = "The one with the braid"
+licence = "EUPL-1.2"
+language = "Flutter"
+latest_release = "2025-03-18"
+maturity = "Beta"
+repo = "https://gitlab.com/polycule_client/polycule/"
+website = "https://polycule.im"
+featured = false
+[extra.features]
+e2ee = true
+spaces = false
+voip_1to1 = false
+voip_jitsi = true
+threads = false
+sso = true
+multi_account = true
+multi_language = true
+[extra.packages]
+f_droid.app_id = "business.braid.polycule"
+webapp = "https://polycule.im/web"
+flathub.app_id = "business.braid.Polycule"
++++
+
+A geeky and efficient \[matrix\] client for power users.

--- a/content/ecosystem/clients/polycule.svg
+++ b/content/ecosystem/clients/polycule.svg
@@ -1,0 +1,1 @@
+<svg fill="#fff" height="48" viewBox="480 -1920 1920 960" width="48" xmlns="http://www.w3.org/2000/svg"><g transform="translate(960 -960)"><circle cx="480" cy="-480" fill="#3f51b5" r="960"/><path d="m198-160-178-320 180-320h160l-180 320 104 186 312-506h164l180 320-180 320h-160l180-320-104-184-310 504z"/></g></svg>


### PR DESCRIPTION
I feel like now that we became an ecosystem foundation member, it might slowly be time to list < polycule > on the client list.

I'm not sure how to deal with the following change of the metadata : < polycule > targets Linux but only uses conventional packaging rather than Flathub. Is there any way to propagate Linux support without being on Flathub ? It'd be highly confusing since < polycule > *mainly* targets Linux.

*This PR is contributed on behalf of < polycule > as foundation ecosystem member.*
