### PR TITLE
Add Matrix Safety Guild WG

### DIFF
--- a/content/foundation/working-groups/matrix-safety-guild.md
+++ b/content/foundation/working-groups/matrix-safety-guild.md
@@ -1,0 +1,4 @@
++++
+title = "Matrix Safety Guild WG"
+template = "governing-board/working_group.html"
++++

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -233,14 +233,14 @@ Membership is maintained to foster a collaborative environment of mutual trust b
 
 To be eligible, applicants must either:
 
-- Contribute to an open source Matrix project and be responsible for a safety-sensitive concern within that project.
-- Be actively involved with the moderation of a Matrix community that has significant ties to, or contributes feedback to, a safety guild project.
+- Contribute to an open source project in the Matrix ecosystem and be responsible for a safety-sensitive concern within that project.
+- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a safety guild project.
 
 Guild members may introduce other applicants to the gateway procedure when they can provide sufficient reasoning to the rest of the guild and address any raised concerns.
 
 ### Gateway Procedure
 
-To join the guild, first join the Matrix Shared Safety Guild - Join Here - Landing and answer the following questions:
+To join the guild, first join the [landing room](https://matrix.to/#/#shared-safety-guild-landing:matrix.org) and answer the following questions:
 
 1. Which project are you affiliated with? Can you please also link the repository url?
 2. Why are you interested in the guild specifically?
@@ -295,7 +295,7 @@ The informational section summarises project updates and announcements, and any 
 The attentive section is used to escalate discussion or make the committee aware of events.
 An example would be a new spam pattern within the community that is driving people away.
 
-#### Foundation
+#### The Foundation
 
 Amendments to the charter must be explicitly agreed by consensus of safety guild contributors.
 The sponsor and chairs are responsible for proposing amendments when changes are requested by the Foundation.
@@ -313,7 +313,7 @@ Chairs are responsible for ensuring continuity of the community. Chairs have fin
 
 Should chairs become vacant, it is the responsibility of guild members to field volunteers and elect new chairs.
 Should the position of sponsor and both chairs become vacant or unaccountable, the Foundation's Trust & Safety Committee should organise replacements or amend the charter while respecting the membership process, autonomy, and consent of contributors.
-If this option has been exhausted, the Foundation should close the working group.
+If this option has been exhausted, the Foundation should close the Working Group.
 """
 committee = "Trust & Safety Committee"
 members = []

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -208,6 +208,122 @@ matrix_room_alias = "#room-dir-wg-office:neko.dev"
 email = ""
 
 [[working_groups]]
+name = "Matrix Safety Guild"
+summary = "The Matrix Safety Guild is an autonomous community of safety contributors."
+description = """
+The guild provides space for contributors to discuss safety sensitive problems that they have encountered.
+"""
+charter = """
+### Overview
+
+The Matrix Safety Guild is an autonomous community of safety contributors.
+The guild encourages projects to share transparent updates in advance of upcoming work.
+In order to provide opportunity for early feedback and collaboration.
+The guild provides space for contributors to discuss safety sensitive problems that they have encountered.
+All members, including foundation staff and representatives participate within the guild as equal partners in mutual understanding and cooperation.
+This charter formalises the governance of the guild to safe guard the space.
+
+[Matrix Safety Guild - Join Here - Landing](https://matrix.to/#/#shared-safety-guild-landing:matrix.org)
+
+### Membership
+
+Membership is maintained to foster a collaborative environment of mutual trust between contributors.
+
+#### Eligibility
+
+To be eligible, applicants must either:
+
+- Contribute to an open source Matrix project and be responsible for a safety-sensitive concern within that project.
+- Be actively involved with the moderation of a Matrix community that has significant ties to, or contributes feedback to, a safety guild project.
+
+Guild members may introduce other applicants to the gateway procedure when they can provide sufficient reasoning to the rest of the guild and address any raised concerns.
+
+### Gateway Procedure
+
+To join the guild, first join the Matrix Shared Safety Guild - Join Here - Landing and answer the following questions:
+
+1. Which project are you affiliated with? Can you please also link the repository url?
+2. Why are you interested in the guild specifically?
+
+This could be answered as follows:
+
+> Hi, I am applying to join the safety guild.
+>
+> I contribute to the Draupnir project https://github.com/the-draupnir-project/Drapunir. I want to share the work I have been doing with other safety contributors, particularly on standardising admin APIs between homeserver implementations.
+
+### Application Review Process
+
+1. On receipt of an application, the application is announced to other guild members internally and members are prompted to raise concerns.
+  They may ask follow-up questions or clarifications to the applicant.
+  Guild members should acknowledge this notification with a thumbs-up emoji.
+
+2. Chairs are responsible for ensuring enough feedback has been gathered before proceeding, including acknowledgements from active members.
+
+3. After feedback has been gathered, and there are no concerns remaining, a chair accepts the application and invites the applicant to the space.
+
+### Removal Process
+
+If trust has been violated, chairs are obligated to try to mediate the concern or remove contributors.
+
+### Confidentiality Notice
+
+#### Within the announcements channel:
+
+Project updates made in the announcements channel are public information unless explicitly stated in the announcement.
+
+#### Within the space:
+
+The [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) applies within the safety guild space.
+The Individual membership roster of the working group is not to be disclosed publicly in order to protect the privacy of contributors.
+
+Security-sensitive or confidential details could intentionally or unintentionally be disclosed anywhere within the space as a result of discussion. These details may not even be explicitly noted.
+In these situations, members must maintain confidentiality in order not to undermine the mutual trust between guild members.
+
+Generally, members are expected to be considerate of the work of other projects and act responsibly with details discussed with them.
+
+Chairs reserve the right to remove members from the guild if it has been established that trust has been broken.
+
+### Responsibilities
+
+#### Reporting
+
+The guild produces a report to inform the T&S Committee of guild activities.
+The report is split into two parts: one informs the committee with a general summary of guild activity, and another specifically highlights anything that may require committee attention.
+
+The informational section summarises project updates and announcements, and any notable discussion undertaken within the guild.
+
+The attentive section is used to escalate discussion or make the committee aware of events.
+An example would be a new spam pattern within the community that is driving people away.
+
+#### Foundation
+
+Amendments to the charter must be explicitly agreed by consensus of safety guild contributors.
+The sponsor and chairs are responsible for proposing amendments when changes are requested by the Foundation.
+Foundation staff or other representatives are not exempt from the membership process.
+
+### Decision Making
+
+All decisions are made by proposing changes and eliminating raised concerns.
+The autonomy of decision-making lies with contributors.
+
+### Chairs
+
+Chairs are highly trusted contributors responsible for maintaining the space. Chairs are selected by contributors in consensus.
+Chairs are responsible for ensuring continuity of the community. Chairs have final authority on a way forward in times of crisis.
+
+Should chairs become vacant, it is the responsibility of guild members to field volunteers and elect new chairs.
+Should the position of sponsor and both chairs become vacant or unaccountable, the Foundation's Trust & Safety Committee should organise replacements or amend the charter while respecting the membership process, autonomy, and consent of contributors.
+If this option has been exhausted, the Foundation should close the working group.
+"""
+committee = "Trust & Safety Committee"
+members = []
+chairs = ["Gnuxie, Cat"]
+sponsor = "@Gnuxie"
+meetings = ""
+matrix_room_alias = "#shared-safety-guild-landing:matrix.org"
+email = ""
+
+[[working_groups]]
 name = "Governance"
 summary = "Discuss the governance of the Governing Board and the Foundation"
 description = """

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -211,18 +211,18 @@ email = ""
 name = "Matrix Safety Guild"
 summary = "The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration."
 description = """
-The guild provides space for contributors to discuss safety-sensitive problems that they have encountered
+The Guild provides space for contributors to discuss safety-sensitive problems that they have encountered
 and any upcoming work that may impact other projects.
 """
 charter = """
 ### Overview
 
 The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration.
-The guild encourages projects to share transparent updates in advance of upcoming work,
+The Guild encourages projects to share transparent updates in advance of upcoming work,
 in order to provide opportunity for early feedback and collaboration.
-The guild provides space for contributors to discuss safety-sensitive problems that they have encountered.
-All members, including Foundation staff and representatives participate within the guild as equal partners in mutual understanding and cooperation.
-This charter formalises the governance of the guild to safe-guard the space.
+The Guild provides space for contributors to discuss safety-sensitive problems that they have encountered.
+All members, including Foundation staff and representatives participate within the Guild as equal partners in mutual understanding and cooperation.
+This charter formalises the governance of the Guild to safe-guard the space.
 
 ### Membership
 
@@ -233,26 +233,26 @@ Membership is maintained to foster a collaborative environment of mutual trust b
 To be eligible, applicants must either:
 
 - Contribute to an open source project in the Matrix ecosystem and be responsible for a safety-sensitive concern within that project.
-- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a project that is a member of the safety guild.
+- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a project that is a member of the safety Guild.
 
-Guild members may introduce other applicants to the gateway procedure when they can provide sufficient reasoning to the rest of the guild and address any raised concerns.
+Guild members may introduce other applicants to the gateway procedure when they can provide sufficient reasoning to the rest of the Guild and address any raised concerns.
 
 #### Gateway Procedure
 
-To join the guild, first join the [landing room](https://matrix.to/#/#shared-safety-guild-landing:matrix.org) and answer the following questions:
+To join the Guild, first join the [landing room](https://matrix.to/#/#shared-safety-guild-landing:matrix.org) and answer the following questions:
 
 1. Which project are you affiliated with? Can you please also link the repository url?
-2. Why are you interested in the guild specifically?
+2. Why are you interested in the Guild specifically?
 
 This could be answered as follows:
 
-> Hi, I am applying to join the safety guild.
+> Hi, I am applying to join the Safety Guild.
 >
 > I contribute to the Draupnir project <https://github.com/the-draupnir-project/Drapunir>. I want to share the work I have been doing with other safety contributors, particularly on standardising admin APIs between homeserver implementations.
 
 #### Application Review Process
 
-1. On receipt of an application, the application is announced to other guild members internally and members are prompted to raise concerns.
+1. On receipt of an application, the application is announced to other Guild members internally and members are prompted to raise concerns.
   They may ask follow-up questions or clarifications to the applicant.
   Guild members should acknowledge this notification with a thumbs-up emoji.
 
@@ -272,31 +272,31 @@ Project updates made in the announcements channel are public information unless 
 
 #### Within the space
 
-The [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) applies within the safety guild space.
+The [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) applies within the Safety Guild space.
 The individual membership roster of the Working Group is not to be disclosed publicly in order to protect the privacy of contributors.
 
 Security-sensitive or confidential details could intentionally or unintentionally be disclosed anywhere within the space as a result of discussion. These details may not even be explicitly noted as confidential or of security context.
-In these situations, members must maintain confidentiality in order not to undermine the mutual trust between guild members.
+In these situations, members must maintain confidentiality in order not to undermine the mutual trust between Guild members.
 
 Generally, members are expected to be considerate of the work of other projects and act responsibly with details discussed with them.
 
-Chairs reserve the right to remove members from the guild if it has been established that trust has been broken.
+Chairs reserve the right to remove members from the Guild if it has been established that trust has been broken.
 
 ### Responsibilities
 
 #### Reporting
 
-The guild produces a report to inform the T&S Committee of guild activities.
-The report is split into two parts: one informs the committee with a general summary of guild activity, and another specifically highlights anything that may require committee attention.
+The Guild produces a report to inform the T&S Committee of Guild activities.
+The report is split into two parts: one informs the committee with a general summary of Guild activity, and another specifically highlights anything that may require committee attention.
 
-The informational section summarises project updates and announcements, and any notable discussion undertaken within the guild.
+The informational section summarises project updates and announcements, and any notable discussion undertaken within the Guild.
 
 The attentive section is used to escalate discussion or make the committee aware of events.
 An example would be a new spam pattern within the community that is driving people away.
 
 #### The Foundation
 
-Amendments to the charter must be explicitly agreed by consensus of safety guild contributors.
+Amendments to the charter must be explicitly agreed by consensus of Safety Guild contributors.
 The sponsor and chairs are responsible for proposing amendments when changes are requested by the Foundation.
 Foundation staff or other representatives are not exempt from the membership process.
 
@@ -310,7 +310,7 @@ The autonomy of decision-making lies with contributors.
 Chairs are highly trusted contributors responsible for maintaining the space. Chairs are selected by contributors in consensus.
 Chairs are responsible for ensuring continuity of the community. Chairs have final authority on a way forward in times of crisis.
 
-Should chairs become vacant, it is the responsibility of guild members to field volunteers and elect new chairs.
+Should chairs become vacant, it is the responsibility of Guild members to field volunteers and elect new chairs.
 Should the position of sponsor and both chairs become vacant or unaccountable, the Foundation's Trust & Safety Committee should organise replacements or amend the charter while respecting the membership process, autonomy, and consent of contributors.
 If this option has been exhausted, the Foundation should close the Working Group.
 """

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -209,14 +209,15 @@ email = ""
 
 [[working_groups]]
 name = "Matrix Safety Guild"
-summary = "The Matrix Safety Guild is an autonomous community of safety contributors."
+summary = "The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration."
 description = """
-The guild provides space for contributors to discuss safety sensitive problems that they have encountered.
+The guild provides space for contributors to discuss safety sensitive problems that they have encountered
+and any upcoming work that may impact other projects.
 """
 charter = """
 ### Overview
 
-The Matrix Safety Guild is an autonomous community of safety contributors.
+The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration.
 The guild encourages projects to share transparent updates in advance of upcoming work.
 In order to provide opportunity for early feedback and collaboration.
 The guild provides space for contributors to discuss safety sensitive problems that they have encountered.

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -211,7 +211,7 @@ email = ""
 name = "Matrix Safety Guild"
 summary = "The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration."
 description = """
-The guild provides space for contributors to discuss safety sensitive problems that they have encountered
+The guild provides space for contributors to discuss safety-sensitive problems that they have encountered
 and any upcoming work that may impact other projects.
 """
 charter = """
@@ -220,7 +220,7 @@ charter = """
 The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration.
 The guild encourages projects to share transparent updates in advance of upcoming work,
 in order to provide opportunity for early feedback and collaboration.
-The guild provides space for contributors to discuss safety sensitive problems that they have encountered.
+The guild provides space for contributors to discuss safety-sensitive problems that they have encountered.
 All members, including Foundation staff and representatives participate within the guild as equal partners in mutual understanding and cooperation.
 This charter formalises the governance of the guild to safe-guard the space.
 
@@ -233,11 +233,11 @@ Membership is maintained to foster a collaborative environment of mutual trust b
 To be eligible, applicants must either:
 
 - Contribute to an open source project in the Matrix ecosystem and be responsible for a safety-sensitive concern within that project.
-- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a safety guild project.
+- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a project that is a member of the safety guild.
 
 Guild members may introduce other applicants to the gateway procedure when they can provide sufficient reasoning to the rest of the guild and address any raised concerns.
 
-### Gateway Procedure
+#### Gateway Procedure
 
 To join the guild, first join the [landing room](https://matrix.to/#/#shared-safety-guild-landing:matrix.org) and answer the following questions:
 
@@ -248,9 +248,9 @@ This could be answered as follows:
 
 > Hi, I am applying to join the safety guild.
 >
-> I contribute to the Draupnir project https://github.com/the-draupnir-project/Drapunir. I want to share the work I have been doing with other safety contributors, particularly on standardising admin APIs between homeserver implementations.
+> I contribute to the Draupnir project <https://github.com/the-draupnir-project/Drapunir>. I want to share the work I have been doing with other safety contributors, particularly on standardising admin APIs between homeserver implementations.
 
-### Application Review Process
+#### Application Review Process
 
 1. On receipt of an application, the application is announced to other guild members internally and members are prompted to raise concerns.
   They may ask follow-up questions or clarifications to the applicant.
@@ -260,22 +260,22 @@ This could be answered as follows:
 
 3. After feedback has been gathered, and there are no concerns remaining, a chair accepts the application and invites the applicant to the space.
 
-### Removal Process
+#### Removal Process
 
 If trust has been violated, chairs are obligated to try to mediate the concern or remove contributors.
 
 ### Confidentiality Notice
 
-#### Within the announcements channel:
+#### Within the announcements channel
 
 Project updates made in the announcements channel are public information unless explicitly stated in the announcement.
 
-#### Within the space:
+#### Within the space
 
 The [Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) applies within the safety guild space.
-The Individual membership roster of the working group is not to be disclosed publicly in order to protect the privacy of contributors.
+The individual membership roster of the Working Group is not to be disclosed publicly in order to protect the privacy of contributors.
 
-Security-sensitive or confidential details could intentionally or unintentionally be disclosed anywhere within the space as a result of discussion. These details may not even be explicitly noted.
+Security-sensitive or confidential details could intentionally or unintentionally be disclosed anywhere within the space as a result of discussion. These details may not even be explicitly noted as confidential or of security context.
 In these situations, members must maintain confidentiality in order not to undermine the mutual trust between guild members.
 
 Generally, members are expected to be considerate of the work of other projects and act responsibly with details discussed with them.

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -318,7 +318,7 @@ If this option has been exhausted, the Foundation should close the Working Group
 committee = "Trust & Safety Committee"
 members = []
 chairs = ["Gnuxie, Cat"]
-sponsor = "@Gnuxie"
+sponsor = "Jade"
 meetings = ""
 matrix_room_alias = "#shared-safety-guild-landing:matrix.org"
 email = ""

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -315,7 +315,6 @@ Should the position of sponsor and both chairs become vacant or unaccountable, t
 If this option has been exhausted, the Foundation should close the Working Group.
 """
 committee = "Trust & Safety Committee"
-members = []
 chairs = ["Gnuxie, Cat"]
 sponsor = "Jade"
 meetings = ""

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -218,13 +218,11 @@ charter = """
 ### Overview
 
 The Matrix Safety Guild is a space to facilitate communication between safety projects and encourage collaboration.
-The guild encourages projects to share transparent updates in advance of upcoming work.
-In order to provide opportunity for early feedback and collaboration.
+The guild encourages projects to share transparent updates in advance of upcoming work,
+in order to provide opportunity for early feedback and collaboration.
 The guild provides space for contributors to discuss safety sensitive problems that they have encountered.
-All members, including foundation staff and representatives participate within the guild as equal partners in mutual understanding and cooperation.
-This charter formalises the governance of the guild to safe guard the space.
-
-[Matrix Safety Guild - Join Here - Landing](https://matrix.to/#/#shared-safety-guild-landing:matrix.org)
+All members, including Foundation staff and representatives participate within the guild as equal partners in mutual understanding and cooperation.
+This charter formalises the governance of the guild to safe-guard the space.
 
 ### Membership
 

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -233,7 +233,7 @@ Membership is maintained to foster a collaborative environment of mutual trust b
 To be eligible, applicants must either:
 
 - Contribute to an open source project in the Matrix ecosystem and be responsible for a safety-sensitive concern within that project.
-- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a project that is a member of the safety Guild.
+- Be actively involved with the moderation of a community on the public Matrix network that has significant ties to, or contributes feedback to, a project that is a member of the Safety Guild.
 
 Guild members may introduce other applicants to the gateway procedure when they can provide sufficient reasoning to the rest of the Guild and address any raised concerns.
 

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -316,6 +316,7 @@ If this option has been exhausted, the Foundation should close the Working Group
 """
 committee = "Trust & Safety Committee"
 chairs = ["Gnuxie, Cat"]
+members = []
 sponsor = "Jade"
 meetings = ""
 matrix_room_alias = "#shared-safety-guild-landing:matrix.org"

--- a/templates/governing-board/working_groups.html
+++ b/templates/governing-board/working_groups.html
@@ -31,7 +31,9 @@
         <p class="summary">{{ wg.summary }}</p>
         <div class="description">
             <div class="members">
-                <p><strong>Members:</strong> {{ wg.members | join(sep=", ") }}</p>
+                {% if wg.members %}
+                    <p><strong>Members:</strong> {{ wg.members | join(sep=", ") }}</p>
+                {% endif %}
                 <p><strong>Sponsor:</strong> {{ wg.sponsor }}</p>
                 {% if wg.meetings %}<p><strong>Meeting schedule:</strong> {{ wg.meetings }}</p>{% endif %}
             </div>


### PR DESCRIPTION
### Description

Adds the Matrix Saftey Guild working group information to the website

### Role

Contributing on behalf of the Matrix Saftey Guild Working Group of the Foundation.

### Timeline

At the leisure of the website working group but we would prefer to have the merge done inside of the next 2 weeks if possible.

### Signoff

Signed-off-by: Catalan Lover [catalanlover@protonmail.com](mailto:catalanlover@protonmail.com)



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
