### PR TITLE
Add palpo homeserver to  ecosystem

### DIFF
--- a/content/ecosystem/servers/servers.toml
+++ b/content/ecosystem/servers/servers.toml
@@ -150,6 +150,15 @@ repository = "https://git.telodendria.io/Telodendria/Telodendria"
 room = "#general:synapse.telodendria.io"
 
 [[servers]]
+name = "Palpo"
+description = "Palpo is a Matrix homeserver written in Rust"
+author = "Palpo Team"
+maturity = "Alpha"
+language = "Rust"
+licence = "Apache-2.0"
+repository = "https://github.com/palpo-im/palpo"
+
+[[servers]]
 name = "conduwuit"
 description = "conduwuit is a well-maintained, hard-fork of Conduit with tons of new features, many bug fixes, huge performance improvements, quality of life enhancements, moderation tools, and much more!"
 author = "strawberry"


### PR DESCRIPTION
### Description
Add palpo homeserver

Signed-off-by: Chrislearn Young [chris@acroidea.com](mailto:chris@acroidea.com)

### :heavy_check_mark: Checklist
<!-- Please tick as appropriate, but don't remove this checklist from your PR, as it is useful for reviewers, too. -->

- [x] Keep this checklist
- Check for common mistakes:
  - [ ] Wrap plain URLs in `<>` to linkify them ([learn more](https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md#publishing-to-the-blog)).
  - [ ] Use the right level of headings: The page title will use a level 1 headings, so your headings should use level 2 and below.
  - [ ] Use internal links: when linking to another page on <https://matrix.org>, use the Zola `[label](@/target.md)` [syntax](https://www.getzola.org/documentation/content/linking/#internal-links).
- For blog posts:
  - [ ] Verify the date and post ordering on the `/blog` page, especially for multiple posts on the same day. Prefer UTC format, e.g. `2025-12-01T14:00:00Z` for Dec 1st, 2025, 2pm UTC.
  - [ ] Set the correct author and category. Browse existing ones at <https://matrix.org/author/> and <https://matrix.org/category/> to match them.
- [ ] If you hold a specific role in relation to the content you are contributing, such as project maintainer or on behalf of a team or organisation, please let us know. See [example](https://github.com/matrix-org/matrix.org/pull/2969).
- [ ] If your PR is time-sensitive in any way, please mention the attached timeline and context in the PR description.
- [ ] Mention any issues related to the PR. Use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) as appropriate.
- [ ] Your individual commits or pull request is [signed off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md).

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
