### PR TITLE
Add Syncloud to distributions page

### DIFF
--- a/content/ecosystem/distributions/distributions.toml
+++ b/content/ecosystem/distributions/distributions.toml
@@ -79,3 +79,15 @@ website = "https://element.io/server-suite"
 support_level = "Commercial"
 matrix_standard = true
 
+
+[[distributions]]
+name = "Syncloud"
+description = "Syncloud is an open-source self-hosting platform that lets non-technical users run mainstream open-source apps, including a Matrix homeserver, on their own device with one click, a domain name and automatic HTTPS. Syncloud also offers a subscription with commercial support."
+vendor = "Syncloud"
+maturity = "Stable"
+frameworks = ["Snap"]
+licence = "GPL-3.0"
+repository = "https://github.com/syncloud/platform"
+website = "https://syncloud.org"
+support_level = "Commercial"
+matrix_standard = true

--- a/content/ecosystem/distributions/distributions.toml
+++ b/content/ecosystem/distributions/distributions.toml
@@ -79,3 +79,14 @@ website = "https://element.io/server-suite"
 support_level = "Commercial"
 matrix_standard = true
 
+[[distributions]]
+name = "Syncloud"
+description = "Syncloud is an open-source self-hosting platform that lets non-technical users run mainstream open-source apps on their own device with one click, a domain name and automatic HTTPS. The Matrix app bundles the Dendrite homeserver, Element Web, PostgreSQL and the mautrix Discord, Signal, Slack, Telegram and WhatsApp bridges. Syncloud also offers a subscription with commercial support."
+vendor = "Syncloud"
+maturity = "Stable"
+frameworks = ["Snap"]
+licence = "GPL-3.0"
+repository = "https://github.com/syncloud/matrix"
+website = "https://syncloud.org"
+support_level = "Commercial"
+matrix_standard = true


### PR DESCRIPTION
### Description

Adds Syncloud to the distributions page. This is the move suggested in #2194. Syncloud is an open-source self-hosting platform that lets non-technical users run mainstream open-source apps, including a Matrix homeserver, on their own device with one click, a domain name and automatic HTTPS. Syncloud also offers a subscription with commercial support.

### Related issues

Follow-up to #2194

### Role

Contributing as the author of the Syncloud project.

### Timeline

No specific deadline — review whenever convenient.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.
