### PR TITLE
Add a script to enforce usage of sign-off as required by the contributing.md

### DIFF
--- a/.github/workflows/sign-off.yml
+++ b/.github/workflows/sign-off.yml
@@ -1,0 +1,61 @@
+# Copyright 2025 The Matrix.org Foundation C.I.C.
+# Copyright 2024 - 2025 Catalan Lover <catalanlover@protonmail.com>
+# Copyright 2022 - 2024 The Matrix.org Foundation C.I.C.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# SPDX-FileAttributionText: <text>
+# This modified file incorporates work from matrix-org/backend-meta
+# https://github.com/matrix-org/backend-meta
+# </text>
+
+name: Contribution requirements
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  workflow_call:
+
+jobs:
+  signoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR for sign-off text
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // We don't require owners or members of the org to sign off.
+            const authorAssociation = context.payload.pull_request.author_association;
+            if (['OWNER', 'MEMBER'].includes(authorAssociation) ||
+                // GitHub sometimes mislables users as 'CONTRIBUTOR'/'COLLABORATOR',
+                // so check that the user created the PR on the base project to check they have write access.
+                context.payload.pull_request.head.user.login === context.repo.owner) {
+              core.notice('Pull request does not require sign-off.');
+              return;
+            }
+
+            // This regex is intentionally left lenient.
+            const signOffRegex = /signed[_\- ]off[_\- ]by: [\S ]+ <?.+(@|at).+>?/i;
+
+            if (signOffRegex.test(context.payload.pull_request.body ?? "")) {
+              core.notice('Pull request body contains a sign-off notice');
+              return;
+            }
+
+            const commits = await github.rest.pulls.listCommits({
+              pull_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              // It's *possible* the author has buried the sign-off 101 commits down, but
+              // we don't want to max out the API searching for it.
+              per_page: 100,
+            });
+
+            const commit = commits.data.find(c => signOffRegex.test(c.commit.message));
+            if (commit) {
+              core.notice(`Commit '${commit.id}' contains a sign-off notice`);
+              return;
+            }
+
+            core.setFailed('No sign off found. Please ensure you have signed off following the advice in https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md#sign-off .')
+            core.notice('Ensure you have matched the format `Signed-off-by: Your Name <your@email.example.org>`')


### PR DESCRIPTION
This adds the same CI as seen over at https://github.com/the-draupnir-project/Draupnir which itself in turn was based upon the CI seen in https://github.com/matrix-org/backend-meta

This should enforce that sign off actually happens by external contributors.

This currently cannot check for sign off in ~~PR text or~~ comments. We should discuss if we a) want this kind of ci b) if we need to deal with comments ~~and PR description here as wel~~l. (cc @matrix-org/website-wg )

<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md

     You can use the CI build or a local environment to check your changes are working as expected.
     
     If you have questions at any time, please contact the Website Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

<!-- Please don't remove this checklist from your PR, as it is useful for reviewers, too. -->
**:heavy_check_mark: Checklist**

- Check for common mistakes:
  - [ ] Wrap plain URLs in `<>` to linkify them ([learn more](https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md#publishing-to-the-blog)).
  - [ ] Use the right level of headings: The page title will use a level 1 headings, so your headings should use level 2 and below.
  - [ ] Use internal links: when linking to another page on <https://matrix.org>, use the Zola `[label](@/target.md)` [syntax](https://www.getzola.org/documentation/content/linking/#internal-links).
- For blog posts:
  - [ ] Verify the date and post ordering on the `/blog` page, especially for multiple posts on the same day. Prefer UTC format, e.g. `2025-12-01T14:00:00Z` for Dec 1st, 2025, 2pm UTC.
  - [ ] Set the correct author and category. Browse existing ones at <https://matrix.org/author/> and <https://matrix.org/category/> to match them.
- [ ] Let us know if you are contributing in a specific role, such as on behalf of an organisation or team, [for example](https://github.com/matrix-org/matrix.org/pull/2788).
- [ ] Let us know if your PR is time-sensitive in any way.
- [ ] Mention any issues related to the PR. Use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) as appropriate.
- [ ] Your individual commits or pull request is [signed off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md).
