### PR TITLE
Remove conference call for proposals from banner

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,5 +67,5 @@ skip_anchor_prefixes = [
 # governing_board_elections: "🗳️ We are holding our Governing Board elections. Find 
 # all the information [on the elections page](https:/matrix.org/foundation/governing-board-elections/<year>/)."
 banner = """
-📢 We are happy to launch [The Matrix Conference](https://conference.matrix.org) on 20th-23rd October in Malmö, Sweden. [Submit a proposal](https://cfp.2026.matrix.org/matrix-conference-2026/cfp) until 30th June and [get your ticket](https://conference.matrix.org/register/)!
+📢 We are happy to launch [The Matrix Conference](https://conference.matrix.org) on 20th-23rd October in Malmö, Sweden. Don't forget to [get your ticket](https://conference.matrix.org/register/)!
 """


### PR DESCRIPTION
### Description

<!-- Please describe what you added or changed. This helps us review the PR faster. -->

Removes the call for proposals for this year's (2026) conference.

See also https://github.com/matrix-org/matrix-conf-website/pull/219

### Related issues

<!-- If you know that your PR closes issues, please list them here -->

Given this is such a minor change, there are no related issues.

### Role

<!-- Are you contributing as an individual or on behalf of an organisation? Are you affiliated with any project relevant to this PR? -->

Member of The Matrix.org Foundation Website & Content Working Group.

### Timeline

<!-- By when do you need us to review your PR at the latest? -->

Given that the Call for Proposals is open until 30th June, let's potentially review the PR before then but wait until that date to actually merge.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.

<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
