### PR TITLE
enable linting MD031 blank lines around code fences

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -6,7 +6,7 @@
 # disable = ["MD013", "MD033"]
 
 # List of rules to enable exclusively (if provided, only these rules will run)
-enable = ["MD001", "MD003", "MD011", "MD030", "MD034", "MD039"]
+enable = ["MD001", "MD003", "MD011", "MD030", "MD031", "MD034", "MD039"]
 
 # List of file/directory patterns to include for linting (if provided, only these will be linted)
 # include = [

--- a/CONTENT.md
+++ b/CONTENT.md
@@ -99,11 +99,13 @@ In your markdown file, add this line to embed the YouTube player in a way that r
 ```jinja
 {{ youtube_player(video_id="S1nBXjWWHoU") }}
 ```
+
 You can also provide a start time using `start` and noscript-text using `noscript_text`, e.g. 
 
 ```jinja 
 {{ youtube_player(video_id="Xje32fIIUyg",start="1240",noscript_text="Matrix Live S11E05 - Project Hydra") }}
 ```
+
 which will start the video at 20:40 and add custom text for users with JavaScript disabled.
 
 ### Adding a picture for the socials

--- a/content/blog/2020/03/2020-03-23-synapse-1-12-0-released.md
+++ b/content/blog/2020/03/2020-03-23-synapse-1-12-0-released.md
@@ -60,9 +60,11 @@ installation remains secure.
 * Administrators who have [installed Synapse from
   source](https://github.com/matrix-org/synapse/blob/master/INSTALL.md#installing-from-source)
   should upgrade Twisted within their virtualenv by running:
+
   ```sh
   <path_to_virtualenv>/bin/pip install 'Twisted>=20.3.0'
   ```
+
 * Administrators who have installed Synapse from distribution packages should
   consult the information from their distributions.
 

--- a/content/blog/2020/04/2020-04-06-running-your-own-secure-communication-service-with-matrix-and-jitsi.md
+++ b/content/blog/2020/04/2020-04-06-running-your-own-secure-communication-service-with-matrix-and-jitsi.md
@@ -95,6 +95,7 @@ echo '{ "m.server": "matrix.dangerousdemos.net:443" }' > server
 ```
 
  * **Alternatively**, you could advertise the server via DNS, if you don't have write access to `/.well-known` on your main domain.  However, to prove you are allowed to host the Matrix traffic for dangerousdemos.net, you would have to configure nginx to use the dangerousdemos.net TLS certificate for the matrix.dangerousdemos.net vhost (i.e. the "wrong" one), and in general we think that `/.well-known` is much easier to reason about.  In this case you would advertise the server with an SRV record like this:
+
 ```
 _matrix._tcp.dangerousdemos.net. 300    IN  SRV 10 5 443 matrix.dangerousdemos.net.
 ```

--- a/content/blog/2021/06/2021-06-10-low-bandwidth-matrix-an-implementation-guide.md
+++ b/content/blog/2021/06/2021-06-10-low-bandwidth-matrix-an-implementation-guide.md
@@ -42,19 +42,24 @@ Steps:
 - Build the low bandwidth proxy: `go build ./cmd/proxy`
 - Generate a elliptic curve DTLS key/certificate: (we use curve keys as they are smaller than RSA
   keys, but both work.)
+
   ```bash
   openssl ecparam -name prime256v1 -genkey -noout -out private-key.pem
   openssl req -new -x509 -key private-key.pem -out cert.pem -days 365
   # you now have cert.pem and private-key.pem
   ```
+
 - Run it pointing at matrix.org:
+
   ```bash
   ./proxy -local 'https://matrix-client.matrix.org' \
   --tls-cert cert.pem --tls-key private-key.pem \
   --advertise "http://127.0.0.1:8008" \
   --dtls-bind-addr :8008
   ```
+
 - You should see something like this:
+
   ```
   INFO[0000] Listening on :8008/tcp to reverse proxy from http://127.0.0.1:8008 to https://matrix-client.matrix.org - HTTPS enabled: false 
   INFO[0000] Listening for DTLS on :8008 - ACK piggyback period: 5s
@@ -65,6 +70,7 @@ not LibreSSL which comes by default: `openssl version`. To use OpenSSL, `brew in
 then dumps the binary to `/usr/local/opt/openssl/bin/openssl`.
 
 To test it is working correctly:
+
 ```bash
 # build command line tools we can use to act as a low bandwidth client
 go build ./cmd/jc
@@ -111,18 +117,22 @@ Steps:
  - Clone the low bandwidth repo if you haven't already:
    `git clone https://github.com/matrix-org/lb.git`
  - In the low bandwidth repo, build the mobile bindings:
+
    ```
    go get golang.org/x/mobile/cmd/gomobile
    cd mobile
    # if gomobile isn't on your path, then ~/go/bin/gomobile
    gomobile bind -target=android
    ```
+
  - Copy the output files to a directory in the Element Android repo which Gradle will pick up:
+
    ```
    mkdir $PATH_TO_ELEMENT_ANDROID_REPO/matrix-sdk-android/libs
    cp mobile-sources.jar $PATH_TO_ELEMENT_ANDROID_REPO/matrix-sdk-android/libs
    cp mobile.aar $PATH_TO_ELEMENT_ANDROID_REPO/matrix-sdk-android/libs
    ```
+
  - Open the project in Android Studio.
  - Build and run on a device/emulator.
  - Configure the proxy's `--advertise` address. If you are running on a local device, restart the
@@ -171,4 +181,3 @@ and receive the response, including connection setup:
   network with so much data that the sync stream begins to fall behind. Future work will look
   to optimise the sync API.
 - The proxy currently doesn't implement the [low bandwidth response](https://github.com/matrix-org/matrix-doc/blob/kegan/low-bandwidth/proposals/3079-low-bandwidth-csapi.md#versioning) in `/versions`.
-

--- a/content/blog/2021/12/2021-12-03-type-coverage-for-sydent-motivation.md
+++ b/content/blog/2021/12/2021-12-03-type-coverage-for-sydent-motivation.md
@@ -111,6 +111,8 @@ In this sample, `resp.headers` is a [twisted.web.http_headers.Headers](https://t
         headers = dict(resp.headers.getAllRawHeaders())
         reveal_type(headers)
 ```
+
+
 ```
 $ mypy
 sydent/sms/openmarket.py:110: note: Revealed type is "builtins.dict[builtins.bytes*, typing.Sequence*[builtins.bytes]]"

--- a/content/blog/2021/12/2021-12-10-type-coverage-for-sydent-annotation.md
+++ b/content/blog/2021/12/2021-12-10-type-coverage-for-sydent-annotation.md
@@ -93,6 +93,7 @@ and later, [the IResponse](https://github.com/matrix-org/sydent/blob/e4b4dbbdf25
         res: IResponse
         res = yield agent.request(method, uri, headers, bodyProducer)
 ```
+
 - In this example:
 
 - We yield a value `y: Deferred[Any]`.

--- a/content/blog/2021/12/2021-12-17-type-coverage-for-sydent-evaluation.md
+++ b/content/blog/2021/12/2021-12-17-type-coverage-for-sydent-evaluation.md
@@ -198,6 +198,7 @@ After the sprint to improve coverage, I spent a short amount of time trying the 
 - Didn't seem to recognise `getLogger` as being imported from `logging`. Not sure what happened there—maybe something wrong with its bundled version of `typeshed`?
 - In a few places, Sydent uses `urllib.parse.quote` but only imports `urllib`. We must be unintentionally relying on our dependencies to `import urllib.parse` somewhere! Mypy didn't complain about this; pyright did.
 - Seemed to give a better explanations of why complex types were incompatible. For example:
+
   ```
   /home/dmr/workspace/sydent/sydent/replication/pusher.py
      /home/dmr/workspace/sydent/sydent/replication/pusher.py:77:16 - error: Expression of type "DeferredList" cannot be assigned to return type "Deferred[List[Tuple[bool, None]]]"
@@ -212,8 +213,10 @@ After the sprint to improve coverage, I spent a short amount of time trying the 
            Type "_KT@dict" is incompatible with constrained type variable "AnyStr"
          Type cannot be assigned to type "None" (reportGeneralTypeIssues)
   ```
+
   This would have been really helpful when interpreting mypy's error reports; I'd love to see something like it in mypy.
   Here's another example where I tried running against a Synapse file.
+
   ```
   /home/dmr/workspace/synapse/synapse/storage/databases/main/cache.py
   /home/dmr/workspace/synapse/synapse/storage/databases/main/cache.py:103:53 - error: Expression of type "list[tuple[Unknown, Tuple[Unknown, ...]]]" cannot be assigned to declared type "List[Tuple[int, _CacheData]]"
@@ -221,6 +224,7 @@ After the sprint to improve coverage, I spent a short amount of time trying the 
       Tuple entry 2 is incorrect type
         Tuple size mismatch; expected 3 but received indeterminate number (reportGeneralTypeIssues)
   ```
+
   This is really valuable information. It's worth considering Pyright as an option to get a second opinion!
 - It looks like Pyright's name for `Any` is `Unknown`. I think that does a better job of emphasising that `Unknown` won't be type checked. I'd certainly be more reluctant to type `x: Unknown` versus `x: Any`!
 - Pyright is the machinery behind [Pylance](https://github.com/microsoft/pylance-release), which drives [VS Code's Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance). That alone probably makes it worthy of more eyes.

--- a/content/docs/spec-guides/state-res-2.1/_index.md
+++ b/content/docs/spec-guides/state-res-2.1/_index.md
@@ -20,6 +20,7 @@ implemented.
 
 This is a trivial change to make. When performing the initial iterative auth checks, replace the
 unconflicted set with the empty set:
+
 ```py
     resolved_state = await _iterative_auth_checks(
         clock,


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Enabled MD031 linting rule in rumdl to enforce empty lines around code blocks.

Changes done with with `rumdl fmt` and reviewed by me.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

#3058

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
