### PR TITLE
Vodozemac issues blog: clarify that we have found the reporter's email

### DIFF
--- a/content/blog/2026/02/2026-02-18-analysis-of-reported-issues-in-vodozemac.md
+++ b/content/blog/2026/02/2026-02-18-analysis-of-reported-issues-in-vodozemac.md
@@ -99,6 +99,8 @@ In his timeline, the reporter notes:
 
 We did not receive the referenced additional response prior to publication of the reporter's blog post. Our response was sent at 22:19 UTC while the blog post was published no later than 23:47 UTC.
 
+**Updated 2026-02-21**: The referenced response, sent at 23:28 UTC, was discovered to have been caught by a spam filter. Thanks to Gnuxie for working with us and the reporter to resolve this.
+
 ## Closing words
 
 In summary, Matrix's threat model relies on authenticated key distribution: identity keys and pre-keys are signed by device keys and verified prior to session establishment. This prevents a network adversary from substituting non-contributory public keys to force a predictable shared secret between honest clients. The absence of an all-zero check does not compromise this.


### PR DESCRIPTION
### Description

Clarified the Vodozemac issues blog post about the missing email

### Related issues

n/a

### Role

I am a staff engineer at Element. This contribution is made as a member of the Matrix governing board.

### Timeline

Asap, but not to be merged before review from Matrix Security team

### Signoff

Signed-off-by: Richard van der Hoff <richard@matrix.org>
