### PR TITLE
Add Members link under Foundation in navbar

### DIFF
--- a/navigation.toml
+++ b/navigation.toml
@@ -3,8 +3,26 @@ title = "Spec"
 href = "https://spec.matrix.org"
 
 [[header]]
+id = "foundation"
 title = "Foundation"
-section = "foundation"
+href = "/foundation/"
+
+[[header.children]]
+title = "About Matrix"
+href = "/aboutmatrix/"
+
+[[header.children]]
+title = "Members"
+href = "/membership/"
+
+[[header.children]]
+title = "Governing Board"
+href = "/governingboard/"
+
+[[header.children]]
+title = "Working Groups"
+href = "/workinggroups/"
+
 
 [[header]]
 id = "blog"


### PR DESCRIPTION
### Description
Add a "Members" link under the Foundation section in the main navigation bar.

### Related issues
closes #3013

### Role
Contributor

### Timeline
Not time-sensitive

### Signoff
I confirm that this contribution is my own work and I agree to the project's contribution guidelines.






<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
