### PR TITLE
Document decision on preferred image formats

### DIFF
--- a/CONTENT.md
+++ b/CONTENT.md
@@ -84,7 +84,8 @@ It is possible to add pictures to your posts in markdown. First you need to drop
 
 This shortcode ensures that images have a consistent look across posts.
 
-We prefer using avif or webp files when possible. However if this is not an option we also accept PNG files provided they are reasonable sized and the file size is appropriate for web usage.
+We prefer using AVIF, or failing that WebP, files when possible.
+However if this is not an option we also accept PNG files provided they are reasonable sized and the file size is appropriate for web usage.
 
 ### Embedding a YouTube player
 


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

- https://caniuse.com/avif
- https://caniuse.com/webp
- https://caniuse.com/png-alpha i guess
- meanwhile NOT supported: https://caniuse.com/heif

I have benchmarked using `magick mogrify` ImageMagick 7.1.2-13.

based on https://github.com/matrix-org/matrix.org/blob/main/static/blog/img/4d7a1357bc58a20717b2be02d29d2f47003707d0.png (the biggest PNG I could find):
- PNG 8.7Mi (down from the 9.4 in-repo)
- WebP 336Ki (3,77%)
- AVIF 147Ki (1,65%)

based on https://github.com/matrix-org/matrix.org/blob/main/static/blog/img/20250801-matrix-community-summit.png (the most recent one):
- PNG 1.7Mi
- WebP 189Ki (10,9%)
- AVIF 149Ki (8,6%)

Hence we recommend AVIF where possible.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
