### PR TITLE
Add basic pagefind setup

### DIFF
--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,0 +1,10 @@
+site: public
+output_subdir: pagefind
+exclude_selectors:
+  # Ignore codeblocks
+  - "code"
+  # Blocked due to https://github.com/Pagefind/pagefind/issues/1134
+  # - "#that-s-all-i-know"
+  # - "#that-s-all-i-know-checkered-flag"
+  # - "#that-s-all-i-know+p"
+  # - "#that-s-all-i-know-checkered-flag+p"

--- a/templates/docs/index.html
+++ b/templates/docs/index.html
@@ -1,6 +1,6 @@
 {% extends "skel.html" %}
 {% block content %}
-<article class="content">
+<article data-pagefind-filter="section:Documentation" class="content">
     <header>
         <h1>{{ section.title }}</h1>
         {% set iso_date = section.extra.updated | date(format = '%Y-%m-%d') %}

--- a/templates/docs/with_menu.html
+++ b/templates/docs/with_menu.html
@@ -16,8 +16,8 @@
 {% set root_section = get_section(path="docs/technical/_index.md") %}
 {% endif %}
 
-<div class="docs-body">
-    <div class="docs-menu">
+<div data-pagefind-filter="section:Documentation" class="docs-body">
+    <div class="docs-menu" data-pagefind-ignore="all">
         <div class="docs-menu-inner">
             {% for doc_section_path in docs_sections.subsections %}
             {% set doc_section = get_section(path=doc_section_path) %}

--- a/templates/includes/header.html
+++ b/templates/includes/header.html
@@ -7,6 +7,11 @@
     <label for="site-header-dropdown-checkbox" class="page-overlay"></label>
     <nav>
         {% for link in navigation.header %}
+        {% if loop.index0 == navigation.header | length - 1 %}
+        <pagefind-modal-trigger></pagefind-modal-trigger>
+        <pagefind-modal></pagefind-modal>
+        {% endif %}
+        
         {% if link.section %}
         {% set href = "/" ~ link.section ~ "/" %}
         {% set section = get_section(path=link.section ~ "/_index.md") %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -6,7 +6,7 @@
 {% endif %}
 {% endblock head_extra %}
 {% block content %}
-<article class="content">
+<article data-pagefind-filter="section:Pages" class="content">
     <header>
         <h1>{{ page.title }}</h1>
     </header>

--- a/templates/post.html
+++ b/templates/post.html
@@ -44,22 +44,24 @@
 </script>
 {% endblock head_extra %}
 {% block content %}
-<article class="content post {%- if page.toc %} with-sidebar{% endif %}">
+<article data-pagefind-filter="section:Blog" class="content post {%- if page.toc %} with-sidebar{% endif %}">
     <header>
-        <h1>{{ page.title }}</h1>
+        <h1 data-pagefind-filter="heading">{{ page.title }}</h1>
         <span>
+            <span data-pagefind-sort="date:{{page.date | date(format='%Y-%m-%d')}}">
             {{ page.date | date(format="%Y-%m-%d") }}
+            </span>
             {% if page.taxonomies.category %}
             —
             {% for category in page.taxonomies.category | sort %}
-                <a href="/category/{{ category | slugify }}">
+                <a href="/category/{{ category | slugify }}" data-pagefind-filter="category">
                     {{- category -}}
                 </a>
             {%- if not loop.last %}, {% endif %}{% endfor %}
             {% endif %}
             —
             {% for author in page.taxonomies.author %}
-                <a href="/author/{{ author | default (value=['unknown author']) | slugify }}">
+                <a href="/author/{{ author | default (value=['unknown author']) | slugify }}" data-pagefind-filter="author">
                     {{- author | default (value=["unknown author"]) -}}
                 </a>
             {%- if not loop.last %}, {% endif %}

--- a/templates/skel.html
+++ b/templates/skel.html
@@ -49,7 +49,8 @@
     <link rel="stylesheet" href="{{ get_url(path="/style.css" , cachebust=true) }}" />
     <script async src="{{ get_url(path="/js/components.js" , cachebust=true) }}"></script>
     <script defer data-domain="matrix.org" src="https://plausible.io/js/script.tagged-events.js"></script>
-
+    <link href="/pagefind/pagefind-component-ui.css" rel="stylesheet">
+    <script src="/pagefind/pagefind-component-ui.js" type="module"></script>
 
     {% block head_extra %}{% endblock head_extra -%}
 </head>
@@ -58,7 +59,7 @@
     {% set navigation = load_data(path="navigation.toml") %}
     {% include "includes/header.html" %}
     {{ banner::banner() }}
-    <main>
+    <main data-pagefind-body>
         {% block content %}{% endblock content %}
     </main>
 


### PR DESCRIPTION
### Description

This adds a basic pagefind setup with the default search box and some extra labeling in case we decide we want some more advanced search dialog later.

It also does not do any styling for now. I think the defaults are sufficient for matrix.org

cc @thibaultamartin This likely needs SRE to update cloudflare for it to work. I am not sure who to ping and whats needed. Iirc you already run something like this on cloudflare so maybe you can help here?

To build pagefind we need `npx -y pagefind --site public` added to cloudflare

---

#### Visual changes

**Search Bar in the Navigation**

<img width="3840" height="190" alt="grafik" src="https://github.com/user-attachments/assets/c518ac61-ee9b-4c04-9de2-d4d26b32fc89" />

**Search Modal Empty**

<img width="3840" height="1936" alt="grafik" src="https://github.com/user-attachments/assets/3131f1ad-8a71-4282-bd67-a7b3fe71b395" />

**Search bar when used**

<img width="3840" height="1936" alt="grafik" src="https://github.com/user-attachments/assets/c4bb542a-4ceb-499a-9b72-125379957843" />

### Related issues

Fixes #19 

### Role

Website & Content WG

### Timeline

N/A

### Signoff

See commits



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
