### PR TITLE
Fix #3179: Add title attributes to footer social links for hover tool…

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -4,11 +4,11 @@
         <a href="{{ item.href }}" {% if item.newTab %}target="_blank"{% endif %}>{{ item.title }}</a>
         {% endfor %}
     </div>
-    <div class="external-links">
-        {% for item in navigation.footer_external %}
-        <a href="{{ item.href }}" {% if item.newTab %}target="_blank"{% endif %} {% if item.relMe %}rel="me"{% endif %} {% if item.alt %}aria-label="{{ item.alt }}"{% endif %}><span aria-hidden="true">{{ load_data(path="/assets/" ~ item.image) | safe }}</span></a>
-        {% endfor %}
-    </div>
+<div class="external-links">
+    {% for item in navigation.footer_external %}
+    <a href="{{ item.href }}" {% if item.newTab %}target="_blank"{% endif %} {% if item.relMe %}rel="me"{% endif %} {% if item.alt %}aria-label="{{ item.alt }}" title="{{ item.alt | replace(from="Matrix on ", to="") }}"{% endif %}><span aria-hidden="true">{{ load_data(path="/assets/" ~ item.image) | safe }}</span></a>
+    {% endfor %}
+</div>
     <div class="subfooter-links">
         {% for item in navigation.footer_subfooter %}
         <a href="{{ item.href }}" {% if item.newTab %}target="_blank"{% endif %}>{{ item.title }}</a>


### PR DESCRIPTION
### Description

Added the `title` attribute to the external social media links in the footer. It includes a template string filter to dynamically remove the "Matrix on " prefix so that only the clean platform names (like "GitHub", "Mastodon", etc.) display as native tooltips on hover. This resolves basic usability, missing cues, and accessibility needs.

#### Visual Proof
| Before (No tooltip on hover) | After (Clean tooltip on hover) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/d3d58181-1875-4753-b89d-1da77ee869d2" height="90" alt="Before"> | <img src="https://github.com/user-attachments/assets/7238c909-17e1-4516-9d0a-ad69a8cdf12a" height="90" alt="After"> |

### Related issues

Closes #3179

