### PR TITLE
Add og:site_name

### DIFF
--- a/templates/skel.html
+++ b/templates/skel.html
@@ -12,6 +12,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@matrixdotorg" />
     <meta name="twitter:creator" content="@matrixdotorg" />
+    <meta name="og:site_name" content="matrix.org" />
     {% if current_url %}
     <meta property="og:url" content="{{ current_url }}" />
     {% endif %}

--- a/templates/skel.html
+++ b/templates/skel.html
@@ -12,7 +12,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@matrixdotorg" />
     <meta name="twitter:creator" content="@matrixdotorg" />
-    <meta name="og:site_name" content="matrix.org" />
+    <meta property="og:site_name" content="matrix.org" />
     {% if current_url %}
     <meta property="og:url" content="{{ current_url }}" />
     {% endif %}


### PR DESCRIPTION
### Description

https://ogp.me/#optional has a `og:site_name` and some Matrix clients use this to give a little identifying name at the bottom. Synapse also uses `twitter:site` if this is not set, which is *really* annoying. I will be fixing Synapse too, but the website might as well be updated.


### Related issues

<!-- If you know that your PR closes issues, please list them here -->

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
