### PR TITLE
Add blog archive page (list)

### DIFF
--- a/content/archive.md
+++ b/content/archive.md
@@ -1,0 +1,9 @@
++++
+title = "Blog Archive"
+template = "blog-archive.html"
+extra.meta_description = """
+The Matrix.org Foundation blog is where the Matrix.org Foundation and Community
+post updates on their activity. Every Friday evening they publish This Week In
+Matrix, a digest of the past week activity.
+"""
++++

--- a/content/blog/archive.md
+++ b/content/blog/archive.md
@@ -1,7 +1,11 @@
 +++
+date = "1970-01-01"
 title = "Blog Archive"
 template = "blog-archive.html"
-extra.meta_description = """
+
+[extra]
+hide_from_blog = true
+meta_description = """
 The Matrix.org Foundation blog is where the Matrix.org Foundation and Community
 post updates on their activity. Every Friday evening they publish This Week In
 Matrix, a digest of the past week activity.

--- a/navigation.toml
+++ b/navigation.toml
@@ -1,36 +1,118 @@
-header = [
-    { title = "Spec", href = "https://spec.matrix.org" },
-    { title = "Foundation", section = "foundation" },
-    { title = "Blog", href = "/blog/" },
-    { title = "Docs", href = "/docs/" },
-    { title = "Ecosystem", section = "ecosystem" },
-    { title = "Homeserver", section = "homeserver" },
-    { title = "Support us", href = "/support" },
-    { title = "Try Matrix", href = "/try-matrix/", primary = true },
-]
+[[header]]
+title = "Spec"
+href = "https://spec.matrix.org"
 
-footer_internal = [
-    { title = "Donate", href = "/support" },
-    { title = "Shop", href = "https://shop.matrix.org" },
-    { title = "Security Disclosure Policy", href = "/security-disclosure-policy" },
-    { title = "Security Hall of Fame", href = "/security-hall-of-fame" },
-    { title = "Code of Conduct", href = "/legal/code-of-conduct" },
-    { title = "Legal", href = "/legal" },
-    { title = "Law Enforcement Guidelines", href = "/legal/law-enforcement-guidelines" },
-    { title = "Contact", href = "/contact" },
-    { title = "Matrix.org Status", href = "https://status.matrix.org" },
-    { title = "Site Source", href = "https://github.com/matrix-org/matrix.org/" },
-]
+[[header]]
+title = "Foundation"
+section = "foundation"
 
-footer_external = [
-    { image = "github.svg", alt = "Matrix on GitHub", href = "https://github.com/matrix-org", newTab = true },
-    { image = "gitlab.svg", alt = "Matrix on GitLab", href = "https://gitlab.matrix.org/", newTab = true },
-    { image = "mastodon.svg", alt = "Matrix on Mastodon", href = "https://mastodon.matrix.org/@matrix", relMe = true, newTab = true },
-    { image = "x.svg", alt = "Matrix on X", href = "https://x.com/matrixdotorg", newTab = true },
-    { image = "youtube.svg", alt = "Matrix on YouTube", href = "https://www.youtube.com/channel/UCVFkW-chclhuyYRbmmfwt6w", newTab = true },
-    { image = "rss.svg", alt = "Matrix Atom Feed", href = "/atom.xml", newTab = true },
-]
+[[header]]
+id = "blog"
+title = "Blog"
+href = "/blog/"
 
-footer_subfooter = [
-    { title = "Copyright Notice", href = "/legal/copyright-notice" },
-]
+[[header.children]]
+title = "Archive"
+href = "/blog/archive/"
+
+[[header]]
+title = "Docs"
+href = "/docs/"
+
+[[header]]
+title = "Ecosystem"
+section = "ecosystem"
+
+[[header]]
+title = "Homeserver"
+section = "homeserver"
+
+[[header]]
+title = "Support us"
+href = "/support"
+
+[[header]]
+title = "Try Matrix"
+href = "/try-matrix/"
+primary = true
+
+[[footer_internal]]
+title = "Donate"
+href = "/support"
+
+[[footer_internal]]
+title = "Shop"
+href = "https://shop.matrix.org"
+
+[[footer_internal]]
+title = "Security Disclosure Policy"
+href = "/security-disclosure-policy"
+
+[[footer_internal]]
+title = "Security Hall of Fame"
+href = "/security-hall-of-fame"
+
+[[footer_internal]]
+title = "Code of Conduct"
+href = "/legal/code-of-conduct"
+
+[[footer_internal]]
+title = "Legal"
+href = "/legal"
+
+[[footer_internal]]
+title = "Law Enforcement Guidelines"
+href = "/legal/law-enforcement-guidelines"
+
+[[footer_internal]]
+title = "Contact"
+href = "/contact"
+
+[[footer_internal]]
+title = "Matrix.org Status"
+href = "https://status.matrix.org"
+
+[[footer_internal]]
+title = "Site Source"
+href = "https://github.com/matrix-org/matrix.org/"
+
+[[footer_external]]
+image = "github.svg"
+alt = "Matrix on GitHub"
+href = "https://github.com/matrix-org"
+newTab = true
+
+[[footer_external]]
+image = "gitlab.svg"
+alt = "Matrix on GitLab"
+href = "https://gitlab.matrix.org/"
+newTab = true
+
+[[footer_external]]
+image = "mastodon.svg"
+alt = "Matrix on Mastodon"
+href = "https://mastodon.matrix.org/@matrix"
+relMe = true
+newTab = true
+
+[[footer_external]]
+image = "x.svg"
+alt = "Matrix on X"
+href = "https://x.com/matrixdotorg"
+newTab = true
+
+[[footer_external]]
+image = "youtube.svg"
+alt = "Matrix on YouTube"
+href = "https://www.youtube.com/channel/UCVFkW-chclhuyYRbmmfwt6w"
+newTab = true
+
+[[footer_external]]
+image = "rss.svg"
+alt = "Matrix Atom Feed"
+href = "/atom.xml"
+newTab = true
+
+[[footer_subfooter]]
+title = "Copyright Notice"
+href = "/legal/copyright-notice"

