### PR TITLE
feat: add git_repo to working groups

### DIFF
--- a/content/foundation/working-groups/working_groups.toml
+++ b/content/foundation/working-groups/working_groups.toml
@@ -161,6 +161,7 @@ sponsor = "Jade Ellis"
 meetings = "On the first Monday of the month, 19:00-20:00 Berlin time. Please reach out via our Matrix room to join."
 matrix_room_alias = "#homeserver-decentralisation:matrix.org"
 email = ""
+git_repo = "https://github.com/cleverer/matrix-wg-promote-alternative-homeservers"
 summary = "Helping users discover and join homeservers other than matrix.org"
 description = """
 The Homeserver Decentralisation Working Group promotes decentralisation across the Matrix network by helping users discover and join homeservers other than [`matrix.org`](@/homeserver/about.md).

--- a/templates/governing-board/working_group.html
+++ b/templates/governing-board/working_group.html
@@ -64,6 +64,21 @@
                     <span>Email</span>
                 </a>
                 {% endif %}
+                {% if wg.git_repo %}
+                <a href="{{ wg.git_repo }}" class="button">
+                    <!-- This icon is part of Material Icons by Google https://fonts.google.com/icons.
+                            The source is available at https://github.com/google/material-design-icons/blob/941fa95d7f6084a599a54ca71bc565f48e7c6d9e/src/action/commit/materialicons/24px.svg
+                            SPDX-SnippetBegin
+                            SPDX-SnippetCopyrightText: Copyright 2020 Google LLC
+                            SPDX-License-Identifier: Apache-2.0 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
+                        <path
+                            d="M352.5-325.5Q298-371 284-440H80v-80h204q14-69 68.5-114.5T480-680q73 0 127.5 45.5T676-520h204v80H676q-14 69-68.5 114.5T480-280q-73 0-127.5-45.5ZM480-360q50 0 85-35t35-85q0-50-35-85t-85-35q-50 0-85 35t-35 85q0 50 35 85t85 35Z" />
+                    </svg>
+                    <!-- SPDX-SnippetEnd -->
+                    <span>Git Repository</span>
+                </a>
+                {% endif %}
             </div>
         </div>
 

--- a/templates/governing-board/working_groups.html
+++ b/templates/governing-board/working_groups.html
@@ -65,6 +65,21 @@
                     <span>Email</span>
                 </a>
                 {% endif %}
+                {% if wg.git_repo %}
+                <a href="{{ wg.git_repo }}" class="button">
+                    <!-- This icon is part of Material Icons by Google https://fonts.google.com/icons.
+                                            The source is available at https://github.com/google/material-design-icons/blob/941fa95d7f6084a599a54ca71bc565f48e7c6d9e/src/action/commit/materialicons/24px.svg
+                                            SPDX-SnippetBegin
+                                            SPDX-SnippetCopyrightText: Copyright 2020 Google LLC
+                                            SPDX-License-Identifier: Apache-2.0 -->
+                    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
+                        <path
+                            d="M352.5-325.5Q298-371 284-440H80v-80h204q14-69 68.5-114.5T480-680q73 0 127.5 45.5T676-520h204v80H676q-14 69-68.5 114.5T480-280q-73 0-127.5-45.5ZM480-360q50 0 85-35t35-85q0-50-35-85t-85-35q-50 0-85 35t-35 85q0 50 35 85t85 35Z" />
+                    </svg>
+                    <!-- SPDX-SnippetEnd -->
+                    <span>Git Repository</span>
+                </a>
+                {% endif %}
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Description

This PR adds the ability to add a link to a git-repo to a working group and adds the Git Repo of the Homeserver Decentralization WG.

### Related issues

This is in response to the change discussed here: https://github.com/matrix-org/twim-config/pull/109#discussion_r3632436843

### Role

I am contributing as the chair of the Homeserver Decentralisation Working Group.

### Timeline

No specific timeline.

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->
