### PR TITLE
Add Venator to ecosystem servers

### DIFF
--- a/content/ecosystem/servers/servers.toml
+++ b/content/ecosystem/servers/servers.toml
@@ -167,3 +167,13 @@ language = "Rust"
 licence = "Apache-2.0"
 repository = "https://forgejo.ellis.link/continuwuation/continuwuity"
 room = "#continuwuity:continuwuity.org"
+
+[[servers]]
+name = "Venator"
+description = "Versatile experimental Matrix homeserver written in Golang from scratch using mautrix-go."
+author = "timedout"
+maturity = "Alpha"
+licence = "MPL-2.0"
+repository = "https://codeberg.org/timedout/venator"
+room = "#venator:nexy7574.co.uk"
+language = "Go"


### PR DESCRIPTION
### Description

Adds [Venator](https://codeberg.org/timedout/venator) to the "Servers" page of the ecosystem section. It has been around in some form for quite some time now, and I think enough progress has been made that it makes sense to add it to the ecosystem page now.

I've listed it as Alpha because you can use Venator for most day-to-day tasks with common clients, however it does not yet support appservices or federation. Or in less words, the API surface is still relatively small compared to some other listed projects.

### Related issues

N/A.

### Role

Individual (project maintainer)

### Timeline

N/A.

### Signoff

Signed-Off-By: timedout <git@nexy7574.co.uk>



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
