### PR TITLE
Remove the trailing slash from the og image path of TWIM

### DIFF
--- a/content/blog/2026/06/2026-06-05-twim.md
+++ b/content/blog/2026/06/2026-06-05-twim.md
@@ -8,7 +8,7 @@ author = ["Thib"]
 category = ["This Week in Matrix"]
 
 [extra]
-image = "https://matrix.org/blog/img/2026-06-05-og.png/"
+image = "https://matrix.org/blog/img/2026-06-05-og.png"
 +++
 
 ## Matrix Live S12E11 - Relay, macOS client


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Remove the trailing slash that borked the og preview image in the latest TWIM issue

### Related issues

<!-- If you know that your PR closes issues, please list them here -->


### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

🫡 Website & Content WG

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

Ideally asap

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.

✅ 

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
