### PR TITLE
fix: typo in bridging

### DIFF
--- a/content/docs/communities/bridging/_index.md
+++ b/content/docs/communities/bridging/_index.md
@@ -8,7 +8,7 @@ tile = "I want to bridge my community from another platform with Matrix"
 updated = "2022-11-18T09:50:00Z"
 +++
 
-The easiest way to bridge your Matrix community with you Discord one is to rely
+The easiest way to bridge your Matrix community with your Discord one is to rely
 on the free Discord bridge [provided by t2bot.io](https://t2bot.io/discord/).
 
 It contains all the instructions about how to bridge your Discord channels with


### PR DESCRIPTION
### Description

Fixes a typo in the Bridging docs page: "with you Discord one" → "with your Discord one".

Single-word change in `content/docs/communities/bridging/_index.md`, line 10. No other changes.


### Related issues

None. Partially related to #3096 (Update bridging docs), but this is only the typo — it does not address the wider content refresh requested there.

### Role

Contributing as an individual. Not affiliated with any project relevant to this PR.

### Timeline

No deadline — review whenever convenient.

### Signoff

Commit is signed off with `Signed-off-by:` per CONTRIBUTING.md.
