### PR TITLE
Trust and Safety Research and Documentation WG updates

### DIFF
--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -174,7 +174,7 @@ The T&S committee may decide to remove members from the WG if it sees a member a
 Interested members should be able to apply to the WG freely, but the WG and the T&S committee should do a short background check, if they are willing to give the applicant access to the information or if there are any active abuse concerns. This should be a low bar to clear, but is intended to keep malicious individuals out.
 """
 committee = "Trust & Safety Committee"
-members = ["Nico", "Cat", "Niko", "SFaulken", "Gnuxie", "Sky", "Andy Balaam", "Tobias Fella"]
+members = ["Nico", "Cat", "Niko", "SFaulken", "Gnuxie", "Sky", "Andy Balaam", "Tobias Fella", "Max"]
 chairs = ["Niko", "Cat"]
 sponsor = "Nico"
 matrix_room_alias = "#tns-rnd-wg-office:neko.dev"

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -175,7 +175,7 @@ Interested members should be able to apply to the WG freely, but the WG and the 
 """
 committee = "Trust & Safety Committee"
 members = ["Nico", "Cat", "Niko", "SFaulken", "Gnuxie", "Sky", "Andy Balaam", "Tobias Fella", "Max"]
-chairs = ["Niko", "Cat"]
+chairs = ["Andy Balaam"]
 sponsor = "Nico"
 matrix_room_alias = "#tns-rnd-wg-office:neko.dev"
 email = ""


### PR DESCRIPTION
### Description

Two changes to the T&S R&D WG entry:

1. Add one new member
2. Set me as the chair, and remove Cat as vice-chair.

Both Niko and Cat are stepping down, and I have their support to take over.

Authority for this comes from this poll: https://matrix.discourse.group/t/chair-for-the-t-s-r-d-wg/391 and the support of Nico, our governing board sponsor.

### Role

I am contributing this as the newly-elected chair of the working group.

### Signoff

Commits contain signoffs.