### PR TITLE
Add Homeserver Decentralisation Working Group

### DIFF
--- a/content/foundation/working-groups/homeserver-decentralisation.md
+++ b/content/foundation/working-groups/homeserver-decentralisation.md
@@ -1,0 +1,4 @@
++++
+title = "Homeserver Decentralisation WG"
+template = "governing-board/working_group.html"
++++

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -157,7 +157,7 @@ The Working Group focuses on improving the onboarding experience across Matrix h
 The Working Group is responsible for maintaining The Matrix.org Foundation’s trusted public homeserver list and periodically reviewing the homeservers included on it.
 """
 committee = "Community Committee"
-members = ["Nicolas Da Mutten", "Cat", "Ginger [she/her]", "Sky", "Austin Huang", "Zach", "HarHarLinks", "june ✿ 🏳️‍⚧️ (it/she/puppy)", "mcnesium", ", "Clément", "Max (TheDarkWizard)" ]
+members = ["Nicolas Da Mutten", "Cat", "Ginger [she/her]", "Sky", "Austin Huang", "Zach", "HarHarLinks", "june ✿ 🏳️‍⚧️ (it/she/puppy)", "mcnesium", "Clément", "Max (TheDarkWizard)" ]
 chairs = ["Nicolas Da Mutten", "Clément"]
 sponsor = "Max (TheDarkWizard)"
 meetings = "On the first Monday of the month, 19:00-20:00 Berlin time. Please reach out via our Matrix room to join."

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -158,7 +158,7 @@ The Working Group is responsible for maintaining The Matrix.org Foundation’s t
 """
 committee = "Community Committee"
 members = ["mcnesium", "Nicolas Da Mutten", "Clément", "HarHarLinks", "Sky", "Max (TheDarkWizard)", "Jade Ellis"]
-chairs = ["Nicolas Da Mutten", "Clement"]
+chairs = ["Nicolas Da Mutten", "Clément"]
 sponsor = "Max (TheDarkWizard)"
 meetings = "On the first Monday of the month, 19:00-20:00 Berlin time. Please reach out via our Matrix room to join."
 matrix_room_alias = "#homeserver-decentralisation:matrix.org"

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -132,6 +132,39 @@ matrix_room_alias = "#events-wg:matrix.org"
 email = "events-wg@foundation.matrix.org"
 
 [[working_groups]]
+name = "Homeserver Decentralisation"
+summary = "Helping users discover and join homeservers other than matrix.org"
+description = """
+The Homeserver Decentralisation Working Group promotes decentralisation across the Matrix network by helping users discover and join homeservers other than `matrix.org`.
+The Working Group focuses on improving the onboarding experience across Matrix homeservers and clients. This may include developing technical solutions for homeserver discovery and selection, as well as proposing broader ecosystem improvements that make decentralised onboarding easier and more reliable.
+"""
+charter = """
+### Purpose
+
+The Matrix Homeserver Decentralisation Working Group promotes decentralisation across the Matrix network by helping users discover and join homeservers other than `matrix.org`.
+
+The Working Group focuses on improving the onboarding experience across Matrix homeservers and clients. This may include developing technical solutions for homeserver discovery and selection, as well as proposing broader ecosystem improvements that make decentralised onboarding easier and more reliable.
+
+### Expected outcomes
+
+- A technical solution that helps users choose a suitable public homeserver.
+- A Matrix.org Foundation-maintained list of trusted public homeservers.
+- Clear, public criteria for inclusion on and removal from the trusted homeserver list.
+- A transparent process through which homeserver operators can apply for inclusion.
+
+### Ongoing responsibilities
+
+The Working Group is responsible for maintaining The Matrix.org Foundation’s trusted public homeserver list and periodically reviewing the homeservers included on it.
+"""
+committee = "Community Committee"
+members = ["mcnesium", "Nicolas Da Mutten", "Clement", "HarHarLinks", "Sky", "Max (TheDarkWizard)", "Jade Ellis"]
+chairs = ["Nicolas Da Mutten", "Clement"]
+sponsor = "Max (TheDarkWizard)"
+meetings = "On the first Monday of the month, 19:00-20:00 Berlin time. Please reach out via our Matrix room to join."
+matrix_room_alias = "#homeserver-decentralisation:matrix.org"
+email = ""
+
+[[working_groups]]
 name = "Trust & Safety Research & Documentation"
 summary = "Documenting and Researching the state of Trust and Safety in the ecosystem"
 description = """

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -157,7 +157,7 @@ The Working Group focuses on improving the onboarding experience across Matrix h
 The Working Group is responsible for maintaining The Matrix.org Foundation’s trusted public homeserver list and periodically reviewing the homeservers included on it.
 """
 committee = "Community Committee"
