### PR TITLE
Better inline code

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -1,3 +1,6 @@
+$color-code-background: #272822;
+$color-code-color: #f8f8f2;
+
 :root {
     --page-max-width: 57rem;
     --page-with-toc-max-width: 81rem;
@@ -117,9 +120,10 @@ ol:last-child {
 }
 
 pre {
+    background-color: $color-code-background;
     padding: 1rem;
     overflow: auto;
-    border-radius: 4px;
+    border-radius: 0.3rem;
 }
 
 // The line numbers already provide some kind of left/right padding
@@ -206,15 +210,31 @@ pre table {
     }
 }
 
-:not(pre)>code {
-    color: #f54029;
-    border: 1px solid #f54029;
-    border-radius: 4px;
-    padding: 0 .4rem;
+code {
+    background-color: $color-code-background;
+    color: $color-code-color;
+    border-radius: 0.3rem;
+    padding: 1px 5px 2px;
+    font-size: 0.8em;
+    white-space: nowrap;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    code {
+        font-size: 0.75em;
+        padding-top: 0;
+    }
+}
+
+pre code {
+    white-space: inherit;
+    font-size: inherit;
+    padding: 0;
+    background-color: transparent;
+    border-radius: 0;
 }
 
 a>code {
-    border-color: var(--color-link);
     color: var(--color-link);
 }
 


### PR DESCRIPTION
### Description

I am not sure if this is actually better or not. Happy to hear feedback on this though.

Personally the red always felt a bit out of place. This is now a bit closer to the big blocks but not sure if thats a good thing.

I also tried to size match the text around it a bit better than before.

<img width="1008" height="306" alt="grafik" src="https://github.com/user-attachments/assets/ef2889e5-44cf-4af8-8f6b-6ae473dd9587" />


### Related issues

<!-- If you know that your PR closes issues, please list them here -->

### Role

Website & Content WG.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

See commits



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
