### PR TITLE
Remove unstable MSC2965 entries from .well-known

### DIFF
--- a/static/.well-known/matrix/client
+++ b/static/.well-known/matrix/client
@@ -5,10 +5,6 @@
     "m.identity_server": {
         "base_url": "https://vector.im"
     },
-    "org.matrix.msc2965.authentication": {
-        "issuer": "https://account.matrix.org/",
-        "account": "https://account.matrix.org/account/"
-    },
     "org.matrix.msc4143.rtc_foci": [
         {
             "type": "livekit",


### PR DESCRIPTION
### Description

Remove unstable MSC2965 entries from .well-known.

These entries were used for an earlier version of OAuth authentication. They are no longer needed.

Previously: https://github.com/matrix-org/matrix.org/pull/2767.

Per @sandhose:

> Some time ago, Element Classic Android and iOS relied on it, see: [matrix-org/matrix.org#2767](https://github.com/matrix-org/matrix.org/pull/2767)
> 
> But that was fixed in the meantime:
> 
> * [Support for stable version of MSC3824 OAuth 2.0 aware element-android#9102](https://github.com/element-hq/element-android/pull/9102)
> * [Support for stable version of MSC3824 OAuth 2.0 aware matrix-org/matrix-ios-sdk#1917](https://github.com/matrix-org/matrix-ios-sdk/pull/1917)


Fixes: https://github.com/element-hq/synapse/issues/19227

### Related issues

https://github.com/element-hq/synapse/issues/19227

### Role

:tophat: Spec core team

### Timeline

No rush

### Signoff

Please [sign off](https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md) your individual commits.



<!-- ------------------------------ DO NOT WRITE BELOW THIS LINE ------------------------------ -->
<!-- Thank you for creating a Pull Request to the matrix.org website!
     Please read our documentation for contributors to make the review process a smooth as possible:
     - https://github.com/matrix-org/matrix.org/blob/main/README.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTRIBUTING.md
     - https://github.com/matrix-org/matrix.org/blob/main/CONTENT.md
     
     If you have questions at any time, please contact the Website & Content Working Group at
     https://matrix.to/#/#matrix.org-website:matrix.org -->