-members = ["mcnesium", "Nicolas Da Mutten", "Clement", "HarHarLinks", "Sky", "Max (TheDarkWizard)", "Jade Ellis"]
+members = ["mcnesium", "Nicolas Da Mutten", "Clément", "HarHarLinks", "Sky", "Max (TheDarkWizard)", "Jade Ellis"]
 chairs = ["Nicolas Da Mutten", "Clement"]
 sponsor = "Max (TheDarkWizard)"
 meetings = "On the first Monday of the month, 19:00-20:00 Berlin time. Please reach out via our Matrix room to join."

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -157,7 +157,7 @@ The Working Group focuses on improving the onboarding experience across Matrix h
 The Working Group is responsible for maintaining The Matrix.org Foundation’s trusted public homeserver list and periodically reviewing the homeservers included on it.
 """
 committee = "Community Committee"
-members = ["mcnesium", "Nicolas Da Mutten", "Clément", "HarHarLinks", "Sky", "Max (TheDarkWizard)", "Jade Ellis"]
+members = ["Nicolas Da Mutten", "Cat", "Ginger [she/her]", "Sky", "Austin Huang", "Zach", "HarHarLinks", "june ✿ 🏳️‍⚧️ (it/she/puppy)", "mcnesium", ", "Clément", "Max (TheDarkWizard)" ]
 chairs = ["Nicolas Da Mutten", "Clément"]
 sponsor = "Max (TheDarkWizard)"
 meetings = "On the first Monday of the month, 19:00-20:00 Berlin time. Please reach out via our Matrix room to join."

--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -135,7 +135,7 @@ email = "events-wg@foundation.matrix.org"
 name = "Homeserver Decentralisation"
 summary = "Helping users discover and join homeservers other than matrix.org"
 description = """
-The Homeserver Decentralisation Working Group promotes decentralisation across the Matrix network by helping users discover and join homeservers other than `matrix.org`.
+The Homeserver Decentralisation Working Group promotes decentralisation across the Matrix network by helping users discover and join homeservers other than [`matrix.org`](@/homeserver/about.md).
 The Working Group focuses on improving the onboarding experience across Matrix homeservers and clients. This may include developing technical solutions for homeserver discovery and selection, as well as proposing broader ecosystem improvements that make decentralised onboarding easier and more reliable.
 """
 charter = """


### PR DESCRIPTION
### Description

This adds the **Homeserver Decentralisation Working Group** to [/foundation/working-groups/](https://matrix.org/foundation/working-groups/), under the Community Committee:

- New entry in `working_groups.toml` with the group's charter (purpose, expected outcomes, and ongoing responsibilities), initial members, chairs, sponsor, meeting schedule, and Matrix room (`#homeserver-decentralisation:matrix.org`)
- A charter subpage at `/foundation/working-groups/homeserver-decentralisation/`, matching the format of the other working groups

The charter text matches the group's [existing repository](https://github.com/cleverer/matrix-wg-promote-alternative-homeservers).

### Related issues

None. 

### Role

I'm Max from the Governing Board and the sponsor for this Working Group.

### Timeline

No hard deadline.

### Signoff

Signed-off-by: Max <hat@thedarkwizard.com>