### PR TITLE
Wrap footer socials in flex layout

### DIFF
--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -38,8 +38,9 @@
         justify-content: center;
         align-items: center;
         color: var(--footer-link-color);
-        gap: 2rem;
+        gap: 1rem 2rem;
         line-height: 1;
+        flex-wrap: wrap;
     }
 
     .subfooter-links {


### PR DESCRIPTION
### Description

The footer socials exceeded the page width. This caused horizontal scrolling on mobile. This is fixed by introducing flex-wrap for the social items.

### Role

Website WG

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits or whole pull request.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
