### PR TITLE
Add matrix_bot_light Erlang SDK (Beta)

### DIFF
--- a/content/ecosystem/sdks/sdks.toml
+++ b/content/ecosystem/sdks/sdks.toml
@@ -698,3 +698,15 @@ purpose = ["client", "bot", "bridge"]
 description = """
 A Matrix library for the client-server and appservice API's written in Nim!
 """
+
+[[sdks]]
+name = "matrix_bot_light"
+maintainer = "roquess"
+maturity = "Beta"
+language = "Erlang"
+licence = "Apache-2.0"
+repository = "https://github.com/roquess/matrix_bot_light"
+purpose = ["bot"]
+description = """
+A simple lightweight library for creating Matrix bots. Available on Hex.pm.
+"""


### PR DESCRIPTION
### Description
I'm adding matrix_bot_light, a lightweight Erlang bot SDK available on Hex.pm.

### Related issues
N/A

### Role
I am the author, contributing as an individual.

### Timeline
No rush.

### Signoff
Commits are signed off.