### PR TITLE
Include Conference section in main navigation bar (resolves #2943)

### DIFF
--- a/navigation.toml
+++ b/navigation.toml
@@ -36,6 +36,10 @@ title = "Homeserver"
 section = "homeserver"
 
 [[header]]
+title = "Conference"
+href = "https://conference.matrix.org"
+
+[[header]]
 title = "Support us"
 href = "/support"
 


### PR DESCRIPTION
## Changes
fixes  #2943
- Added "Conference" navigation item in `navigation.toml`
- Positioned between "Homeserver" and "Support us" for logical flow
- Links directly to the conference website (no dedicated page needed)
<img width="1862" height="115" alt="image" src="https://github.com/user-attachments/assets/1ef06cf6-59a8-41d2-a2cd-38ca9d0950ff" />
<img width="386" height="814" alt="image" src="https://github.com/user-attachments/assets/b7d4f204-7734-4457-b10e-ac39df41c133" />
