### PR TITLE
Add TWIM to blog sub nav

### DIFF
--- a/navigation.toml
+++ b/navigation.toml
@@ -16,6 +16,10 @@ title = "Archive"
 href = "/blog/archive/"
 
 [[header.children]]
+title = "TWIM"
+href = "/category/this-week-in-matrix/"
+
+[[header.children]]
 title = "Authors"
 href = "/author/"
 


### PR DESCRIPTION
I want to access the TWIM posts quickly. Adds a TWIM link to the main nav.

<img width="837" height="334" alt="image" src="https://github.com/user-attachments/assets/26f85959-c420-4400-a3ab-ccda86c7b811" />


<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md

     You can use the CI build or a local environment to check your changes are working as expected.
     
     If you have questions at any time, please contact the Website Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

<!-- Please don't remove this checklist from your PR, as it is useful for reviewers, too. -->
**:heavy_check_mark: Checklist**

- Check for common mistakes:
  - [x] Wrap plain URLs in `<>` to linkify them ([learn more](https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md#publishing-to-the-blog)).
  - [x] Use the right level of headings: The page title will use a level 1 headings, so your headings should use level 2 and below.
  - [x] Use internal links: when linking to another page on <https://matrix.org>, use the Zola `[label](@/target.md)` [syntax](https://www.getzola.org/documentation/content/linking/#internal-links).
- For blog posts:
  - [x] Verify the date and post ordering on the `/blog` page, especially for multiple posts on the same day. Prefer UTC format, e.g. `2025-12-01T14:00:00Z` for Dec 1st, 2025, 2pm UTC.
  - [x] Set the correct author and category. Browse existing ones at <https://matrix.org/author/> and <https://matrix.org/category/> to match them.
- [x] Let us know if you are contributing in a specific role, such as on behalf of an organisation or team, [for example](https://github.com/matrix-org/matrix.org/pull/2788).
- [x] Let us know if your PR is time-sensitive in any way.
- [x] Mention any issues related to the PR. Use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) as appropriate.
- [x] Your individual commits or pull request is [signed off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md).
