### PR TITLE
Update: Change unit for hero heading max-width

### DIFF
--- a/sass/_index.scss
+++ b/sass/_index.scss
@@ -28,7 +28,7 @@
                 color: #fff;
                 font-size: 2.5rem;
                 font-weight: 700;
-                max-width: 40rem;
+                max-width: 16em;
                 margin: 0 auto;
                 padding: 0 30px;
                 text-align: center;


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Currently, we use `rem` as the unit for the `max-width` of the hero heading. However, that isn't the best unit to use. Instead, we should use `em` so the `max-width` is set relative to the `font-size` of the heading itself, not the root `font-size`.

To maintain the current computed `max-width` of `640px`, let's use `max-width: 16em`, which also equals `640px` when computed.


### Related issues

<!-- If you know that your PR closes issues, please list them here -->

No related issues, as this is a fairly minor change. However, this PR does address [this](https://github.com/matrix-org/matrix.org/pull/3074#pullrequestreview-3582914712) comment.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Individual not affiliated with any project relevant to this PR.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

There’s no immediate deadline, so feel free to review this PR whenever you can.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
