### PR TITLE
enable linting MD042, MD056, MD058

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -16,6 +16,7 @@ enable = [
   "MD039",  # Remove extra spaces in links
   "MD042",  # Avoid Empty Links
   "MD056",  # Keep table column count consistent
+  "MD058",  # Add blank lines around tables
 ]
 
 # List of file/directory patterns to include for linting (if provided, only these will be linted)

--- a/content/blog/2022/10/2022-10-21-this-week-in-matrix-2022-10-21.md
+++ b/content/blog/2022/10/2022-10-21-this-week-in-matrix-2022-10-21.md
@@ -299,6 +299,7 @@ Join [#ping-no-synapse:maunium.net](https://matrix.to/#/#ping-no-synapse:maunium
 |6|forlorn.day|1297|
 |7|frai.se|9140|
 |8|zemos.net|15335|
+
 ## That's all I know
 
 See you next week, and be sure to stop by [#twim:matrix.org](https://matrix.to/#/#twim:matrix.org) with your updates!


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Enabled MD042 linting rule in rumdl to enforce that links have both label and target, MD056 to enforce consistent amount of table columns, MD058 to enforce empty lines around tables.

Changes done with with `rumdl fmt` and reviewed by me.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

#3058

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
