### PR TITLE
enable linting MD037 no space inside emphasis markers

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -6,7 +6,7 @@
 # disable = ["MD013", "MD033"]
 
 # List of rules to enable exclusively (if provided, only these rules will run)
-enable = ["MD001", "MD003", "MD011", "MD030", "MD031", "MD034", "MD039"]
+enable = ["MD001", "MD003", "MD011", "MD030", "MD031", "MD034", "MD037", "MD039"]
 
 # List of file/directory patterns to include for linting (if provided, only these will be linted)
 # include = [

--- a/content/blog/2019/11/2019-11-15-this-week-in-matrix-2019-11-15.md
+++ b/content/blog/2019/11/2019-11-15-this-week-in-matrix-2019-11-15.md
@@ -34,16 +34,16 @@ Feedback: <https://ditto.upvoty.com>
 
 [anoa](https://matrix.to/#/@andrewm:amorgan.xyz) said:
 
-> ** New MSCs **
+> **New MSCs**
 >
 > * [MSC2354: Device to device streaming file transfers](https://github.com/matrix-org/matrix-doc/pull/2354)
 > * [MSC2356: Bulk /joined_members endpoint](https://github.com/matrix-org/matrix-doc/pull/2356)
 >
-> ** In Final Comment Period **
+> **In Final Comment Period**
 >
 > * [MSC2284: Making the identity server optional during discovery](https://github.com/matrix-org/matrix-doc/pull/2284)
 >
-> ** Merged MSCs **
+> **Merged MSCs**
 >
 > * [MSC1946: Secure Secret Storage and Sharing](https://github.com/matrix-org/matrix-doc/pull/1946)
 > * [MSC2244: Mass redactions](https://github.com/matrix-org/matrix-doc/pull/2244)

--- a/content/blog/2021/06/2021-06-30-security-update-synapse-1-37-1-released.md
+++ b/content/blog/2021/06/2021-06-30-security-update-synapse-1-37-1-released.md
@@ -31,7 +31,7 @@ Meanwhile, over to Dan for the Synapse 1.37 release notes.
 
 Synapse 1.37 is now available!
 
-> **Note: ** The legacy APIs for Spam Checker extension modules are now considered deprecated and targeted for removal in August. Please see [the module docs](https://matrix-org.github.io/synapse/v1.37/modules.html#porting-an-existing-module-that-uses-the-old-interface) for information on updating.
+> **Note:** The legacy APIs for Spam Checker extension modules are now considered deprecated and targeted for removal in August. Please see [the module docs](https://matrix-org.github.io/synapse/v1.37/modules.html#porting-an-existing-module-that-uses-the-old-interface) for information on updating.
 >
 > This release also removes Synapse's built-in support for the obsolete ACMEv1 protocol for automatically obtaining TLS certificates. Server administrators should place Synapse behind a [reverse proxy](https://matrix-org.github.io/synapse/v1.37/reverse_proxy.html) for TLS termination, or switch to a standalone ACMEv2 client like [certbot](https://certbot.eff.org/).
 

--- a/content/blog/2023/02/2023-02-14-matrix-v1-6-release.md
+++ b/content/blog/2023/02/2023-02-14-matrix-v1-6-release.md
@@ -22,7 +22,7 @@ We’ve covered a couple of the MSCs below, but read on to the full changelog fo
 
 ## MSC3030: Jump to date API
 
-_It’s here! The time machine we’ve been waiting for! _
+_It’s here! The time machine we’ve been waiting for!_
 
 Primarily part of the [Gitter feature parity project](https://github.com/vector-im/roadmap/issues/26) (congratulations to the team [going all-in on Matrix](https://blog.gitter.im/2023/02/13/gitter-has-fully-migrated-to-matrix/), by the way) to drive the [Matrix Public Archive](https://github.com/matrix-org/matrix-public-archive), the [new API](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event) gives clients the ability to jump back in time to a nearby event. Being able to find something that was posted on a given day/week, but not being sure of which keywords to look for is a major usability improvement - many thanks to the Gitter team for making Matrix better!
 


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Enabled MD037 linting rule in rumdl to enforce there are not spaces within emphasis markers.

Changes done with with `rumdl fmt` and reviewed by me.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

#3058

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
