### PR TITLE
Fix: Remove duplicate meta description elements

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,5 @@
 {% extends "skel.html" %}
 {% block head_extra %}
-<meta name="description"
-    content="The homepage of the matrix.org website. Chat securely with your family, friends, community, or build great apps with Matrix!">
 <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
 {% endblock head_extra %}
 {% block content %}


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Currently, in `index.html`, we include two meta description elements, which is not valid. Let's remove the duplicate element. See: https://validator.w3.org/nu/?doc=https%3A%2F%2Fmatrix.org

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

No related issues, as this is a fairly minor change.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Individual not affiliated with any project relevant to this PR.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

There’s no immediate deadline, so feel free to review this PR whenever you can.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
