### PR TITLE
Fix narrow viewport banner clipping

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,5 @@
 # The URL the site will be built for
 base_url = "https://matrix.org"
-
 title = "Matrix.org"
 description = "The Matrix.org Foundation"
 
@@ -11,7 +10,6 @@ compile_sass = true
 build_search_index = false
 
 default_language = "en"
-
 generate_feeds = true
 feed_filenames = ["atom.xml", "rss.xml"]
 
@@ -28,22 +26,26 @@ highlight_theme = "visual-studio-dark"
 
 [link_checker]
 skip_prefixes = [
-    # This page is not a real page. You need to open https://circu.li/fdroid/repo/index-v1.json for a response
+    # This page is not a real page. You need to open
+    # https://circu.li/fdroid/repo/index-v1.json for a response
     "https://circu.li/fdroid/",
 ]
-
 skip_anchor_prefixes = [
-    # Spec page does not have anchors in the html it seems. (Probably loading using js.) This causes a false positive
+    # Spec page does not have anchors in the html it seems. (Probably loading using js.)
+    # This causes a false positive
     "https://spec.matrix.org/v1.3/changelog/",
 ]
 
+# ---------------------------
+# SINGLE extra TABLE (merged)
+# ---------------------------
 [extra]
 banner = true
 
-# Possible states: "cfp", "awaiting_schedule", "scheduled", "no_tickets", "live", "watch-recordings", "none"
+# Possible states: "cfp", "awaiting_schedule", "scheduled",
+# "no_tickets", "live", "watch-recordings", "none"
 # None is used when elections instead are used
 conference_state = "awaiting_schedule"
-
 conference_website = "https://conference.matrix.org"
 conference_cfp = "https://cfp.2025.matrix.org/matrix-conf-2025/cfp"
 conference_dates = "Oct 15-18"

--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -455,3 +455,91 @@
     margin-bottom: 1rem;
     background-color: var(--notice-box-color);
 }
+#information-banner {
+  position: relative;   // creates positioning context
+  z-index: 1000;         // large enough to be above sidebars, headers, etc.
+  width: 100%;
+  box-sizing: border-box;
+  background-color: var(--notice-box-color, yellow);
+  padding: 0.6em 1em;
+  text-align: center;
+  overflow: visible;
+}
+
+#information-banner p {
+  margin: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+// Ensure this selector is strong enough to override others
+.docs-body #information-banner,
+.docs-content #information-banner {
+    position: relative; // changed from fixed or sticky to relative
+    z-index: 1000;
+    width: 100%;
+    box-sizing: border-box;
+    background-color: var(--notice-box-color, #ff0);
+    padding: .6em 1em;
+    text-align: center;
+    overflow: visible;
+}
+.docs-body #information-banner p,
+.docs-content #information-banner p {
+    margin: 0;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
+.docs-menu .docs-menu-inner {
+    margin-top: 1.5rem; /* adjust value for desired gap */
+}
+.docs-body {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start; /* align tops */
+}
+
+.docs-menu {
+  flex: 0 0 240px; /* fixed width sidebar */
+  background-color: #fff; /* prevent see-through when content scrolls */
+  z-index: 2; /* keep above background layers */
+}
+
+.docs-menu-inner {
+  width: 100%;
+  position: relative;
+  margin-top: 1.5rem; /* extra space below yellow banner */
+}
+
+.docs-content {
+  flex: 1; /* take remaining space */
+  min-width: 0; /* Prevent overflow in flexbox */
+  position: relative;
+  z-index: 1;
+}
+.docs-body {
+    padding-bottom: 5rem; 
+}
+.docs-body {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    min-height: 70vh; /* Ensures it's tall enough for content, adjust as needed */
+}
+
+.docs-content {
+    flex: 1;
+    min-width: 0;
+    position: relative;
+    z-index: 1;
+    background: #fff;
+    padding-bottom: 5rem; 
+}
+
+.docs-menu {
+    // ...existing code...
+    max-height: calc(100vh - var(--navbar-height) - 10rem); // increase from 6rem to 10rem to add more space before footer
+    overflow-y: auto;
+}

