### PR TITLE
Fix: Multiple labels in the navigation bar

### DIFF
--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -220,6 +220,10 @@
     }
 }
 
+.page-overlay {
+    display: none;
+}
+
 #site-header-dropdown-checkbox {
     display: none;
 

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -2,9 +2,9 @@
     <a href="/" class="brand">
         <img src="/images/matrix-logo-white.svg" alt="Matrix logo">
     </a>
-    <input id="site-header-dropdown-checkbox" type="checkbox" class="dropdown-checkbox" aria-hidden="true">
-    <label for="site-header-dropdown-checkbox" class="dropdown-button">&#xe602;</label>
-    <label for="site-header-dropdown-checkbox" class="page-overlay"></label>
+    <input id="site-header-dropdown-checkbox" type="checkbox" class="dropdown-checkbox" aria-hidden="true" aria-labelledby="dropdown-button">
+    <label for="site-header-dropdown-checkbox" class="dropdown-button" id="dropdown-button">&#xe602;</label>
+    <label for="site-header-dropdown-checkbox" class="page-overlay" aria-hidden="true"></label>
     <nav>
         {% for link in navigation.header %}
         {% if link.section %}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -3,7 +3,7 @@
         <img src="/images/matrix-logo-white.svg" alt="Matrix logo">
     </a>
     <input id="site-header-dropdown-checkbox" type="checkbox" class="dropdown-checkbox" aria-hidden="true" aria-labelledby="dropdown-button">
-    <label for="site-header-dropdown-checkbox" class="dropdown-button" id="dropdown-button">&#xe602;</label>
+    <label for="site-header-dropdown-checkbox" class="dropdown-button" id="dropdown-button" aria-label="Toggle Site Header Dropdown">&#xe602;</label>
     <label for="site-header-dropdown-checkbox" class="page-overlay" aria-hidden="true"></label>
     <nav>
         {% for link in navigation.header %}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -2,8 +2,8 @@
     <a href="/" class="brand">
         <img src="/images/matrix-logo-white.svg" alt="Matrix logo">
     </a>
-    <input id="site-header-dropdown-checkbox" type="checkbox" class="dropdown-checkbox" aria-hidden="true" aria-labelledby="dropdown-button">
-    <label for="site-header-dropdown-checkbox" class="dropdown-button" id="dropdown-button" aria-label="Toggle Site Header Dropdown">&#xe602;</label>
+    <input id="site-header-dropdown-checkbox" type="checkbox" class="dropdown-checkbox" aria-hidden="true">
+    <label for="site-header-dropdown-checkbox" class="dropdown-button" id="dropdown-button" aria-label="Toggle header drop-down">&#xe602;</label>
     <label for="site-header-dropdown-checkbox" class="page-overlay" aria-hidden="true"></label>
     <nav>
         {% for link in navigation.header %}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -4,7 +4,7 @@
     </a>
     <input id="site-header-dropdown-checkbox" type="checkbox" class="dropdown-checkbox" aria-hidden="true">
     <label for="site-header-dropdown-checkbox" class="dropdown-button" id="dropdown-button" aria-label="Toggle header drop-down">&#xe602;</label>
-    <label for="site-header-dropdown-checkbox" class="page-overlay" aria-hidden="true"></label>
+    <label for="site-header-dropdown-checkbox" class="page-overlay" aria-label="Close header drop-down"></label>
     <nav>
         {% for link in navigation.header %}
         {% if link.section %}


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Add `aria-label` attributes to both `label` elements in the header to ensure neither is seen as empty by assistive technologies. Style the `.page-overlay` `label` so it is not displayed (e.g., `display: none`) on desktop viewports to avoid accessibility issues.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

Closes #3090.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Member of The Matrix.org Foundation Website & Content Working Group.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

There’s no immediate deadline, so feel free to review this PR whenever you can.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
