### PR TITLE
Add Synod.im client

### DIFF
--- a/content/ecosystem/clients/synod-im.md
+++ b/content/ecosystem/clients/synod-im.md
@@ -1,0 +1,26 @@
++++
+title = "Synod.im"
+
+[extra]
+maintainer = "LUKi e.V."
+maturity = "Stable"
+website = "https://synod.im/"
+licence = "AGPL-3.0-or-later OR Element Commercial License"
+featured = false
+
+[extra.features]
+e2ee = true
+spaces = true
+voip_1to1 = true
+voip_jitsi = true
+threads = true
+sso = true
+multi_account = false
+multi_language = true
+
+[extra.packages]
+google_play_store.app_id = "im.synod"
+apple_app_store = { app_id = "id1488171544", org = "synod-im" }
++++
+
+Matrix client maintained by LUKi e.V. for Synod.im users on Android, iPhone, and iPad.


### PR DESCRIPTION
### Description

Adds Synod.im to the Matrix ecosystem client list using the existing client metadata format.

Root cause: the ecosystem catalog did not have a Synod.im entry, even though the issue links live App Store and Google Play listings.

Code shape: single content-only page; no template, build, dependency, or runtime behavior changed.

Security assessment: low risk. This adds static metadata only, with no scripts, secrets, auth handling, dependencies, redirects, or user-input processing. Store links are generated through the repository's existing package metadata fields.

Verification:

- `rg -n "Synod\.im|im\.synod|id1488171544|LUKi" content\ecosystem\clients\synod-im.md`
- `git diff --check`

Note: `zola` is not installed in my local environment, so I could not run a full local site build here.

### Related issues

Fixes #3430

### Role

Individual contributor. I am not affiliated with Synod.im, LUKi e.V., or Matrix.org. This PR was prepared with AI assistance through Codex and reviewed before submission.

### Timeline

No deadline.

### Signoff

The commit is signed off.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
