### PR TITLE
Add matrix_icon shortcode for inline emoji-sized Matrix icon

### DIFF
--- a/templates/shortcodes/matrix_icon.html
+++ b/templates/shortcodes/matrix_icon.html
@@ -1,0 +1,3 @@
+<span style="display:inline-block; width:1em; height:1em; vertical-align:-0.15em;">
+    {{ load_data(path="static/assets/favicon.svg") | safe }}
+</span>


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

 Adds a reusable Zola shortcode named `matrix_icon` that renders the existing
favicon SVG inline at emoji-size (1em), so it aligns consistently with text
and other emoji-sized icons.

This makes it easier to include the Matrix icon inline in content without
having to insert or manually resize image assets.

The shortcode loads the favicon SVG and wraps it in a small styled span to
ensure consistent size and vertical alignment.

Usage:    {{ matrix_icon() }}

Note: While working on this, I confirmed that the site is built with Zola
rather than Hugo, so the helper is implemented as a Zola shortcode.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->
 Fixes #3106

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->
Individual contributor


### Timeline

<!-- By when do you need us to review your PR at the latest? -->
 No specific deadline — review at your convenience

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.
 All commits in this PR are signed off.




<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
