### PR TITLE
Strip the "(website)" text from TOC entries

### DIFF
--- a/templates/post.html
+++ b/templates/post.html
@@ -98,12 +98,12 @@
             <ul style="list-style: none; padding-left: 0px;">
                 {% for h1 in page.toc %}
                 <li>
-                    <a href="{{ h1.permalink | safe }}">{{ h1.title | split(pat=" (") | first }}</a>
+                    <a href="{{ h1.permalink | safe }}">{{ h1.title | split(pat=" (website)") | first }}</a>
                     {% if h1.children %}
                     <ul>
                         {% for h2 in h1.children %}
                         <li>
-                            <a href="{{ h2.permalink | safe }}">{{ h2.title | split(pat=" (") | first }}</a>
+                            <a href="{{ h2.permalink | safe }}">{{ h2.title | split(pat=" (website)") | first }}</a>
                         </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
### Description

This just annoyed me since the first day I added the TOC...

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

### Role

Website & Content WG

### Timeline

meow?

### Signoff

In the commits!



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
