### PR TITLE
Fix a typo in docs/matrix-concepts/rooms_and_events

### DIFF
--- a/content/docs/matrix-concepts/rooms_and_events/_index.md
+++ b/content/docs/matrix-concepts/rooms_and_events/_index.md
@@ -146,7 +146,7 @@ else.
 }}
 
 If Walter fiddled with its homeserver database to alter its local copy of the
-room, his change would not propagate: nobody has granted him power level 0: when
+room, his change would not propagate: nobody has granted him power level 100: when
 the other homeservers would want to update their local copy of the room, they
 would reject the change making Walter administrator of the room.
 


### PR DESCRIPTION
Walter (an example user) gets power level of 0 by joining the room. The point is he hasn't been promoted to an admin (power level 100), so if he does it himself, the missing explicit grant will tell other homeservers to reject the event.

<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md

     You can use the CI build or a local environment to check your changes are working as expected.
     
     If you have questions at any time, please contact the Website Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

<!-- Please don't remove this checklist from your PR, as it is useful for reviewers, too. -->
**:heavy_check_mark: Checklist**

- Check for common mistakes:
  - [x] Wrap plain URLs in `<>` to linkify them ([learn more](https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md#publishing-to-the-blog)).
  - [x] Use the right level of headings: The page title will use a level 1 headings, so your headings should use level 2 and below.
  - [x] Use internal links: when linking to another page on <https://matrix.org>, use the Zola `[label](@/target.md)` [syntax](https://www.getzola.org/documentation/content/linking/#internal-links).
- For blog posts:
  - [ ] Verify the date and post ordering on the `/blog` page, especially for multiple posts on the same day. Prefer UTC format, e.g. `2025-12-01T14:00:00Z` for Dec 1st, 2025, 2pm UTC.
  - [ ] Set the correct author and category. Browse existing ones at <https://matrix.org/author/> and <https://matrix.org/category/> to match them.
- [x] Let us know if you are contributing in a specific role, such as on behalf of an organisation or team, [for example](https://github.com/matrix-org/matrix.org/pull/2788).
  - No, I'm not
- [x] Let us know if your PR is time-sensitive in any way.
  - No, it isn't
- [x] Mention any issues related to the PR. Use [GitHub keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) as appropriate.
- [x] Your individual commits or pull request is [signed off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md).
