### PR TITLE
fix: language and punctuation in conference banner

### DIFF
--- a/templates/macros/banner.html
+++ b/templates/macros/banner.html
@@ -31,8 +31,8 @@
         <a href="{{ config.extra.conference_website }}/watch/">Check the livestreams</a>!
     </p>
     {% elif config.extra.conference_state == "watch-recordings" %}
-    <p><a href="{{ config.extra.conference_website }}">The Matrix Conference</a> is over and the recordings are here!.
-        <a href="{{ config.extra.conference_website }}/watch/">Check out the recordings</a>!
+    <p><a href="{{ config.extra.conference_website }}">The Matrix Conference</a> is over and the recordings are here!
+        <a href="{{ config.extra.conference_website }}/watch/">Check them out</a>.
     </p>
     {% endif %}
     {% if config.extra.governing_board_elections %}


### PR DESCRIPTION
- fix language (repetition of the word "recordings")
- fix punctuation (two punctuation marks next to each other)