### PR TITLE
Fix: Use span instead of div for header drop-down arrows

### DIFF
--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -14,9 +14,9 @@
             <input id="{{ link.section }}-submenu-checkbox" type="checkbox" class="submenu-checkbox" aria-hidden="true"
                 {{ util::current_checked(if_path_starts_with="/" ~ link.section) }}>
             <label for="{{ link.section }}-submenu-checkbox" class="submenu-title">
-            <a href="/{{ link.section }}">
-                {{ link.title }}</a> <div class="arrow">
-                </div></label>
+                <a href="/{{ link.section }}">{{ link.title }}</a>
+                <span class="arrow"></span>
+            </label>
 
             <div class="section-submenu-wrap">
                 <div class="section-submenu">
@@ -50,7 +50,7 @@
                         <a href="{{ link.href }}">
                             {{ link.title }}
                         </a>
-                        <div class="arrow"></div>
+                        <span class="arrow"></span>
                     </label>
                     <div class="section-submenu-wrap">
                         <div class="section-submenu">


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Refactors the header's drop-down to use `span` instead of `div` for its arrows since the latter isn't valid as a child element of a `label`. See: https://validator.w3.org/nu/?doc=https%3A%2F%2Fmatrix.org

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

No related issues, as this is a fairly minor change.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Individual not affiliated with any project relevant to this PR.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

There’s no immediate deadline, so feel free to review this PR whenever you can.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