--- a/templates/blog-archive.html
+++ b/templates/blog-archive.html
@@ -5,8 +5,13 @@
 <article class="content">
     <h1>Blog Archive</h1>
     <ul>
-        {% for page in pages %}
-        <li>{{ page.date | date }} — <a href="{{ page.path }}">{{ page.title }}</a></li>
+        {% for blog_page in pages %}
+            {% if blog_page.extra.hide_from_blog %}
+                {% continue %}
+            {% endif %}
+            <li>
+                {{ blog_page.date | date }} — <a href="{{ blog_page.path }}">{{ blog_page.title }}</a>
+            </li>
         {% endfor %}
     </ul>
 </article>

--- a/templates/blog-archive.html
+++ b/templates/blog-archive.html
@@ -1,0 +1,13 @@
+{% extends "page.html" %}
+{% block content %}
+{% set section = get_section(path="blog/_index.md") %}
+{% set pages = section.pages | sort(attribute="date") | reverse %}
+<article class="content">
+    <h1>Blog Archive</h1>
+    <ul>
+        {% for page in pages %}
+        <li>{{ page.date | date }} — <a href="{{ page.path }}">{{ page.title }}</a></li>
+        {% endfor %}
+    </ul>
+</article>
+{% endblock content %}

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -2,6 +2,9 @@
 {% block content -%}
 <div class="content">
     {% for page in paginator.pages %}
+    {% if page.extra.hide_from_blog %}
+        {% continue %}
+    {% endif %}
     <article class="post">
         <header>
             <h1><a href="{{ page.permalink }}" title="{{ page.title }}">{{ page.title }}</a></h1>

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -37,10 +37,35 @@
             </div>
         </div>
         {% else %}
-        <a href="{{ link.href }}" class="{% if link.primary %}primary{% endif %}
-            {{ util::current_class(if_path_starts_with=link.href) }}">
-            {{ link.title }}
-        </a>
+            {% if link.children %}
+                <div class="section-wrap">
+                    <input
+                        id="{{ link.id }}-submenu-checkbox"
+                        type="checkbox"
+                        class="submenu-checkbox"
+                        aria-hidden="true"
+                        {{ util::current_checked(if_path_starts_with=link.href) }}
+                    >
+                    <label for="{{ link.id }}-submenu-checkbox" class="submenu-title">
+                        <a href="{{ link.href }}">
+                            {{ link.title }}
+                        </a>
+                        <div class="arrow"></div>
+                    </label>
+                    <div class="section-submenu-wrap">
+                        <div class="section-submenu">
+                            {% for child in link.children %}
+                                <a href="{{ child.href }}">{{ child.title }}</a>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            {% else %}
+                <a href="{{ link.href }}" class="{% if link.primary %}primary{% endif %}
+                    {{ util::current_class(if_path_starts_with=link.href) }}">
+                    {{ link.title }}
+                </a>
+            {% endif %}
         {% endif %}
         {% endfor %}
     </nav>


### PR DESCRIPTION
Extends https://github.com/matrix-org/matrix.org/pull/2752 with

- Blog posts with date and title under `/blog/archive`
- Dropdown nav item for the archive page (part of https://github.com/matrix-org/matrix.org/issues/2931)

<img width="1918" height="1049" alt="image" src="https://github.com/user-attachments/assets/fdd330b2-1f0d-4456-8081-71fcc7e89e29" />
