### PR TITLE
Change maturity status of LINE bridge to Obsolete

### DIFF
--- a/content/ecosystem/bridges/line/bridges.toml
+++ b/content/ecosystem/bridges/line/bridges.toml
@@ -7,7 +7,7 @@ A Matrix-LINE puppeting bridge based on running LINE's Chrome extension in
 
 Fork of [mautrix-amp](https://mau.dev/tulir/mautrix-amp/).
 """
-maturity = "Beta"
+maturity = "Obsolete"
 language = "Python, Node"
 license = "AGPL-3.0-or-later"
 repo = "https://src.miscworks.net/fair/matrix-puppeteer-line.git"


### PR DESCRIPTION
### Description

The LINE bridge does not work currently. Last commit was more than 3 years ago.

### Role

Private individual.

### Timeline

Not critical.

### Signoff

Signed-off-by: Jakob Yanagibashi <jakob.yanagibashi@rwth-aachen.de>



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