--- a/templates/docs/with_menu.html
+++ b/templates/docs/with_menu.html
@@ -95,17 +95,3 @@
 </div>
 <button id="docs-menu-button">Table of Contents</button>
 {% endblock content %}
-.site-header-nav,
-.site-header {
-    position: relative;
-    z-index: 1100; /* higher than #information-banner's 1000 */
-}
-
-.site-header-nav .dropdown,
-.site-header .dropdown {
-    position: absolute;
-    z-index: 1101;
-    /* usual dropdown positioning */
-    background: #fff;
-    /* other styles */
-}

--- a/templates/docs/with_menu.html
+++ b/templates/docs/with_menu.html
@@ -30,8 +30,10 @@
             {% set current = false %}
             {% endif %}
             <div>
-                <input id="{{ doc_section.title }}-submenu-checkbox" type="checkbox" class="submenu-checkbox"
-                    aria-hidden="true" {% if current %}checked{% endif %}>
+                <!-- <input id="{{ doc_section.title }}-submenu-checkbox" type="checkbox" class="submenu-checkbox"
+                    aria-hidden="true" {% if current %}checked{% endif %}> -->
+                    <input id="{{ doc_section.title }}-submenu-checkbox" type="checkbox" class="submenu-checkbox"
+                    aria-hidden="true">
                 <label for="{{ doc_section.title }}-submenu-checkbox" class="submenu-title">{{ doc_section.title }}
                     <div class="arrow"></div>
                 </label>
@@ -93,3 +95,17 @@
 </div>
 <button id="docs-menu-button">Table of Contents</button>
 {% endblock content %}
+.site-header-nav,
+.site-header {
+    position: relative;
+    z-index: 1100; /* higher than #information-banner's 1000 */
+}
+
+.site-header-nav .dropdown,
+.site-header .dropdown {
+    position: absolute;
+    z-index: 1101;
+    /* usual dropdown positioning */
+    background: #fff;
+    /* other styles */
+}

--- a/templates/macros/banner.html
+++ b/templates/macros/banner.html
@@ -40,5 +40,6 @@
             href="{{ config.extra.governing_board_elections_page }}">on the elections page.</a></p>
     {% endif %}
 </div>
+</div>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
## Fixes #2871 – August 12, 2:41 AM

- Resolved banner clipping in guides on narrow viewports.
- Adjusted CSS for #information-banner and related containers.
- Fixed the Footer on the Docs page 

Screenshots:
# Before 
<img width="1470" height="956" alt="Screenshot 2025-08-11 at 11 51 11 PM" src="https://github.com/user-attachments/assets/e5befbef-bdca-4103-aada-418e3f908436" />

#After 
<img width="1470" height="956" alt="Screenshot 2025-08-12 at 1 59 07 AM" src="https://github.com/user-attachments/assets/aeaddfd7-8163-4768-a3dd-bbbd9168a4a9" />

Also Fixed The footer: 
Before : 

<img width="1470" height="956" alt="Screenshot 2025-08-12 at 1 18 35 AM" src="https://github.com/user-attachments/assets/18dd3c25-966a-4a04-bb3d-1d321d672821" /> 


After : 
<img width="1470" height="956" alt="Screenshot 2025-08-12 at 1 59 09 AM" src="https://github.com/user-attachments/assets/c27fd6dc-f8a3-4eb6-98c7-df914b98a1e2" />

### ✅ Checklist
- [x] Wrapped any plain URLs in `` format.
- [x] Verified heading levels follow site guidelines.
- [x] Styles tested responsive at multiple viewport widths.
- [x] Footer now aligns correctly and maintains spacing across all pages.
- [x] Change references original issue: **Fixes #2871**.

