### PR TITLE
Add share bar to blog posts

### DIFF
--- a/partials/share_bar.html
+++ b/partials/share_bar.html
@@ -1,0 +1,20 @@
+<div class="share-bar">
+  <span>Share:</span>
+
+  {% set encoded_url = page.permalink | urlencode %}
+  {% set encoded_title = page.title | urlencode %}
+
+  {% set share_text = (page.title ~ " by @matrix@mastodon.matrix.org " ~ page.permalink) | urlencode %}
+
+  <a href="https://share.joinmastodon.org/?text={{ share_text }}" target="_blank" rel="noopener noreferrer">Mastodon</a>
+
+  <a href="https://bsky.app/intent/compose?text={{ share_text }}" target="_blank" rel="noopener noreferrer">Bluesky</a>
+
+  <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ encoded_url }}" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+
+  <a href="https://news.ycombinator.com/submitlink?u={{ encoded_url }}&t={{ encoded_title }}" target="_blank" rel="noopener noreferrer">Hacker News</a>
+
+  <a href="https://lobste.rs/stories/new?url={{ encoded_url }}&title={{ encoded_title }}" target="_blank" rel="noopener noreferrer">Lobsters</a>
+
+  <a href="https://www.reddit.com/submit?url={{ encoded_url }}&title={{ encoded_title }}" target="_blank" rel="noopener noreferrer">Reddit</a>
+</div>

--- a/sass/_blog.scss
+++ b/sass/_blog.scss
@@ -149,3 +149,32 @@ h3 a {
     margin-right: 0.5rem;
     color: inherit;
 }
+
+.share-bar {
+    display: flex;
+    gap: 12px;
+    margin-top: 40px;
+    padding-top: 16px;
+    border-top: 1px solid #e5e5e5;
+    font-size: 14px;
+    flex-wrap: wrap;
+
+    > span {
+        font-weight: 600;
+    }
+
+    a {
+        text-decoration: none;
+        opacity: 0.8;
+        transition: opacity 0.2s ease;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+
+    @media (max-width: 767px) {
+        font-size: 12px;
+        gap: 8px;
+    }
+}

--- a/templates/partials/share_bar.html
+++ b/templates/partials/share_bar.html
@@ -1,0 +1,22 @@
+<div class="share-bar">
+  <span>Share:</span>
+
+  {% set full_url = config.base_url ~ page.permalink %}
+  {% set encoded_url = full_url | urlencode %}
+  {% set encoded_title = page.title | urlencode %}
+
+  {% set share_text = page.title ~ " " ~ full_url %}
+  {% set share_text_encoded = share_text | urlencode %}
+
+  <a href="https://share.joinmastodon.org/?text={{ share_text_encoded }}" target="_blank" rel="noopener noreferrer">Mastodon</a>
+
+  <a href="https://bsky.app/intent/compose?text={{ share_text_encoded }}" target="_blank" rel="noopener noreferrer">Bluesky</a>
+
+  <a href="https://www.linkedin.com/sharing/share-offsite/?url={{ full_url }}" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+
+  <a href="https://news.ycombinator.com/submitlink?u={{ encoded_url }}&t={{ encoded_title }}" target="_blank" rel="noopener noreferrer">Hacker News</a>
+
+  <a href="https://lobste.rs/stories/new?url={{ encoded_url }}&title={{ encoded_title }}" target="_blank" rel="noopener noreferrer">Lobsters</a>
+
+  <a href="https://www.reddit.com/submit?url={{ encoded_url }}&title={{ encoded_title }}" target="_blank" rel="noopener noreferrer">Reddit</a>
+</div>

--- a/templates/post.html
+++ b/templates/post.html
@@ -114,5 +114,6 @@
         </aside>
         {% endif %}
     </div>
+    {% include "partials/share_bar.html" %}
 </article>
 {% endblock content %}


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Added a reusable share bar component for blog posts that includes multiple social sharing options.

Changes made:

Created templates/partials/share_bar.html
Integrated share bar into templates/post.html
Added share links for Mastodon, Bluesky, LinkedIn, Hacker News, Lobsters, and Reddit
Automatically populates post title and URL
Positioned at the bottom of blog posts (after Foundation CTA)
Added responsive styling for mobile devices
Ensured security best practices using rel="noopener noreferrer"


### Related issues

<!-- If you know that your PR closes issues, please list them here -->

Closes #3321 


### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->
Contributing as an individual.
No affiliation with any organization related to this PR.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->
No strict deadline. Review at your convenience.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.
All commits are signed off in accordance with the contributing guidelines.


<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->