### PR TITLE
enable linting MD038 remove extra spaces in code

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -13,6 +13,7 @@ enable = [
   "MD030",  # Add consistent spacing after list markers
   "MD031",  # Code blocks need blank lines around them
   "MD034",  # URLs should be formatted as links
+  "MD038",  # Remove extra spaces in code
   "MD039",  # Remove extra spaces in links
   "MD042",  # Avoid Empty Links
   "MD056",  # Keep table column count consistent

--- a/content/blog/2019/07/2019-07-05-this-week-in-matrix-2019-07-05.md
+++ b/content/blog/2019/07/2019-07-05-this-week-in-matrix-2019-07-05.md
@@ -175,7 +175,7 @@ But that could be any room, so it seems ok to me.
 >
 > Changes:
 >
-> * Fix the infamous `FormatException: Not a valid url: ` error!
+> * Fix the infamous `FormatException: Not a valid url:` error!
 > * Room upgrades are now handled!
 >   * Upgraded rooms are now hidden from the overview
 >   * To access older messages from the previous room, simply scroll up: the timeline is seamless

--- a/content/blog/2019/10/2019-10-03-synapse-1-4-0-released.md
+++ b/content/blog/2019/10/2019-10-03-synapse-1-4-0-released.md
@@ -223,7 +223,7 @@ Note that this release includes significant changes around 3pid verification. Ad
 - Cleanup event auth type initialisation. ([\#5975](https://github.com/matrix-org/synapse/issues/5975))
 - Clean up dependency checking at setup. ([\#5989](https://github.com/matrix-org/synapse/issues/5989))
 - Update OpenTracing docs to use the unified `trace` method. ([\#5776](https://github.com/matrix-org/synapse/issues/5776))
-- Small refactor of function arguments and docstrings in` RoomMemberHandler`. ([\#6009](https://github.com/matrix-org/synapse/issues/6009))
+- Small refactor of function arguments and docstrings in `RoomMemberHandler`. ([\#6009](https://github.com/matrix-org/synapse/issues/6009))
 - Remove unused `origin` argument on `FederationHandler.add_display_name_to_third_party_invite`. ([\#6010](https://github.com/matrix-org/synapse/issues/6010))
 - Add a `failure_ts` column to the `destinations` database table. ([\#6016](https://github.com/matrix-org/synapse/issues/6016), [\#6072](https://github.com/matrix-org/synapse/issues/6072))
 - Clean up some code in the retry logic. ([\#6017](https://github.com/matrix-org/synapse/issues/6017))

--- a/content/blog/2021/12/2021-12-10-type-coverage-for-sydent-annotation.md
+++ b/content/blog/2021/12/2021-12-10-type-coverage-for-sydent-annotation.md
@@ -240,7 +240,7 @@ It's worth a read through the [module documentation](https://docs.python.org/3/l
 
 - [Protocol](https://docs.python.org/3/library/typing.html?highlight=typing%20protocol#typing.Protocol): lets you formalise duck typing. To use it, define a class that inherits from `Protocol`. Its methods and attributes are all stubs which describe what you require of objects belonging to this type. It's like an [abstract base class](https://docs.python.org/3/library/abc.html?highlight=abc#module-abc) or interface, but purely at typecheck time.
 - [Generic](https://docs.python.org/3/library/typing.html?highlight=typing%20generic#typing.Generic): define your own generic types. A bit of a slippery slope to type mania!
-- [Optional`](https://docs.python.org/3/library/typing.html?highlight=typing%20generic#typing.Optional): I use this all the time. It's always good to make your `None`s explicit!
+- [Optional](https://docs.python.org/3/library/typing.html?highlight=typing%20generic#typing.Optional): I use this all the time. It's always good to make your `None`s explicit!
 - [NewType](https://docs.python.org/3/library/typing.html?highlight=typing%20generic#typing.NewType): I haven't had a chance to use it much. As I understand it, it's a way to define a "strong typedef". For example, we can use it to distinguish lengths from durations, even if they're both represented by a `float` at runtime.
 
 I want to call out two parts of `typing` in particular:

--- a/content/blog/2023/07/2023-07-28-twim.md
+++ b/content/blog/2023/07/2023-07-28-twim.md
@@ -200,7 +200,7 @@ Next-gen crypto-included SDK for developing Clients, Bots and Appservices; writt
 > **it is now a lot easier to run the bot**
 > 
 > * Create an admin account on your server for the bot
-> * run `docker run -it -e "BOT_USERNAME=@matrix-registration-bot:example.org" -e "BOT_PASSWORD=SECURE_PASSWORD" -e "BOT_SERVER=https://synapse.example.org"  moanos/matrix-registration-bot:1.3.0 `
+> * run `docker run -it -e "BOT_USERNAME=@matrix-registration-bot:example.org" -e "BOT_PASSWORD=SECURE_PASSWORD" -e "BOT_SERVER=https://synapse.example.org"  moanos/matrix-registration-bot:1.3.0`
 > * Message the bot `help` to find out about all it can do
 > 
 > For all the folks using [matrix-docker-ansible-deploy](https://github.com/spantaleev/matrix-docker-ansible-deploy/tree/master):

--- a/content/blog/2023/09/2023-09-29-twim.md
+++ b/content/blog/2023/09/2023-09-29-twim.md
@@ -168,7 +168,7 @@ Secure and independent communication, connected via Matrix. Come talk with us in
 > * Correction in function names to correctly display async vs non-async functions
 > * `AuthenticatedHomeserverGeneric.GetRoom(string id)` is no longer async, since that is only a constructor call.
 > * Sync code has gotten a slight cleanup
-> * ` AuthenticatedHomeserverGeneric.WhoAmI` was turned into a property that only gets fetched when attempting to get the info for the first time, rather than fetching it when constructing the homeserver object.
+> * `AuthenticatedHomeserverGeneric.WhoAmI` was turned into a property that only gets fetched when attempting to get the info for the first time, rather than fetching it when constructing the homeserver object.
 > * Added a null check for `creationEvent.Invite` when callign `CreateRoom`
 >   - This field was also made nullable
 > * Renamed `canonicalHomeServerDomain` to `baseUrl` in the constructors for homeservers

--- a/content/blog/2025/02/2025-02-03-twim.md
+++ b/content/blog/2025/02/2025-02-03-twim.md
@@ -160,7 +160,7 @@ A moderation bot for open Matrix communities
 > 
 > * Some moderators noticed that on upgrading from `v1.87.0` to `v2.0.*` some rooms would appear unprotected. It later turned out that the functionality for the config option `protectAllJoinedRooms` was missing from this release. We've now fixed this and also updated the `!draupnir rooms` command to show which rooms Draupnir is and isn't protecting. Your rooms should be automatically protected again on upgrading to `v2.1.0`.
 > 
-> * The config option ` commands.allowNoPrefix` has been fixed again. Some commands would interact badly with the setting in the `v2.0.*` releases, this has now been fixed.
+> * The config option `commands.allowNoPrefix` has been fixed again. Some commands would interact badly with the setting in the `v2.0.*` releases, this has now been fixed.
 > 
 > * Functionality has been added in conjunction with `protectAllJoinedRooms` to automatically unprotect rooms that it has been kicked from and notify the management room.
 > 

--- a/content/docs/older/understanding-synapse-hosting.md
+++ b/content/docs/older/understanding-synapse-hosting.md
@@ -260,7 +260,7 @@ at is the homeserver.yaml file, which contains all the basic information to
 allow our server to run. Docker volumes data is located in
 `/var/lib/docker/volumes/your_volume_name/_data`. We asked this container to
 generate the files in the `infra_synapse_data` volumes. Let’s have a look at
-`/var/lib/docker/volumes/infra_synapse_data/_data/homeserver.yaml `and see what
+`/var/lib/docker/volumes/infra_synapse_data/_data/homeserver.yaml` and see what
 it contains:
 
 ```yaml


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Enabled MD038 linting rule in rumdl to enforce no extra spaces in inline code.

Changes done with with `rumdl fmt`, tweaked and reviewed by me.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

#3058

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
