### PR TITLE
Remove post-FOSDEM banner

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -66,4 +66,4 @@ skip_anchor_prefixes = [
 #
 # governing_board_elections: "We are holding our Governing Board elections. Find 
 # all the information [on the elections page](https:/matrix.org/foundation/governing-board-elections/<year>/)."
-banner = "Matrix was at [FOSDEM](/blog/2026/02/fosdem-wrap-up/)! Did you miss it? Don't worry, you can watch all the talks [here](https://fosdem.org/2026/schedule/track/decentralised-communication/)."
+banner = ""


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Removes post-FOSDEM banner.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

There are no issues related to this change, as it is a rather small modification. However, please see [this](https://github.com/matrix-org/matrix.org/pull/3190#issuecomment-3861162151) comment.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Individual not affiliated with any project relevant to this PR.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

On or after Friday, 13th February 2026 (roughly a week after opening this PR), the aim is to display the current post-FOSEM banner for one week before removing it.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
