### PR TITLE
Deduplicate election macros

### DIFF
--- a/templates/governing-board/elections.html
+++ b/templates/governing-board/elections.html
@@ -40,8 +40,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for individual in nominees.individual_members %}
-        {{ nominee::individual(individual=individual) }}
+        {% for candidate in nominees.individual_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -54,8 +54,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for representative in nominees.ecosystem_members %}
-        {{ nominee::project(representative=representative) }}
+        {% for candidate in nominees.ecosystem_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -67,8 +67,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for representative in nominees.associate_members %}
-        {{ nominee::project(representative=representative) }}
+        {% for candidate in nominees.associate_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -80,8 +80,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for representative in nominees.platinum_members %}
-        {{ nominee::project(representative=representative) }}
+        {% for candidate in nominees.platinum_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -93,8 +93,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for representative in nominees.gold_members %}
-        {{ nominee::project(representative=representative) }}
+        {% for candidate in nominees.gold_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -106,8 +106,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for representative in nominees.silver_members %}
-        {{ nominee::project(representative=representative) }}
+        {% for candidate in nominees.silver_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -119,8 +119,8 @@
         <div class="nominees-buttons-row">
             <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for guardian in nominees.guardians %}
-        {{ nominee::individual(individual=guardian) }}
+        {% for candidate in nominees.guardians %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}
@@ -130,12 +130,10 @@
     <h3 id="sct-nominees">Spec Core Team Members (Max. {{ seats }} Seat{{ seats | pluralize }})</h3>
     <div class="nominees">
         <div class="nominees-buttons-row">
-            <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">
-                Collapse all
-            </button>
+            <button class="expand-all">Expand all</button> &ndash; <button class="collapse-all">Collapse all</button>
         </div>
-        {% for individual in nominees.sct_members %}
-        {{ nominee::individual(individual=individual) }}
+        {% for candidate in nominees.sct_members %}
+        {{ nominee::candidate(candidate=candidate) }}
         {% endfor %}
     </div>
     {% endif %}

--- a/templates/macros/nominee.html
+++ b/templates/macros/nominee.html
@@ -1,39 +1,18 @@
-{% macro individual(individual) %}
+{% macro candidate(candidate) %}
 <details class="nominee">
-    <summary>{{ individual.name }} {% if individual.pronouns %}({{ individual.pronouns }}){% endif %}</summary>
+    <summary>{{ candidate.name }} {% if candidate.pronouns %}({{ candidate.pronouns }}){% endif %}{% if candidate.project %} - {{
+        candidate.project }}{% endif %}</summary>
     <h4>Biography</h4>
-    {% if individual.bio %}
-    {{ individual.bio | markdown() | safe }}
+    {% if candidate.bio %}
+    {{ candidate.bio | markdown() | safe }}
     {% else %}
     <p>(The candidate submitted no biography.)</p>
     {% endif %}
     <h4>Platform Statement</h4>
-    {% if individual.platform_statement %}
-    {{ individual.platform_statement | markdown() | safe }}
-    {% if individual.extended_platform %}
-    <p><a href="{{ individual.extended_platform | safe }}" target="_blank">Read this candidate's extended platform.</a></p>
-    {% endif %}
-    {% else %}
-    <p>(The candidate submitted no platform statement.)</p>
-    {% endif %}
-</details>
-{% endmacro %}
-
-{% macro project(representative) %}
-<details class="nominee">
-    <summary>{{ representative.name }} {% if representative.pronouns %}({{ representative.pronouns }}){% endif %} - {{
-        representative.project }}</summary>
-    <h4>Biography</h4>
-    {% if representative.bio %}
-    {{ representative.bio | markdown() | safe }}
-    {% else %}
-    <p>(The candidate submitted no biography.)</p>
-    {% endif %}
-    <h4>Platform Statement</h4>
-    {% if representative.platform_statement %}
-    {{ representative.platform_statement | markdown() | safe }}
-    {% if representative.extended_platform %}
-    <p><a href="{{ representative.extended_platform | safe }}" target="_blank">Read this candidate's extended platform.</a></p>
+    {% if candidate.platform_statement %}
+    {{ candidate.platform_statement | markdown() | safe }}
+    {% if candidate.extended_platform %}
+    <p><a href="{{ candidate.extended_platform | safe }}" target="_blank">Read this candidate's extended platform.</a></p>
     {% endif %}
     {% else %}
     <p>(The candidate submitted no platform statement.)</p>


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Removes one of the duplicate macros from the election template. Whether a candidate represents an organisation is solely controlled by setting the organisation field in the candidate data.

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

This PR builds upon https://github.com/matrix-org/matrix.org/pull/3415 because it would be very annoying to resolve the conflicts.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
