### PR TITLE
add beeper's line messenger bridge to the ecosystem bridge list

### DIFF
--- a/content/ecosystem/bridges/line/bridges.toml
+++ b/content/ecosystem/bridges/line/bridges.toml
@@ -1,4 +1,33 @@
 [[bridges]]
+name = "beeper-line"
+maintainer = "beeper, highesttt"
+summary = """
+A bridgev2 project for bridging Matrix and [LINE](https://www.line.me/en). Written in Go using [mautrix-go](https://github.com/mautrix/go) and intended for use with [Beeper](https://www.beeper.com).
+"""
+maturity = "Stable"
+language = "Go"
+license = "MIT"
+docs = "https://github.com/beeper/line#setup"
+repo = "https://github.com/beeper/line"
+featured = true
+privilege.platform = "User" # Free text
+privilege.matrix = "Homeserver Admin" # Any of Homeserver Admin, Room Admin, None
+[bridges.supports]
+dm = true
+group_chats = true
+formatted_text = false
+message_media = true
+replies = true
+mentions = true
+redactions = true
+editing = false
+reactions = true
+presence = false
+typing_notifications = false
+read_receipts = true
+history = true
+
+[[bridges]]
 name = "matrix-puppeteer-line"
 maintainer = "Andrew Ferrazzutti"
 summary = """


### PR DESCRIPTION
### Description

I've added the [beeper-line](https://github.com/beeper/line) bridge to the LINE bridge listing

I opted to leave the existing obsolete matrix-puppeteer-line entry. Let me know if it is a better idea to prune it, I can patch it in as well. If not, this is ready 🚢 

<img width="1078" height="874" alt="Screenshot 2026-06-27 at 21 44 07" src="https://github.com/user-attachments/assets/1d294864-16fe-40ce-9e58-e30003f94341" />

### Related issues

- https://github.com/matrix-org/matrix.org/issues/3488
- https://github.com/beeper/line/issues/193

### Role

I contributed individually to the line bridge this year. I'm not affiliated with beeper or line.

### Timeline

No deadline

### Signoff

My commit is signed off