### PR TITLE
clarify candidates must be members

### DIFF
--- a/content/foundation/governing-board-elections/2026/index.md
+++ b/content/foundation/governing-board-elections/2026/index.md
@@ -50,8 +50,8 @@ This year, we are running elections for the following [constituency groups](@/fo
 <!-- Nominations for the 2026 elections are complete, and you can [find the nominees below](@/foundation/governing-board-elections/2026/index.md#nominees). -->
 
 You must be a member of one of the constituency groups
-in order to nominate yourself or someone else
-to be a candidate in the election within the same constituency.
+in order to nominate yourself or another member of the same constituency
+to be a candidate in the election.
 
 All nominees must have consented to nomination *before being nominated*
 and must be a community member in good standing.

--- a/content/foundation/governing-board-elections/2026/index.md
+++ b/content/foundation/governing-board-elections/2026/index.md
@@ -49,9 +49,8 @@ This year, we are running elections for the following [constituency groups](@/fo
 
 <!-- Nominations for the 2026 elections are complete, and you can [find the nominees below](@/foundation/governing-board-elections/2026/index.md#nominees). -->
 
-You must be a member of one of the constituency groups
-in order to nominate yourself or another member of the same constituency
-to be a candidate in the election.
+You must be a member of a constituency group to nominate yourself,
+or another member of that group, as a candidate in the election.
 
 All nominees must have consented to nomination *before being nominated*
 and must be a community member in good standing.


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Attempting to clarify that only constituency members can nominate only members of the same constituency to be candidates in the same constituency's election without saying constituency four times in the same sentence. Constituency.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
